### PR TITLE
Adds 'watch' RBAC for ceph cluster objects

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -57,3 +57,4 @@ rules:
   - delete
   - update
   - list
+  - watch


### PR DESCRIPTION
fixes this error in the ocs-operator caused by the ceph cluster informer not having the 'watch' RBAC permission. 

```
E0823 17:55:09.056177       1 reflector.go:251] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to watch *v1.CephCluster: unknown (get cephclusters.ceph.rook.io)
E0823 17:55:10.060386       1 reflector.go:251] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to watch *v1.CephCluster: unknown (get cephclusters.ceph.rook.io)
E0823 17:55:11.063933       1 reflector.go:251] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to watch *v1.CephCluster: unknown (get cephclusters.ceph.rook.io)
E0823 17:55:12.068141       1 reflector.go:251] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to watch *v1.CephCluster: unknown (get cephclusters.ceph.rook.io)
E0823 17:55:13.071993       1 reflector.go:251] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to watch *v1.CephCluster: unknown (get cephclusters.ceph.rook.io)
E0823 17:55:14.075873       1 reflector.go:251] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to watch *v1.CephCluster: unknown (get cephclusters.ceph.rook.io)
E0823 17:55:15.079768       1 reflector.go:251] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:126: Failed to watch *v1.CephCluster: unknown (get cephclusters.ceph.rook.io)
```