### PR TITLE
adds Placement Configuration for rook-ceph agents and services

### DIFF
--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -233,6 +233,19 @@ spec:
                   value: "false"
                 - name: ROOK_DISABLE_DEVICE_HOTPLUG
                   value: "true"
+                # Placement Configurations
+                - name: AGENT_TOLERATION
+                  value: "NoSchedule"
+                - name: AGENT_TOLERATION_KEY
+                  value: "node.ocs.openshift.io/storage=true"
+                - name: AGENT_NODE_AFFINITY
+                  value: "cluster.ocs.openshift.io/openshift-storage="
+                - name: DISCOVER_TOLERATION
+                  value: "NoSchedule"
+                - name: DISCOVER_TOLERATION_KEY
+                  value: "node.ocs.openshift.io/storage=true"
+                - name: DISCOVER_AGENT_NODE_AFFINITY
+                  value: "cluster.ocs.openshift.io/openshift-storage="
                 - name: NODE_NAME
                   valueFrom:
                     fieldRef:

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -89,6 +89,7 @@ func newCephCluster(sc *ocsv1alpha1.StorageCluster) *rookCephv1.CephCluster {
 	labels := map[string]string{
 		"app": sc.Name,
 	}
+
 	cephCluster := &rookCephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sc.Name,
@@ -117,6 +118,86 @@ func newCephCluster(sc *ocsv1alpha1.StorageCluster) *rookCephv1.CephCluster {
 			},
 			Storage: rook.StorageScopeSpec{
 				StorageClassDeviceSets: newStorageClassDeviceSets(sc.Spec.StorageDeviceSets),
+			},
+			Placement: rook.PlacementSpec{
+				"all": rook.Placement{
+					NodeAffinity: &corev1.NodeAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+								corev1.NodeSelectorTerm{
+									MatchExpressions: []corev1.NodeSelectorRequirement{
+										corev1.NodeSelectorRequirement{
+											Key:      "cluster.ocs.openshift.io/openshift-storage=",
+											Operator: corev1.NodeSelectorOpExists,
+										},
+									},
+								},
+							},
+						},
+					},
+					Tolerations: []corev1.Toleration{
+						corev1.Toleration{
+							Key:      "node.ocs.openshift.io/storage",
+							Operator: corev1.TolerationOpEqual,
+							Value:    "true",
+							Effect:   corev1.TaintEffectNoSchedule,
+						},
+					},
+				},
+				"mon": rook.Placement{
+					PodAntiAffinity: &corev1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										metav1.LabelSelectorRequirement{
+											Key:      "app",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"rook-ceph-mon"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"mgr": rook.Placement{
+					PodAntiAffinity: &corev1.PodAntiAffinity{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										metav1.LabelSelectorRequirement{
+											Key:      "app",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"rook-ceph-mgr"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				"osd": rook.Placement{
+					PodAntiAffinity: &corev1.PodAntiAffinity{
+						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+							corev1.WeightedPodAffinityTerm{
+								Weight: 100,
+								PodAffinityTerm: corev1.PodAffinityTerm{
+									LabelSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{
+											metav1.LabelSelectorRequirement{
+												Key:      "app",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"rook-ceph-osd"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
- updates CSV to change rook-ceph operator deployment
  enables nodeAffinity and toleration env var for rook agents
- updates CephCluster CR
  adds nodeAffinity, toleration, podAntiAffinity to all services

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>