### PR TITLE
storagecluster: Set topologyKey for podAntiAffinity

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -67,6 +67,7 @@ var (
 								},
 							},
 						},
+						TopologyKey: "kubernetes.io/hostname",
 					},
 				},
 			},


### PR DESCRIPTION
This PR sets the podAntiAffinity topologyKey to 'kubernetes.io/hostname'
in the placement config of StorageClassDeviceSet.