### PR TITLE
Remove Rook-Ceph mgr anti-affinity

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -245,24 +245,6 @@ func newCephCluster(sc *ocsv1alpha1.StorageCluster, cephImage string) *rookCephv
 						},
 					},
 				},
-				"mgr": rook.Placement{
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-							corev1.PodAffinityTerm{
-								LabelSelector: &metav1.LabelSelector{
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										metav1.LabelSelectorRequirement{
-											Key:      "app",
-											Operator: metav1.LabelSelectorOpIn,
-											Values:   []string{"rook-ceph-mgr"},
-										},
-									},
-								},
-								TopologyKey: "kubernetes.io/hostname",
-							},
-						},
-					},
-				},
 			},
 		},
 	}


### PR DESCRIPTION
Rook only supports a single mgr, so the anti-affinity will effectively not be
needed anyway.

Continuation of #76 

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>