### PR TITLE
deploy: Remove unnecessary Rook-Ceph configurations

### DIFF
--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -178,10 +178,6 @@ spec:
                   value: "true"
                 - name: ROOK_ENABLE_FLEX_DRIVER
                   value: "false"
-                - name: ROOK_ENABLE_DISCOVERY_DAEMON
-                  value: "false"
-                - name: ROOK_DISABLE_DEVICE_HOTPLUG
-                  value: "true"
                 - name: NODE_NAME
                   valueFrom:
                     fieldRef:


### PR DESCRIPTION
We need these removed in order to support local PVs later on.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>