### PR TITLE
storagecluster: Do not set podAntiAffinity for device sets

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -53,24 +53,6 @@ var (
 				Effect:   corev1.TaintEffectNoSchedule,
 			},
 		},
-		PodAntiAffinity: &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-				corev1.WeightedPodAffinityTerm{
-					Weight: 100,
-					PodAffinityTerm: corev1.PodAffinityTerm{
-						LabelSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{
-								metav1.LabelSelectorRequirement{
-									Key:      "app",
-									Operator: metav1.LabelSelectorOpIn,
-									Values:   []string{"rook-ceph-osd"},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
 	}
 )
 


### PR DESCRIPTION
Commit 062137e (storagecluster: Correctly set tolerations for
StorageClassDeviceSets) ensures that placement configuration is
correctly set for StorageClassDeviceSets, and passed along to Rook.

With this, podAntiAffinity is being set for StorageClassDeviceSets. The
set podAntiAffinity being set, does not have a topologyKey set, which
causes failure of the OSD prepare jobs to be scheduled and prevents
complete deployment of the storage cluster.

This commit removes the podAntiAffinity on StorageClassDeviceSets, to
allow pods to be scheduled.