### PR TITLE
Revert "Change failure domain to zone for all cephv1.PoolSpecs"

### DIFF
--- a/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
+++ b/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
@@ -401,7 +401,7 @@ func (r *ReconcileStorageClusterInitialization) newCephObjectStoreInstances(init
 			},
 			Spec: cephv1.ObjectStoreSpec{
 				MetadataPool: cephv1.PoolSpec{
-					FailureDomain: "zone",
+					FailureDomain: "host",
 					Replicated: cephv1.ReplicatedSpec{
 						Size: 3,
 					},
@@ -498,7 +498,7 @@ func (r *ReconcileStorageClusterInitialization) newCephBlockPoolInstances(initDa
 				Namespace: initData.Namespace,
 			},
 			Spec: cephv1.PoolSpec{
-				FailureDomain: "zone",
+				FailureDomain: "host",
 				Replicated: cephv1.ReplicatedSpec{
 					Size: 3,
 				},
@@ -604,14 +604,13 @@ func (r *ReconcileStorageClusterInitialization) newCephFilesystemInstances(initD
 					Replicated: cephv1.ReplicatedSpec{
 						Size: 3,
 					},
-					FailureDomain: "zone",
 				},
 				DataPools: []cephv1.PoolSpec{
 					cephv1.PoolSpec{
 						Replicated: cephv1.ReplicatedSpec{
 							Size: 3,
 						},
-						FailureDomain: "zone",
+						FailureDomain: "host",
 					},
 				},
 				MetadataServer: cephv1.MetadataServerSpec{


### PR DESCRIPTION
This reverts commit e7be566c5f2d50f990287c2365c9e75e2227c5f4.

This breaks deployments where we don't have zones or have too few zones.
So this needs more thought. Reverting this change so that testing is
unblocked.

Signed-off-by: Michael Adam <obnox@redhat.com>