### PR TITLE
Improve Latest CSV Generation Workflow. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,7 @@ export GO111MODULE=on
 
 all: ocs-operator ocs-must-gather ocs-registry
 
-.PHONY: clean ocs-operator ocs-must-gather ocs-registry gen-csv source-manifests
-
+.PHONY: clean ocs-operator ocs-must-gather ocs-registry gen-release-csv gen-latest-csv source-manifests
 deps-update:
 	go mod tidy && go mod vendor
 
@@ -39,7 +38,11 @@ source-manifests:
 	@echo "Sourcing CSV and CRD manifests from component-level operators"
 	hack/source-manifests.sh
 
-gen-csv:
+gen-latest-csv:
+	@echo "Generating latest development CSV version using predefined ENV VARs."
+	hack/generate-latest-csv.sh
+
+gen-release-csv:
 	@echo "Generating unified CSV from sourced component-level operators"
 	hack/generate-unified-csv.sh
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ operator to create a single unified CSV capable of deploying the component-level
 operators as well as the ocs-operator.
 
 Building the unifed CSV is broken into two steps which are supported by the
-`make source-manifests` and `make gen-csv` make targets.
+`make source-manifests` and `make gen-release-csv` make targets.
 
 **Step 1:** Source in the component-level manifests from the component-level operator
 container images.
@@ -68,7 +68,7 @@ $ export ROOK_CSI_PROVISIONER_IMAGE=<add image here>
 $ export ROOK_CSI_SNAPSHOTTER_IMAGE=<add image here>
 $ export ROOK_CSI_ATTACHER_IMAGE=<add image here>
 
-$ make gen-csv
+$ make gen-release-csv
 ```
 
 This example results in both a unified CSV along with all the corresponding CRDs being placed in `deploy/olm-catalog/ocs-operator/0.0.2/` for release.

--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -766,7 +766,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: rook/ceph:v1.0.0-526.g3ece503
+                image: rook/ceph@sha256:addf210104fd4e222b11529f139fb4e12c44707c7b7d46920cdf46e25a3f6a42
                 name: rook-ceph-operator
                 resources: {}
                 volumeMounts:
@@ -805,7 +805,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: noobaa/noobaa-operator:1.1.0
+                image: noobaa/noobaa-operator@sha256:d6bfdf02d72e763211a89a692f19a8c25bcc26e0d0cd04bda186333bb47894dd
                 imagePullPolicy: IfNotPresent
                 name: noobaa-operator
                 resources:

--- a/hack/generate-latest-csv.sh
+++ b/hack/generate-latest-csv.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+source hack/common.sh
+
+#sha for noobaa-operator:1.1.0
+NOOBAA_SHA="sha256:d6bfdf02d72e763211a89a692f19a8c25bcc26e0d0cd04bda186333bb47894dd"
+
+# sha for rook/ceph:v1.0.0-526.g3ece503
+ROOK_SHA="sha256:addf210104fd4e222b11529f139fb4e12c44707c7b7d46920cdf46e25a3f6a42"
+
+# Current DEV version of the CSV
+export CSV_VERSION=0.0.1
+
+# Current dependency images our DEV CSV are pinned to
+export ROOK_IMAGE=rook/ceph@$ROOK_SHA
+export NOOBAA_IMAGE=noobaa/noobaa-operator@$NOOBAA_SHA
+export CEPH_IMAGE=ceph/ceph:v14.2.2-20190828
+export OCS_IMAGE=quay.io/ocs-dev/ocs-operator:latest
+
+echo "=== Generating DEV CSV with the following vars ==="
+echo -e "\tCSV_VERSION=$CSV_VERSION"
+echo -e "\tROOK_IMAGE=$ROOK_IMAGE"
+echo -e "\tNOOBAA_IMAGE=$NOOBAA_IMAGE"
+echo -e "\tCEPH_IMAGE=$CEPH_IMAGE"
+echo -e "\tOCS_IMAGE=$OCS_IMAGE"
+
+hack/source-manifests.sh
+
+# TODO remove this once we update rook/ceph image
+# This addresses an issue that is already fixed in rook upstream
+# One of the ServiceAccounts we're sourcing from a specific rook
+# build is incorrect.
+if [ "$ROOK_SHA" = "sha256:addf210104fd4e222b11529f139fb4e12c44707c7b7d46920cdf46e25a3f6a42" ]; then
+    sed -i "s/serviceAccountName: rbd-csi-provisioner-sa/serviceAccountName: rook-csi-rbd-provisioner-sa/g" $OUTDIR_TEMPLATES/rook-csv.yaml.in
+fi
+
+hack/generate-unified-csv.sh

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -463,6 +463,19 @@ The OCS operator is the primary operator for Red Hat OpenShift Container Storage
         },
         "spec": {
             "manageNodes": false,
+            "monPVCTemplate": {
+                "spec": {
+                    "accessModes": [
+                        "ReadWriteOnce"
+                    ],
+                    "resources": {
+                        "requests": {
+                            "storage": "10Gi"
+                        }
+                    },
+                    "storageClassName": "gp2"
+                }
+            },
             "storageDeviceSets": [
                 {
                     "count": 3,
@@ -482,6 +495,7 @@ The OCS operator is the primary operator for Red Hat OpenShift Container Storage
                     },
                     "name": "example-deviceset",
                     "placement": {},
+                    "portable": true,
                     "resources": {}
                 }
             ]


### PR DESCRIPTION
This change pins the latest CSV to a specific set of container images and adds a single make target `make gen-latest-csv` to regenerate changes. 

Running `make gen-latest-csv' will rebuild the CSV and cause changes in the source tree to occur if anything is altered. In the openshift/release project (where we have our CI) I've also included a [test](https://github.com/openshift/release/pull/4893) to verify the CSV is up to date. This prevents someone from making a change to the CSV generation logic without updating the CSV manifests themselves. 