### PR TITLE
updated CSV & Bundle to enable OCS Monitoring

### DIFF
--- a/deploy/olm-catalog/ocs-operator/0.0.1/role_binding_metrics.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/role_binding_metrics.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-metrics
+  namespace: openshift-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-metrics
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/deploy/olm-catalog/ocs-operator/0.0.1/role_binding_monitor.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/role_binding_monitor.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-monitor
+  namespace: openshift-storage
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-monitor
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-system
+  namespace: openshift-storage

--- a/deploy/olm-catalog/ocs-operator/0.0.1/role_metrics.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/role_metrics.yaml
@@ -1,0 +1,16 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-metrics
+  namespace: openshift-storage
+rules:
+ - apiGroups:
+   - ""
+   resources:
+    - services
+    - endpoints
+    - pods
+   verbs:
+    - get
+    - list
+    - watch

--- a/deploy/olm-catalog/ocs-operator/0.0.1/role_monitor.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/role_monitor.yaml
@@ -1,0 +1,12 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: rook-ceph-monitor
+  namespace: openshift-storage
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - '*'
+  verbs:
+- '*'


### PR DESCRIPTION
- CSV includes rbac for monitoring components
- Bundle includes rbac for cross-namespace rolebinding

OLM doesn't support cross-namespace rolebinding (via CSV).
This is a must-have for OCS to be monitored via OCP Monitoring.
To achieve this, it is necessary that we add these extra rbac
manifests into the bundle and deploy it as a part of operator
bundle deployment.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>