### PR TITLE
updates CSV : Deploy Local-Storage-Operator

### DIFF
--- a/deploy/deploy-with-olm.yaml
+++ b/deploy/deploy-with-olm.yaml
@@ -1,3 +1,32 @@
+## Create the local-storage namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: local-storage
+
+---
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: local-operator-group
+  namespace: local-storage
+  spec:
+    targetNamespaces:
+    - openshift-storage
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: local-storage-manifests
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/gnufied/local-registry:v4.2.0
+  displayName: Local Storage Operator
+  publisher: Red Hat
+  description: An operator to manage local volumes
+
 ---
 ## Add a custom CatalogSource for the ocs-operator CSV
 apiVersion: operators.coreos.com/v1alpha1
@@ -10,6 +39,7 @@ spec:
   image: quay.io/ocs-dev/ocs-registry:latest
   displayName: Openshift Container Storage
   publisher: Red Hat
+
 ---
 ## Create the openshift-storage namespace
 apiVersion: v1

--- a/deploy/deploy-with-olm.yaml
+++ b/deploy/deploy-with-olm.yaml
@@ -46,6 +46,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-storage
+  labels:
+    openshift.io/cluster-monitoring: "true"
 
 ---
 ## Create the ocs OperatorGroup to allow installation of the OCS CSV into the

--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -129,6 +129,13 @@ spec:
       version: v1alpha1
       displayName: Bucket Class
       description: Add bucket classes to customize the data placement locations.
+    required:
+      # Local-Storage-Operator CRD
+    - name: localvolumes.local.storage.openshift.io
+      version: v1
+      kind: LocalVolume
+      displayName: Local Volume
+      description: Local Storage Operator
   description: |
     Red Hat Openshift Container Storage (OCS) provides hyperconverged storage for applications within an Openshift cluster.
 


### PR DESCRIPTION
- Adds local-storage-operator as dependency of ocs-operator
- Updates deploy-with-olm.yaml to include local-storage-operator

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>

-----
Few things to note,
1. `local-storage-operator` needs to be a part of `olm-catalog` for dependency to be resolved automatically.
2. `deploy-with-olm.yaml` deploys the catalogSource and operatorGroup for `local-storage-operator` along with `ocs-operator`.
3. To be able to test this, we need a new build of `bundle` at `quay.io/ocs-dev/ocs-registry`