### PR TITLE
refactor(must-gather): remove info collections for cephnfs

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -14,7 +14,6 @@ ceph_resources=()
 ceph_resources+=(cephblockpools)
 ceph_resources+=(cephclusters)
 ceph_resources+=(cephfilesystems)
-ceph_resources+=(cephnfses)
 ceph_resources+=(cephobjectstores)
 ceph_resources+=(cephobjectstoreusers)
 


### PR DESCRIPTION
This commit removes info collection for cephnfs CR in must-gather as cephnfs will not be a part of OCS.

Signed-off-by: Ashish Ranjan <aranjan@redhat.com>