### PR TITLE
Openshift e2e CI debug

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -32,7 +32,7 @@ deployments=(ocs-operator rook-ceph-operator noobaa-operator)
 for i in ${deployments[@]}; do
 	current_time=0
 	sample=10
-	timeout=600
+	timeout=1200
 	while [ -z "$(oc get deployments -n openshift-storage | grep "${i} ")" ]; do
 		echo "Waiting for deployment ${i} to be created..."
 		sleep $sample

--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -38,7 +38,12 @@ for i in ${deployments[@]}; do
 		sleep $sample
 		current_time=$((current_time + sample))
 		if [[ $current_time -gt $timeout ]]; then
-			echo "Timed out waiting for deployment ${i} to be created"
+			# On failure, dump debug info about the ocs-catalogsource
+			echo "----------- dumping all pods for debug ----------------"
+			oc get pods --all-namespaces
+			echo "----------- dumping all pods for debug ----------------"
+			echo ""
+			echo "ERROR: Timed out waiting for deployment ${i} to be created"
 			exit 1
 		fi
 	done

--- a/openshift-ci/Dockerfile.deploy
+++ b/openshift-ci/Dockerfile.deploy
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 LABEL com.redhat.delivery.appregistry=true
 
 ENV LANG=en_US.utf8


### PR DESCRIPTION
The Openshift CI e2e job is failing to deploy the ocs-operator. I need info about the pods to diagnose what's happening. 

I also altered one of the Openshift CI Dockerfiles to use ubi7 instead of ubi8. This is to be consistent with the containers defined in the Openshift CI release config. 