### PR TITLE
api: Update generated files

### DIFF
--- a/deploy/crds/ocs_v1alpha1_storageclusterinitialization_crd.yaml
+++ b/deploy/crds/ocs_v1alpha1_storageclusterinitialization_crd.yaml
@@ -10,7 +10,6 @@ spec:
     plural: storageclusterinitializations
     singular: storageclusterinitialization
   scope: Namespaced
-  version: v1alpha1
   subresources:
     status: {}
   validation:
@@ -34,8 +33,6 @@ spec:
           properties:
             errorMessage:
               type: string
-            storageClassesCreated:
-              type: boolean
           type: object
   version: v1alpha1
   versions:

--- a/pkg/apis/ocs/v1alpha1/storagecluster_types.go
+++ b/pkg/apis/ocs/v1alpha1/storagecluster_types.go
@@ -9,6 +9,7 @@ import (
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
+
 // Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 
 // StorageClusterSpec defines the desired state of StorageCluster

--- a/pkg/apis/ocs/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/ocs/v1alpha1/zz_generated.openapi.go
@@ -11,11 +11,14 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.OCSInitialization":       schema_pkg_apis_ocs_v1alpha1_OCSInitialization(ref),
-		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.OCSInitializationSpec":   schema_pkg_apis_ocs_v1alpha1_OCSInitializationSpec(ref),
-		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.OCSInitializationStatus": schema_pkg_apis_ocs_v1alpha1_OCSInitializationStatus(ref),
-		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageCluster":          schema_pkg_apis_ocs_v1alpha1_StorageCluster(ref),
-		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterStatus":    schema_pkg_apis_ocs_v1alpha1_StorageClusterStatus(ref),
+		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.OCSInitialization":                  schema_pkg_apis_ocs_v1alpha1_OCSInitialization(ref),
+		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.OCSInitializationSpec":              schema_pkg_apis_ocs_v1alpha1_OCSInitializationSpec(ref),
+		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.OCSInitializationStatus":            schema_pkg_apis_ocs_v1alpha1_OCSInitializationStatus(ref),
+		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageCluster":                     schema_pkg_apis_ocs_v1alpha1_StorageCluster(ref),
+		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterInitialization":       schema_pkg_apis_ocs_v1alpha1_StorageClusterInitialization(ref),
+		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterInitializationSpec":   schema_pkg_apis_ocs_v1alpha1_StorageClusterInitializationSpec(ref),
+		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterInitializationStatus": schema_pkg_apis_ocs_v1alpha1_StorageClusterInitializationStatus(ref),
+		"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterStatus":               schema_pkg_apis_ocs_v1alpha1_StorageClusterStatus(ref),
 	}
 }
 
@@ -160,6 +163,80 @@ func schema_pkg_apis_ocs_v1alpha1_StorageCluster(ref common.ReferenceCallback) c
 		},
 		Dependencies: []string{
 			"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterSpec", "github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+	}
+}
+
+func schema_pkg_apis_ocs_v1alpha1_StorageClusterInitialization(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StorageClusterInitialization is the Schema for the storageclusterinitializations API",
+				Properties: map[string]spec.Schema{
+					"kind": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"apiVersion": {
+						SchemaProps: spec.SchemaProps{
+							Description: "APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"metadata": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"),
+						},
+					},
+					"spec": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterInitializationSpec"),
+						},
+					},
+					"status": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterInitializationStatus"),
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{
+			"github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterInitializationSpec", "github.com/openshift/ocs-operator/pkg/apis/ocs/v1alpha1.StorageClusterInitializationStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+	}
+}
+
+func schema_pkg_apis_ocs_v1alpha1_StorageClusterInitializationSpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StorageClusterInitializationSpec defines the desired state of StorageClusterInitialization",
+				Properties:  map[string]spec.Schema{},
+			},
+		},
+		Dependencies: []string{},
+	}
+}
+
+func schema_pkg_apis_ocs_v1alpha1_StorageClusterInitializationStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "StorageClusterInitializationStatus defines the observed state of StorageClusterInitialization",
+				Properties: map[string]spec.Schema{
+					"errorMessage": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+			},
+		},
+		Dependencies: []string{},
 	}
 }
 


### PR DESCRIPTION
The openapi generation was not done after the introduction of StorageClusterInitialization.