### PR TITLE
Storage cluster initialization fixes

### DIFF
--- a/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
+++ b/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
@@ -581,8 +581,8 @@ func (r *ReconcileStorageClusterInitialization) ensureCephFilesystems(initialDat
 		switch {
 		case err == nil:
 			reqLogger.Info(fmt.Sprintf("Restoring original cephFilesystem %s", cephFilesystem.Name))
-			cephFilesystem.DeepCopyInto(&existing)
-			err = r.client.Update(context.TODO(), &existing)
+			cephFilesystem.ObjectMeta = existing.ObjectMeta
+			err = r.client.Update(context.TODO(), &cephFilesystem)
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
+++ b/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
@@ -479,8 +479,8 @@ func (r *ReconcileStorageClusterInitialization) ensureCephBlockPools(initialData
 		switch {
 		case err == nil:
 			reqLogger.Info(fmt.Sprintf("Restoring original cephBlockPool %s", cephBlockPool.Name))
-			cephBlockPool.DeepCopyInto(&existing)
-			err = r.client.Update(context.TODO(), &existing)
+			cephBlockPool.ObjectMeta = existing.ObjectMeta
+			err = r.client.Update(context.TODO(), &cephBlockPool)
 			if err != nil {
 				return err
 			}

--- a/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
+++ b/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
@@ -306,8 +306,8 @@ func (r *ReconcileStorageClusterInitialization) ensureStorageClasses(initialData
 		switch {
 		case err == nil:
 			reqLogger.Info(fmt.Sprintf("Restoring original StorageClass %s", sc.Name))
-			sc.DeepCopyInto(&existing)
-			err = r.client.Update(context.TODO(), &existing)
+			sc.ObjectMeta = existing.ObjectMeta
+			err = r.client.Update(context.TODO(), &sc)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
StorageClusterInitialization had a bunch of Update related bugs. It was trying to update objects with empty metadata which caused it to fail. This fixes all the update issues by assigning proper values.