### PR TITLE
updated ensureCephObjectStore func in StorageClusterInitialization

### DIFF
--- a/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
+++ b/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
@@ -381,8 +381,8 @@ func (r *ReconcileStorageClusterInitialization) ensureCephObjectStores(initialDa
 		switch {
 		case err == nil:
 			reqLogger.Info(fmt.Sprintf("Restoring original cephObjectStore %s", cephObjectStore.Name))
-			cephObjectStore.DeepCopyInto(&existing)
-			err = r.client.Update(context.TODO(), &existing)
+			cephObjectStore.ObjectMeta = existing.ObjectMeta
+			err = r.client.Update(context.TODO(), &cephObjectStore)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- updated the func to preserve metadata during updates. using new
objectstore object to do the update rather than overriding the
existing one. This prevents the updates from failing.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>