### PR TITLE
storagecluster: Correctly set tolerations for StorageClassDeviceSets

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -24,6 +24,56 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const (
+	nodeAffinityKey   = "cluster.ocs.openshift.io/openshift-storage"
+	nodeTolerationKey = "node.ocs.openshift.io/storage"
+)
+
+var (
+	defaultOSDPlacement = rook.Placement{
+		NodeAffinity: &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					corev1.NodeSelectorTerm{
+						MatchExpressions: []corev1.NodeSelectorRequirement{
+							corev1.NodeSelectorRequirement{
+								Key:      nodeAffinityKey,
+								Operator: corev1.NodeSelectorOpExists,
+							},
+						},
+					},
+				},
+			},
+		},
+		Tolerations: []corev1.Toleration{
+			corev1.Toleration{
+				Key:      nodeTolerationKey,
+				Operator: corev1.TolerationOpEqual,
+				Value:    "true",
+				Effect:   corev1.TaintEffectNoSchedule,
+			},
+		},
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				corev1.WeightedPodAffinityTerm{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								metav1.LabelSelectorRequirement{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"rook-ceph-osd"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
 // Reconcile reads that state of the cluster for a StorageCluster object and makes changes based on the state read
 // and what is in the StorageCluster.Spec
 // Note:
@@ -240,8 +290,6 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string) *cephv1.CephClus
 	labels := map[string]string{
 		"app": sc.Name,
 	}
-	nodeAffinityKey := "cluster.ocs.openshift.io/openshift-storage"
-	nodeTolerationKey := "node.ocs.openshift.io/storage"
 
 	cephCluster := &cephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -320,50 +368,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string) *cephv1.CephClus
 		// object in the slice.
 		// Hence, we instead get a pointer to actual object using the index and
 		// modify it.
-		scds := &cephCluster.Spec.Storage.StorageClassDeviceSets[i]
-
-		scds.Placement = rook.Placement{
-			NodeAffinity: &corev1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-					NodeSelectorTerms: []corev1.NodeSelectorTerm{
-						corev1.NodeSelectorTerm{
-							MatchExpressions: []corev1.NodeSelectorRequirement{
-								corev1.NodeSelectorRequirement{
-									Key:      nodeAffinityKey,
-									Operator: corev1.NodeSelectorOpExists,
-								},
-							},
-						},
-					},
-				},
-			},
-			Tolerations: []corev1.Toleration{
-				corev1.Toleration{
-					Key:      nodeTolerationKey,
-					Operator: corev1.TolerationOpEqual,
-					Value:    "true",
-					Effect:   corev1.TaintEffectNoSchedule,
-				},
-			},
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-					corev1.WeightedPodAffinityTerm{
-						Weight: 100,
-						PodAffinityTerm: corev1.PodAffinityTerm{
-							LabelSelector: &metav1.LabelSelector{
-								MatchExpressions: []metav1.LabelSelectorRequirement{
-									metav1.LabelSelectorRequirement{
-										Key:      "app",
-										Operator: metav1.LabelSelectorOpIn,
-										Values:   []string{"rook-ceph-osd"},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
+		cephCluster.Spec.Storage.StorageClassDeviceSets[i].Placement = defaultOSDPlacement
 	}
 
 	// If a MonPVCTemplate is provided, use that. If not, if StorageDeviceSets

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -266,14 +266,16 @@ func TestStorageClusterCephClusterCreation(t *testing.T) {
 			},
 		},
 	}
+
 	actual := newCephCluster(expected, "")
 	assert.Equal(t, expected.Name, actual.Name)
 	assert.Equal(t, expected.Namespace, actual.Namespace)
 	assert.Equal(t, expected.Spec.StorageDeviceSets[0].Name, actual.Spec.Storage.StorageClassDeviceSets[0].Name)
 	assert.Equal(t, expected.Spec.StorageDeviceSets[0].Count, actual.Spec.Storage.StorageClassDeviceSets[0].Count)
 	assert.Equal(t, expected.Spec.StorageDeviceSets[0].Resources, actual.Spec.Storage.StorageClassDeviceSets[0].Resources)
-	assert.Equal(t, expected.Spec.StorageDeviceSets[0].Placement, actual.Spec.Storage.StorageClassDeviceSets[0].Placement)
 	assert.Equal(t, expected.Spec.StorageDeviceSets[0].DataPVCTemplate.Spec, actual.Spec.Storage.StorageClassDeviceSets[0].VolumeClaimTemplates[0].Spec)
+	// StorageCluster controller adds a default placement config for OSD StorageClassDeviceSets
+	assert.Equal(t, defaultOSDPlacement, actual.Spec.Storage.StorageClassDeviceSets[0].Placement)
 }
 
 func TestStorageClusterInitConditions(t *testing.T) {


### PR DESCRIPTION
Tolerations were being set on copies of items returned by range, instead
of the actual items themselves. Becuase of this, the CephCluster
resource created by the StorageCluster controller did not have
tolerations set for the StorageClassDeviceSets.

This commit changes the loop used to set the tolerations to use slice
index, to actually modify the object in slice.