### PR TITLE
Use PVs for Mons

### DIFF
--- a/deploy/crds/ocs_v1alpha1_storagecluster_cr.yaml
+++ b/deploy/crds/ocs_v1alpha1_storagecluster_cr.yaml
@@ -5,3 +5,18 @@ metadata:
   name: example-storagecluster
 spec:
   manageNodes: false
+  storageDeviceSets:
+  - name: example-deviceset
+    count: 3
+    resources: {}
+    placement: {}
+    dataPVCTemplate:
+      spec:
+        storageClassName: gp2
+        accessModes:
+        - ReadWriteOnce
+        volumeMode: Block
+        resources:
+          requests:
+            storage: 1Ti
+

--- a/deploy/deploy-with-olm.yaml
+++ b/deploy/deploy-with-olm.yaml
@@ -42,3 +42,87 @@ spec:
   source: ocs-catalogsource
   sourceNamespace: openshift-marketplace
 
+---
+## XXX: Creating the SCCs required to get the mons to run here. This is just a stop-gap arrangement till we have the ocs-operator itself create the required SCCs.
+## TODO: REMOVE THIS.
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: rook-ceph
+allowPrivilegedContainer: true
+allowHostNetwork: true
+allowHostDirVolumePlugin: true
+priority:
+allowedCapabilities: []
+allowHostPorts: true
+allowHostPID: true
+allowHostIPC: true
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+defaultAddCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+allowedFlexVolumes:
+  - driver: "ceph.rook.io/rook"
+  - driver: "ceph.rook.io/rook-ceph"
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - flexVolume
+  - hostPath
+  - persistentVolumeClaim
+  - projected
+  - secret
+users:
+  # A user needs to be added for each rook service account.
+  # This assumes running in the default sample "rook-ceph" namespace.
+  # If other namespaces or service accounts are configured, they need to be updated here.
+  - system:serviceaccount:openshift-storage:rook-ceph-system
+  - system:serviceaccount:openshift-storage:default
+  - system:serviceaccount:openshift-storage:rook-ceph-mgr
+  - system:serviceaccount:openshift-storage:rook-ceph-osd
+---
+# scc for the CSI driver
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: rook-ceph-csi
+allowPrivilegedContainer: true
+allowHostNetwork: true
+allowHostDirVolumePlugin: true
+priority:
+allowedCapabilities: ['*']
+allowHostPorts: true
+allowHostPID: true
+allowHostIPC: true
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+defaultAddCapabilities: []
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+allowedFlexVolumes:
+  - driver: "ceph.rook.io/rook"
+  - driver: "ceph.rook.io/rook-ceph"
+volumes: ['*']
+users:
+  # A user needs to be added for each rook service account.
+  # This assumes running in the default sample "rook-ceph" namespace.
+  # If other namespaces or service accounts are configured, they need to be updated here.
+  - system:serviceaccount:openshift-storage:rook-csi-rbd-plugin-sa
+  - system:serviceaccount:openshift-storage:rook-csi-rbd-provisioner-sa
+  - system:serviceaccount:openshift-storage:rook-csi-rbd-attacher-sa
+  - system:serviceaccount:openshift-storage:rook-csi-cephfs-plugin-sa
+  - system:serviceaccount:openshift-storage:rook-csi-cephfs-provisioner-sa

--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -15,96 +15,6 @@ metadata:
                   "manageNodes": false
               }
           },
-          {
-              "apiVersion": "ceph.rook.io/v1",
-              "kind": "CephCluster",
-              "metadata": {
-                  "name": "my-rook-ceph",
-                  "namespace": "my-rook-ceph"
-              },
-              "spec": {
-                  "cephVersion": {
-                      "image": "ceph/ceph:v14.2.1-20190430"
-                  },
-                  "dataDirHostPath": "/var/lib/rook",
-                  "mon": {
-                      "count": 3
-                  },
-                  "dashboard": {
-                      "enabled": true
-                  },
-                  "network": {
-                      "hostNetwork": false
-                  },
-                  "rbdMirroring": {
-                      "workers": 0
-                  },
-                  "storage": {
-                      "useAllNodes": true,
-                      "useAllDevices": true
-                  }
-              }
-          },
-          {
-              "apiVersion": "ceph.rook.io/v1",
-              "kind": "CephBlockPool",
-              "metadata": {
-                  "name": "replicapool",
-                  "namespace": "my-rook-ceph"
-              },
-              "spec": {
-                  "failureDomain": "host",
-                  "replicated": {
-                      "size": 3
-                  },
-                  "annotations": null
-              }
-          },
-          {
-              "apiVersion": "ceph.rook.io/v1",
-              "kind": "CephObjectStore",
-              "metadata": {
-                  "name": "my-store",
-                  "namespace": "my-rook-ceph"
-              },
-              "spec": {
-                  "metadataPool": {
-                      "failureDomain": "host",
-                      "replicated": {
-                          "size": 3
-                      }
-                  },
-                  "dataPool": {
-                      "failureDomain": "host",
-                      "replicated": {
-                          "size": 3
-                      }
-                  },
-                  "gateway": {
-                      "type": "s3",
-                      "sslCertificateRef": null,
-                      "port": 8080,
-                      "securePort": null,
-                      "instances": 1,
-                      "allNodes": false,
-                      "placement": null,
-                      "annotations": null,
-                      "resources": null
-                  }
-              }
-          },
-          {
-              "apiVersion": "ceph.rook.io/v1",
-              "kind": "CephObjectStoreUser",
-              "metadata": {
-                  "name": "my-user",
-                  "namespace": "my-rook-ceph"
-              },
-              "spec": {
-                  "store": "my-store",
-                  "displayName": "my display name"
-              }
-          }
       ]
     capabilities: Full Lifecycle
     categories: Storage
@@ -146,6 +56,12 @@ spec:
       kind: CephObjectStoreUser
       name: cephobjectstoreusers.ceph.rook.io
       version: v1
+    - description: Represents a Ceph Filesystem
+      displayName: Ceph Filesystem
+      kind: CephFilesystem
+      name: cephfilesystems.ceph.rook.io
+      version: v1
+
       # NooBaa CRDs
     - kind: NooBaa
       name: noobaas.noobaa.io
@@ -255,13 +171,17 @@ spec:
                 - name: ROOK_DISCOVER_DEVICES_INTERVAL
                   value: 60m
                 - name: ROOK_HOSTPATH_REQUIRES_PRIVILEGED
-                  value: "false"
+                  value: "true"
                 - name: ROOK_ENABLE_SELINUX_RELABELING
                   value: "true"
                 - name: ROOK_ENABLE_FSGROUP
                   value: "true"
-                - name: ROOK_DISABLE_DEVICE_HOTPLUG
+                - name: ROOK_ENABLE_FLEX_DRIVER
                   value: "false"
+                - name: ROOK_ENABLE_DISCOVERY_DAEMON
+                  value: "false"
+                - name: ROOK_DISABLE_DEVICE_HOTPLUG
+                  value: "true"
                 - name: NODE_NAME
                   valueFrom:
                     fieldRef:
@@ -274,7 +194,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: rook/ceph:v1.0.1
+                image: rook/ceph:master
+                imagePullPolicy: Always
                 name: rook-ceph-operator
                 resources: {}
                 volumeMounts:
@@ -451,6 +372,65 @@ spec:
           - '*'
           verbs:
           - '*'
+      - serviceAccountName: rook-ceph-cmd-reporter
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+      - serviceAccountName: cephfs-csi-provisioner
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - create
+          - delete
+      - serviceAccountName: rbd-csi-provisioner
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
 
         # NooBaa permissions
       - serviceAccountName: noobaa-operator
@@ -618,6 +598,248 @@ spec:
           - get
           - list
           - watch
+      - serviceAccountName: rook-csi-cephfs-plugin-sa
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - volumeattachments
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+      - serviceAccountName: rook-csi-cephfs-provisioner-sa
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - list
+          - watch
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - volumeattachments
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+      - serviceAccountName: rook-csi-rbd-plugin-sa
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - volumeattachments
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+      - serviceAccountName: rook-csi-rbd-provisioner-sa
+        rules:
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - volumeattachments
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - storage.k8s.io
+          resources:
+          - storageclasses
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - list
+          - watch
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshots
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - snapshot.storage.k8s.io
+          resources:
+          - volumesnapshotcontents
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - create
 
         # NooBaa operator cluster permissions
       - serviceAccountName: noobaa-operator

--- a/deploy/olm-catalog/ocs-operator/0.0.1/rookcephfilesystems.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/rookcephfilesystems.crd.yaml
@@ -1,0 +1,21 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: cephfilesystems.ceph.rook.io
+spec:
+  group: ceph.rook.io
+  names:
+    kind: CephFilesystem
+    listKind: CephFilesystemList
+    plural: cephfilesystems
+    singular: cephfilesystem
+  scope: Namespaced
+  version: v1
+  additionalPrinterColumns:
+    - name: MdsCount
+      type: string
+      description: Number of MDSs
+      JSONPath: .spec.metadataServer.activeCount
+    - name: Age
+      type: date
+      JSONPath: .metadata.creationTimestamp

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -95,7 +95,7 @@ func newCephCluster(sc *ocsv1alpha1.StorageCluster) *rookCephv1.CephCluster {
 		},
 		Spec: rookCephv1.ClusterSpec{
 			CephVersion: rookCephv1.CephVersionSpec{
-				Image:            "ceph/ceph:v14.2.1-20190430",
+				Image:            "ceph/ceph:v14.2.2-20190722",
 				AllowUnsupported: false,
 			},
 			Mon: rookCephv1.MonSpec{


### PR DESCRIPTION
This commit configures the CephClusters created by the controller, to use PVs
for the mon pods.

It adds a VolumeClaimTemplate for the mons. The VolumeClaimTemplate is based on
the DataPVCTemplate of the first StorageDeviceSet configured in the
StorageCluster, and is created only if one StorageDeviceSet is present.

This builds on top of #30, and should be merged after it.