### PR TITLE
Changes Required Pod AntiAffinity to Preferred for MDS

### DIFF
--- a/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
+++ b/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
@@ -684,18 +684,21 @@ func (r *ReconcileStorageClusterInitialization) newCephFilesystemInstances(initD
 							},
 						},
 						PodAntiAffinity: &corev1.PodAntiAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-								corev1.PodAffinityTerm{
-									LabelSelector: &metav1.LabelSelector{
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											metav1.LabelSelectorRequirement{
-												Key:      "app",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"rook-ceph-mds"},
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								corev1.WeightedPodAffinityTerm{
+									Weight: 100,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												metav1.LabelSelectorRequirement{
+													Key:      "app",
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{"rook-ceph-mds"},
+												},
 											},
 										},
+										TopologyKey: "kubernetes.io/hostname",
 									},
-									TopologyKey: "kubernetes.io/hostname",
 								},
 							},
 						},


### PR DESCRIPTION
- RequiredDuringScheduling AntiAffinity does not allow MDS
pods to be deployed on same node when count of MDS pods is
more than count of available nodes. Changing it to Preferred
with weight of 100 will make scheduler try its best to distribute
these pods.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>