### PR TITLE
Changes RequiredDuringScheduling AntiAffinity to Preferred

### DIFF
--- a/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
+++ b/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
@@ -472,18 +472,21 @@ func (r *ReconcileStorageClusterInitialization) newCephObjectStoreInstances(init
 							},
 						},
 						PodAntiAffinity: &corev1.PodAntiAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-								corev1.PodAffinityTerm{
-									LabelSelector: &metav1.LabelSelector{
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											metav1.LabelSelectorRequirement{
-												Key:      "app",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"rook-ceph-rgw"},
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+								corev1.WeightedPodAffinityTerm{
+									Weight: 100,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										LabelSelector: &metav1.LabelSelector{
+											MatchExpressions: []metav1.LabelSelectorRequirement{
+												metav1.LabelSelectorRequirement{
+													Key:      "app",
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{"rook-ceph-rgw"},
+												},
 											},
 										},
+										TopologyKey: "kubernetes.io/hostname",
 									},
-									TopologyKey: "kubernetes.io/hostname",
 								},
 							},
 						},


### PR DESCRIPTION
- RequiredDuringScheduling AntiAffinity of rgw pods does not allow
more rgw pods to be deployed than the number of nodes. Changing
it to PreferredDuringScheduling will enable us to do so. Weight of
100 ensure that scheduler tries its best to spread the pods across
topologyKey.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>