### PR TITLE
Add StorageClusterInitialization to CSV

### DIFF
--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -35,6 +35,12 @@ spec:
       version: v1alpha1
       displayName: OCS Initialization
       description: OCS Initialization represents the initial data to be created when the OCS operator is installed
+    - kind: StorageClusterInitialization
+      name: storageclusterinitializations.ocs.openshift.io
+      version: v1alpha1
+      displayName: StorageCluster Initialization
+      description: StorageCluster Initialization represents a set of tasks the OCS operator wants to implement for every StorageCluster it encounters.
+
       # Rook-Ceph CRDs
     - description: Represents a Ceph cluster.
       displayName: Ceph Cluster

--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -12,9 +12,47 @@ metadata:
                   "namespace": "openshift-storage"
               },
               "spec": {
-                  "manageNodes": false
+                  "manageNodes": false,
+                  "storageDeviceSets": [
+                      {
+                          "count": 3,
+                          "dataPVCTemplate": {
+                              "spec": {
+                                  "accessModes": [
+                                      "ReadWriteOnce"
+                                  ],
+                                  "resources": {
+                                      "requests": {
+                                          "storage": "1Ti"
+                                      }
+                                  },
+                                  "storageClassName": "gp2",
+                                  "volumeMode": "Block"
+                              }
+                          },
+                          "name": "example-deviceset",
+                          "placement": {},
+                          "resources": {}
+                      }
+                  ]
               }
           },
+          {
+              "apiVersion": "ocs.openshift.io/v1alpha1",
+              "kind": "OCSInitialization",
+              "metadata": {
+                  "name": "example-ocsinitialization"
+              },
+              "spec": {}
+          },
+          {
+              "apiVersion": "ocs.openshift.io/v1alpha1",
+              "kind": "StorageClusterInitialization",
+              "metadata": {
+                  "name": "example-storageclusterinitialization"
+              },
+              "spec": {}
+          }
       ]
     capabilities: Full Lifecycle
     categories: Storage

--- a/deploy/olm-catalog/ocs-operator/0.0.1/storageclusterinitialization.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/storageclusterinitialization.crd.yaml
@@ -1,0 +1,44 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: storageclusterinitializations.ocs.openshift.io
+spec:
+  group: ocs.openshift.io
+  names:
+    kind: StorageClusterInitialization
+    listKind: StorageClusterInitializationList
+    plural: storageclusterinitializations
+    singular: storageclusterinitialization
+  scope: Namespaced
+  version: v1alpha1
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          properties:
+            errorMessage:
+              type: string
+            storageClassesCreated:
+              type: boolean
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true


### PR DESCRIPTION
This PR adds StorageClusterInitialization CRD to the CSV. It also updates the
alm-examples to include examples for all CRs managed by the ocs-operator.