### PR TITLE
Add default channel of OCS operator

### DIFF
--- a/deploy/olm-catalog/ocs-operator/ocs-operator.package.yaml
+++ b/deploy/olm-catalog/ocs-operator/ocs-operator.package.yaml
@@ -2,3 +2,4 @@ packageName: ocs-operator
 channels:
 - name: alpha
   currentCSV: ocs-operator.v0.0.1
+defaultChannel: "alpha"


### PR DESCRIPTION
This is something which will be very useful for automation to choose default channel.
This is also how CNV consumes it for HCO operator. 

```yaml
cat kubevirt-hyperconverged.package.yaml
packageName: kubevirt-hyperconverged
channels:
- name: "2.1.0"
  currentCSV: kubevirt-hyperconverged-operator.v2.1.0
- name: "2.0.0"
  currentCSV: kubevirt-hyperconverged-operator.v2.0.0
defaultChannel: "2.1.0"
```