### PR TITLE
refactors Reconcile to support Update and prepare for more resource types

### DIFF
--- a/pkg/controller/storagecluster/storagecluster_controller.go
+++ b/pkg/controller/storagecluster/storagecluster_controller.go
@@ -29,7 +29,11 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileStorageCluster{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	return &ReconcileStorageCluster{
+		client:    mgr.GetClient(),
+		scheme:    mgr.GetScheme(),
+		reqLogger: log,
+	}
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler


### PR DESCRIPTION
Puts "ensure CephCluster" code in its own function with the ability to add more
similar functions that ensure the existence of other resources.

Updates a CephCluster resource if its Spec does not match the desired state.

Stopped accessing r.reqLogger from Reconcile since it's possible for two
Reconciles to run concurrently. We set the name and namespace of the resource
being reconciled on the logger as attributes, so we don't want two Reconciles
fighting over that.