### PR TITLE
csv: Use image versions inplace of SHA

### DIFF
--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -766,7 +766,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: rook/ceph@sha256:addf210104fd4e222b11529f139fb4e12c44707c7b7d46920cdf46e25a3f6a42
+                image: rook/ceph:v1.0.0-526.g3ece503
                 name: rook-ceph-operator
                 resources: {}
                 volumeMounts:
@@ -805,7 +805,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: noobaa/noobaa-operator@sha256:d6bfdf02d72e763211a89a692f19a8c25bcc26e0d0cd04bda186333bb47894dd
+                image: noobaa/noobaa-operator:1.1.0
                 imagePullPolicy: IfNotPresent
                 name: noobaa-operator
                 resources:

--- a/hack/generate-latest-csv.sh
+++ b/hack/generate-latest-csv.sh
@@ -4,18 +4,15 @@ set -e
 
 source hack/common.sh
 
-#sha for noobaa-operator:1.1.0
-NOOBAA_SHA="sha256:d6bfdf02d72e763211a89a692f19a8c25bcc26e0d0cd04bda186333bb47894dd"
-
-# sha for rook/ceph:v1.0.0-526.g3ece503
-ROOK_SHA="sha256:addf210104fd4e222b11529f139fb4e12c44707c7b7d46920cdf46e25a3f6a42"
+NOOBAA_VERSION="1.1.0"
+ROOK_VERSION="v1.0.0-526.g3ece503"
 
 # Current DEV version of the CSV
 export CSV_VERSION=0.0.1
 
 # Current dependency images our DEV CSV are pinned to
-export ROOK_IMAGE=rook/ceph@$ROOK_SHA
-export NOOBAA_IMAGE=noobaa/noobaa-operator@$NOOBAA_SHA
+export ROOK_IMAGE=rook/ceph:$ROOK_VERSION
+export NOOBAA_IMAGE=noobaa/noobaa-operator:$NOOBAA_VERSION
 export CEPH_IMAGE=ceph/ceph:v14.2.2-20190828
 export OCS_IMAGE=quay.io/ocs-dev/ocs-operator:latest
 
@@ -32,7 +29,7 @@ hack/source-manifests.sh
 # This addresses an issue that is already fixed in rook upstream
 # One of the ServiceAccounts we're sourcing from a specific rook
 # build is incorrect.
-if [ "$ROOK_SHA" = "sha256:addf210104fd4e222b11529f139fb4e12c44707c7b7d46920cdf46e25a3f6a42" ]; then
+if [ "$ROOK_VERSION" = "v1.0.0-526.g3ece503" ]; then
     sed -i "s/serviceAccountName: rbd-csi-provisioner-sa/serviceAccountName: rook-csi-rbd-provisioner-sa/g" $OUTDIR_TEMPLATES/rook-csv.yaml.in
 fi
 


### PR DESCRIPTION
The rook/ceph images with SHA do no get pulled in OCP.
Also, image SHA don't work with podman.