### PR TITLE
Unbreak ocs-operator

### DIFF
--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -245,7 +245,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: rook/ceph:master
+                image: rook/ceph:v1.0.0-457.gddfb403
                 imagePullPolicy: Always
                 name: rook-ceph-operator
                 resources: {}
@@ -340,6 +340,7 @@ spec:
           - '*'
           - storageclusters
           - ocsinitializations
+          - storageclusterinitializations
           verbs:
           - '*'
         - apiGroups:
@@ -352,6 +353,7 @@ spec:
           - delete
           - update
           - list
+          - watch
 
         # Rook-Ceph permissions
       - serviceAccountName: rook-ceph-system

--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -233,19 +233,6 @@ spec:
                   value: "false"
                 - name: ROOK_DISABLE_DEVICE_HOTPLUG
                   value: "true"
-                # Placement Configurations
-                - name: AGENT_TOLERATION
-                  value: "NoSchedule"
-                - name: AGENT_TOLERATION_KEY
-                  value: "node.ocs.openshift.io/storage=true"
-                - name: AGENT_NODE_AFFINITY
-                  value: "cluster.ocs.openshift.io/openshift-storage="
-                - name: DISCOVER_TOLERATION
-                  value: "NoSchedule"
-                - name: DISCOVER_TOLERATION_KEY
-                  value: "node.ocs.openshift.io/storage=true"
-                - name: DISCOVER_AGENT_NODE_AFFINITY
-                  value: "cluster.ocs.openshift.io/openshift-storage="
                 - name: NODE_NAME
                   valueFrom:
                     fieldRef:

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -188,7 +188,6 @@ func newCephCluster(sc *ocsv1alpha1.StorageCluster) *rookCephv1.CephCluster {
 	labels := map[string]string{
 		"app": sc.Name,
 	}
-
 	cephCluster := &rookCephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sc.Name,
@@ -217,86 +216,6 @@ func newCephCluster(sc *ocsv1alpha1.StorageCluster) *rookCephv1.CephCluster {
 			},
 			Storage: rook.StorageScopeSpec{
 				StorageClassDeviceSets: newStorageClassDeviceSets(sc.Spec.StorageDeviceSets),
-			},
-			Placement: rook.PlacementSpec{
-				"all": rook.Placement{
-					NodeAffinity: &corev1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-							NodeSelectorTerms: []corev1.NodeSelectorTerm{
-								corev1.NodeSelectorTerm{
-									MatchExpressions: []corev1.NodeSelectorRequirement{
-										corev1.NodeSelectorRequirement{
-											Key:      "cluster.ocs.openshift.io/openshift-storage=",
-											Operator: corev1.NodeSelectorOpExists,
-										},
-									},
-								},
-							},
-						},
-					},
-					Tolerations: []corev1.Toleration{
-						corev1.Toleration{
-							Key:      "node.ocs.openshift.io/storage",
-							Operator: corev1.TolerationOpEqual,
-							Value:    "true",
-							Effect:   corev1.TaintEffectNoSchedule,
-						},
-					},
-				},
-				"mon": rook.Placement{
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-							corev1.PodAffinityTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										metav1.LabelSelectorRequirement{
-											Key:      "app",
-											Operator: metav1.LabelSelectorOpIn,
-											Values:   []string{"rook-ceph-mon"},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				"mgr": rook.Placement{
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-							corev1.PodAffinityTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										metav1.LabelSelectorRequirement{
-											Key:      "app",
-											Operator: metav1.LabelSelectorOpIn,
-											Values:   []string{"rook-ceph-mgr"},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-				"osd": rook.Placement{
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-							corev1.WeightedPodAffinityTerm{
-								Weight: 100,
-								PodAffinityTerm: corev1.PodAffinityTerm{
-									LabelSelector: &metav1.LabelSelector{
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											metav1.LabelSelectorRequirement{
-												Key:      "app",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"rook-ceph-osd"},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
 			},
 		},
 	}


### PR DESCRIPTION
This PR,
- Reverts #51 - This was added new placement configuration which used an
  invalid label, leading the rook failing to correctly deploy a CephCluster
- Pins version of the rook/ceph image to a known working version
- Updates permission for the ocs-operator in CSV.