### PR TITLE
updates permission of ocs-operator serviceaccount

### DIFF
--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -708,10 +708,7 @@ spec:
           - cephobjectstore
           - cephobjectstoreusers
           verbs:
-          - get
-          - create
-          - list
-          - watch
+          - '*'
         serviceAccountName: ocs-operator
       deployments:
       - name: rook-ceph-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -63,7 +63,4 @@ rules:
   - cephobjectstore
   - cephobjectstoreusers
   verbs:
-  - get
-  - create
-  - list
-  - watch
+  - '*'


### PR DESCRIPTION
- this change allows ocs-operator to perform all kinds of actions(CRUD)
  on rook-ceph resources
- this also enables cluster expansion via CephCluster CR update

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>