### PR TITLE
updated ensureCephObjectStoreUser func in StorageClusterInitialization

### DIFF
--- a/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
+++ b/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
@@ -531,8 +531,8 @@ func (r *ReconcileStorageClusterInitialization) ensureCephObjectStoreUsers(initi
 		switch {
 		case err == nil:
 			reqLogger.Info(fmt.Sprintf("Restoring original cephObjectStoreUser %s", cephObjectStoreUser.Name))
-			cephObjectStoreUser.DeepCopyInto(&existing)
-			err = r.client.Update(context.TODO(), &existing)
+			cephObjectStoreUser.ObjectMeta = existing.ObjectMeta
+			err = r.client.Update(context.TODO(), &cephObjectStoreUser)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
- updated the func to preserve metadata during updates. using new
objectstoreuser object to do the update rather than overriding the
existing one. This prevents the updates from failing.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>