### PR TITLE
Add make targets for common prow tests

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,4 +2,4 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 USER nobody
 
-ADD build/_output/bin/ocs-operator /usr/local/bin/ocs-operator
+ADD _output/bin/ocs-operator /usr/local/bin/ocs-operator

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+RETVAL=0
+GENERATED_FILES="zz_generated.*.go"
+for file in $(find . -path ./vendor -prune -o -type f -name '*.go' -print | grep -E -v "$GENERATED_FILES"); do
+	golint -set_exit_status "$file"
+	if [[ $? -eq 1 ]]; then
+		RETVAL=1
+	fi
+done
+exit $RETVAL
+

--- a/hack/verify-generated.sh
+++ b/hack/verify-generated.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+if [[ -n "$(git status --porcelain pkg/apis deploy/crds)" ]]; then
+	echo "uncommitted generated files. run 'make update-generated' and commit results."
+	exit 1
+fi

--- a/hack/verify-latest-csv.sh
+++ b/hack/verify-latest-csv.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+CSV_CHECKSUM_ONLY=1 hack/generate-latest-csv.sh
+if [[ -n "$(git status --porcelain hack/latest-csv-checksum.md5)" ]]; then
+	echo "uncommitted CSV changes. run 'make gen-latest-csv' and commit results."
+	exit 1
+fi
+echo "Success: no out of source tree changes found"


### PR DESCRIPTION
This adds make targets for all the tests Openshift CI prow executes.

I removed the usage of the operator-sdk from the ocs-operater build process (it is still however used for the code generation make target). This allows us to have separate make targets for building the binary and building the container image. There's no impact to the dev flow. 'make ocs-operator' still results in the same container image being built along with the binary. 