### PR TITLE
Hide Rook/NooBaa CRDs in operator catalog (DO-NOT-MERGE)

### DIFF
--- a/deploy/deploy-with-olm.yaml
+++ b/deploy/deploy-with-olm.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: quay.io/ocs-dev/ocs-registry:latest
+  image: quay.io/kshlm/ocs-registry:hidden-crds
   displayName: Openshift Container Storage
   publisher: Red Hat
 ---

--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -79,56 +79,6 @@ spec:
       displayName: StorageCluster Initialization
       description: StorageCluster Initialization represents a set of tasks the OCS operator wants to implement for every StorageCluster it encounters.
 
-      # Rook-Ceph CRDs
-    - description: Represents a Ceph cluster.
-      displayName: Ceph Cluster
-      kind: CephCluster
-      name: cephclusters.ceph.rook.io
-      version: v1
-    - description: Represents a Ceph Block Pool.
-      displayName: Ceph Block Pool
-      kind: CephBlockPool
-      name: cephblockpools.ceph.rook.io
-      version: v1
-    - description: Represents a Ceph Object Store.
-      displayName: Ceph Object Store
-      kind: CephObjectStore
-      name: cephobjectstores.ceph.rook.io
-      version: v1
-    - description: Represents a Ceph Object Store User.
-      displayName: Ceph Object Store User
-      kind: CephObjectStoreUser
-      name: cephobjectstoreusers.ceph.rook.io
-      version: v1
-    - description: Represents a Ceph Filesystem
-      displayName: Ceph Filesystem
-      kind: CephFilesystem
-      name: cephfilesystems.ceph.rook.io
-      version: v1
-
-      # NooBaa CRDs
-    - kind: NooBaa
-      name: noobaas.noobaa.io
-      version: v1alpha1
-      displayName: NooBaa
-      description: NooBaa provides a flexible S3 data service backed by any storage resource for hybrid and multi-cloud environments
-      resources:
-        - kind: Service
-          version: v1
-        - kind: StatefulSet
-          version: v1
-        - kind: Secret
-          version: v1
-    - kind: BackingStore
-      name: backingstores.noobaa.io
-      version: v1alpha1
-      displayName: Backing Store
-      description: Add backing stores to customize the data placement locations.
-    - kind: BucketClass
-      name: bucketclasses.noobaa.io
-      version: v1alpha1
-      displayName: Bucket Class
-      description: Add bucket classes to customize the data placement locations.
   description: |
     Red Hat Openshift Container Storage (OCS) provides hyperconverged storage for applications within an Openshift cluster.
 


### PR DESCRIPTION
This commit removes the Rook and NooBaa CRDs from the owned CRD list in
the CSV. The manifest files for the Rook and NooBaa CRDs are still
present in the catalog directory. Also, the operator deployments for the
rook-ceph and noobaa-operator are still present.

The generated catalog bundle, bundles all the CRD manifests from the
catlog directory, even if they are not present in the CSV. When the OLM
deploys the ocs-operator CSV from this catalog, it creates all the
included CRDs in the cluster, and starts all the operators.

The end result of this, is that only the OCS operator CRDs are available
in the Console, with the other CRDs being hidden. Rook and NooBaa CRDs
not being available from the Console is a good thing for OCS, as we do
not want users to be manually creating their own CephClusters or other
Rook/NooBaa resources.

Users can create a StorageCluster resource from the UI, which leads to
the ocs-opertor creating a CephCluster resource, and the rook-ceph
operator creating the actual ceph cluster. All of this still works, as
the CRDs required are present in the cluster.