### PR TITLE
'make red-hat-storage-ocs-ci' for running downstream ocs-ci tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ all: ocs-operator ocs-must-gather ocs-registry
 	govet \
 	update-generated \
 	ocs-operator-ci \
+	red-hat-storage-ocs-ci \
 	unit-test
 
 deps-update:
@@ -107,7 +108,7 @@ build-functest:
 	hack/build-functest.sh
 
 functest: build-functest
-	@echo "Running functional test suite"
+	@echo "Running ocs developer functional test suite"
 	hack/functest.sh
 gofmt:
 	@echo "Running gofmt"
@@ -140,3 +141,9 @@ verify-generated: update-generated
 
 ocs-operator-ci: gofmt golint govet unit-test build verify-latest-csv verify-generated
 
+red-hat-storage-ocs-ci: build-functest
+	@echo "Running red-hat-storage ocs-ci test suite"
+	# Using ginko functional tests just to setup StorageClass environment.
+	hack/functest.sh --ginkgo.focus "no-op"
+	# Running red-hat-storage/ocs-ci tests.
+	hack/red-hat-storage-ocs-ci-tests.sh

--- a/README.md
+++ b/README.md
@@ -339,3 +339,32 @@ bring you to a directory tree. Follow the `artifacts/` directory to the
 `ocs-operator-e2e-aws/` directory. There you can find logs and information
 pertaining to ever object in the cluster.
 
+## Downstream ocs-ci tests
+
+In addition to the `functest/*` in the ocs-operator source tree we also have
+the ability to run the tests developed in the [red-hat-storage/ocs-ci](https://github.com/red-hat-storage/ocs-ci) repo.
+
+NOTE: Running this test suite requires python3.
+
+To execute the ocs-ci test suite against an already installed ocs-operator, run
+`make red-hat-storage-ocs-ci`. This will download the ocs-ci repo and execute
+a subset of tests against the ocs-operator deployment.
+
+In order to update either the ocs-ci version or subset of tests executed from
+ocs-ci, you'll need to modify the environment variables in hack/common.sh with
+the `REDHAT_OCS_CI` prefix.
+
+## Ginkgo tests vs ocs-ci tests
+
+We currently have two functional test suites. The ginkgo `functests` test suite
+lives in this repo, and there is also an external one called `ocs-ci`.
+
+The ginkgo `functests` test suite in this repo is for developers. As new
+functionality is introduced into the ocs-operator, this repo allows developers
+to prove their functionality works by including tests within their PR. This is
+the test suite where we exercise ocs-operator deployment/update/uninstall as
+well as some basic workload functionality like creating PVCs.
+
+The external `ocs-ci` test suite is maintained by Red Hat QE. We execute this
+test suite against our PRs as another layer of verification in order to catch
+rook/ceph regressions as early as possible.

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -4,11 +4,18 @@ IMAGE_RUN_CMD="${IMAGE_RUN_CMD:-docker run --rm -it}"
 
 OUTDIR="build/_output"
 OUTDIR_BIN="build/_output/bin"
+OUTDIR_OCS_CI="build/_output/ocs-ci-testsuite"
 OUTDIR_TEMPLATES="$OUTDIR/csv-templates"
 OUTDIR_CRDS="$OUTDIR_TEMPLATES/crds"
 OUTDIR_BUNDLEMANIFESTS="$OUTDIR_TEMPLATES/bundlemanifests"
 OUTDIR_TOOLS="$OUTDIR/tools"
 OUTDIR_CLUSTER_DEPLOY_MANIFESTS="$OUTDIR/cluster-deploy-manifests"
+
+REDHAT_OCS_CI_REPO="https://github.com/red-hat-storage/ocs-ci"
+REDHAT_OCS_CI_HASH="e84e06c42cbf3121137fbd94476e2c88aa62d520"
+REDHAT_OCS_CI_TEST_EXPRESSION="TestOSCBasics or TestPvCreation or TestRawBlockPV or TestReclaimPolicy or TestCreateSCSameName or TestBasicPVCOperations or TestVerifyAllFieldsInScYamlWithOcDescribe"
+REDHAT_OCS_CI_PYTHON_BINARY="python3.7"
+
 NOOBAA_CSV="$OUTDIR_TEMPLATES/noobaa-csv.yaml"
 ROOK_CSV="$OUTDIR_TEMPLATES/rook-csv.yaml.in"
 OCS_CSV="$OUTDIR_TEMPLATES/ocs-operator.csv.yaml.in"

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -2,8 +2,7 @@
 
 source hack/common.sh
 
-echo "Running Functional Test Suite"
-$OUTDIR_BIN/functests
+$OUTDIR_BIN/functests $@
 if [ $? -ne 0 ]; then
 	echo "dumping debug information"
 	echo "--- PODS ----"

--- a/hack/red-hat-storage-ocs-ci-tests.sh
+++ b/hack/red-hat-storage-ocs-ci-tests.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# https://github.com/red-hat-storage/ocs-ci/blob/master/docs/getting_started.md
+set -e
+
+source hack/common.sh 
+
+mkdir -p $OUTDIR_OCS_CI
+cd $OUTDIR_OCS_CI
+
+DOWNLOAD_SRC=""
+if ! [ -d "ocs-ci" ]; then
+	DOWNLOAD_SRC="true"
+elif ! [ "$(cat ocs-ci/git-hash)" = "$REDHAT_OCS_CI_HASH" ]; then
+	rm -rf ocs-ci
+	DOWNLOAD_SRC="true"
+fi
+
+if [ -n ${DOWNLOAD_SRC} ]; then
+	echo "Cloning code from $REDHAT_OCS_CI_REPO using hash $REDHAT_OCS_CI_HASH"
+	curl -L ${REDHAT_OCS_CI_REPO}/archive/${REDHAT_OCS_CI_HASH}/ocs-ci.tar.gz | tar xz ocs-ci-${REDHAT_OCS_CI_HASH}
+	mv ocs-ci-${REDHAT_OCS_CI_HASH} ocs-ci
+else
+	echo "Using cached ocs-ci src"
+fi
+
+cd ocs-ci
+
+# record the hash in a file so we don't redownload the source if nothing changed.
+echo "$REDHAT_OCS_CI_HASH" > git-hash
+
+# we are faking an openshift-install cluster directory here
+# for the ocs-ci test suite. All we need is to provide
+# the auth credentials in the predictable directory structure
+mkdir -p fakecluster/auth
+cp $KUBECONFIG fakecluster/auth/kubeconfig
+
+# Create a Python virtual environment for the tests to execute with.
+echo "Using $REDHAT_OCS_CI_PYTHON_BINARY"
+$REDHAT_OCS_CI_PYTHON_BINARY -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# This is the test config we pass into ocs-ci's run-ci tool
+cat << EOF > my-config.yaml
+---
+RUN:
+  log_dir: "/tmp"
+  kubeconfig_location: 'auth/kubeconfig' # relative from cluster_dir
+  bin_dir: './bin'
+
+DEPLOYMENT:
+  force_download_installer: False
+  force_download_client: False
+
+ENV_DATA:
+  cluster_name: null
+  storage_cluster_name: 'test-storagecluster'
+  storage_device_sets_name: "example-deviceset"
+  cluster_namespace: 'openshift-storage'
+  skip_ocp_deployment: true
+  skip_ocs_deployment: true
+EOF
+
+echo "Running ocs-ci testsuite using -k $REDHAT_OCS_CI_TEST_EXPRESSION"
+run-ci -k "$REDHAT_OCS_CI_TEST_EXPRESSION" --cluster-path "$(pwd)/fakecluster/" --ocsci-conf my-config.yaml

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,8 +15,8 @@ github.com/beorn7/perks/quantile
 # github.com/coreos/go-semver v0.2.0
 github.com/coreos/go-semver/semver
 # github.com/coreos/prometheus-operator v0.29.0
-github.com/coreos/prometheus-operator/pkg/apis/monitoring
 github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1
+github.com/coreos/prometheus-operator/pkg/apis/monitoring
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/emicklei/go-restful v2.9.5+incompatible
@@ -61,8 +61,8 @@ github.com/gogo/protobuf/sortkeys
 github.com/golang/groupcache/lru
 # github.com/golang/protobuf v1.3.1
 github.com/golang/protobuf/proto
-github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/any
+github.com/golang/protobuf/ptypes
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/btree v1.0.0
@@ -92,13 +92,13 @@ github.com/imdario/mergo
 # github.com/json-iterator/go v1.1.6
 github.com/json-iterator/go
 # github.com/kube-object-storage/lib-bucket-provisioner v0.0.0-20190712220128-5b3f4e3b90ed
-github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io
 github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io/v1alpha1
 github.com/kube-object-storage/lib-bucket-provisioner/pkg/provisioner/api
+github.com/kube-object-storage/lib-bucket-provisioner/pkg/apis/objectbucket.io
 # github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63
-github.com/mailru/easyjson/buffer
 github.com/mailru/easyjson/jlexer
 github.com/mailru/easyjson/jwriter
+github.com/mailru/easyjson/buffer
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/mitchellh/mapstructure v1.1.2
@@ -114,46 +114,46 @@ github.com/noobaa/noobaa-operator/pkg/apis/noobaa/v1alpha1
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
-github.com/onsi/ginkgo/internal/containernode
 github.com/onsi/ginkgo/internal/failer
-github.com/onsi/ginkgo/internal/leafnodes
 github.com/onsi/ginkgo/internal/remote
-github.com/onsi/ginkgo/internal/spec
-github.com/onsi/ginkgo/internal/spec_iterator
-github.com/onsi/ginkgo/internal/specrunner
 github.com/onsi/ginkgo/internal/suite
 github.com/onsi/ginkgo/internal/testingtproxy
 github.com/onsi/ginkgo/internal/writer
 github.com/onsi/ginkgo/reporters
 github.com/onsi/ginkgo/reporters/stenographer
 github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
-github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
+github.com/onsi/ginkgo/internal/spec_iterator
+github.com/onsi/ginkgo/internal/containernode
+github.com/onsi/ginkgo/internal/leafnodes
+github.com/onsi/ginkgo/internal/spec
+github.com/onsi/ginkgo/internal/specrunner
+github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 # github.com/onsi/gomega v1.4.3
 github.com/onsi/gomega
-github.com/onsi/gomega/format
 github.com/onsi/gomega/internal/assertion
 github.com/onsi/gomega/internal/asyncassertion
-github.com/onsi/gomega/internal/oraclematcher
 github.com/onsi/gomega/internal/testingtsupport
 github.com/onsi/gomega/matchers
+github.com/onsi/gomega/types
+github.com/onsi/gomega/internal/oraclematcher
+github.com/onsi/gomega/format
 github.com/onsi/gomega/matchers/support/goraph/bipartitegraph
 github.com/onsi/gomega/matchers/support/goraph/edge
 github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
-github.com/onsi/gomega/types
 # github.com/openshift/api v3.9.1-0.20190904155310-a25bb2adc83e+incompatible
 github.com/openshift/api/security/v1
 # github.com/openshift/client-go v0.0.0-20190813201236-5a5508328169
-github.com/openshift/client-go/security/clientset/versioned/scheme
 github.com/openshift/client-go/security/clientset/versioned/typed/security/v1
+github.com/openshift/client-go/security/clientset/versioned/scheme
 github.com/openshift/client-go/security/clientset/versioned/typed/security/v1/fake
 # github.com/openshift/custom-resource-status v0.0.0-20190812200727-7961da9a2eb7
 github.com/openshift/custom-resource-status/conditions/v1
 github.com/openshift/custom-resource-status/objectreferences/v1
 # github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190128024246-5eb7ae5bdb7a
-github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators
 github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1
+github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators
 # github.com/operator-framework/operator-sdk v0.10.0
 github.com/operator-framework/operator-sdk/pkg/k8sutil
 github.com/operator-framework/operator-sdk/pkg/leader
@@ -166,24 +166,24 @@ github.com/peterbourgon/diskv
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v0.9.4
+github.com/prometheus/client_golang/prometheus/promhttp
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
-github.com/prometheus/client_golang/prometheus/promhttp
 # github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
 github.com/prometheus/client_model/go
 # github.com/prometheus/common v0.4.1
 github.com/prometheus/common/expfmt
-github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 github.com/prometheus/common/model
+github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg
 # github.com/prometheus/procfs v0.0.2
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 # github.com/rook/rook v1.1.0-beta.1
-github.com/rook/rook/pkg/apis/ceph.rook.io
 github.com/rook/rook/pkg/apis/ceph.rook.io/v1
-github.com/rook/rook/pkg/apis/rook.io
 github.com/rook/rook/pkg/apis/rook.io/v1alpha2
+github.com/rook/rook/pkg/apis/ceph.rook.io
 github.com/rook/rook/pkg/daemon/ceph/model
+github.com/rook/rook/pkg/apis/rook.io
 # github.com/spf13/pflag v1.0.3
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.3.0
@@ -195,22 +195,22 @@ go.uber.org/multierr
 # go.uber.org/zap v1.10.0
 go.uber.org/zap
 go.uber.org/zap/buffer
+go.uber.org/zap/zapcore
 go.uber.org/zap/internal/bufferpool
 go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
-go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7
-golang.org/x/net/context
-golang.org/x/net/context/ctxhttp
-golang.org/x/net/html
-golang.org/x/net/html/atom
+golang.org/x/net/http2
 golang.org/x/net/html/charset
 golang.org/x/net/http/httpguts
-golang.org/x/net/http2
 golang.org/x/net/http2/hpack
 golang.org/x/net/idna
+golang.org/x/net/context/ctxhttp
+golang.org/x/net/context
+golang.org/x/net/html
+golang.org/x/net/html/atom
 # golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 golang.org/x/oauth2
 golang.org/x/oauth2/google
@@ -224,37 +224,37 @@ golang.org/x/sys/windows
 golang.org/x/text/encoding
 golang.org/x/text/encoding/charmap
 golang.org/x/text/encoding/htmlindex
-golang.org/x/text/encoding/internal
+golang.org/x/text/transform
+golang.org/x/text/secure/bidirule
+golang.org/x/text/unicode/bidi
+golang.org/x/text/unicode/norm
+golang.org/x/text/width
 golang.org/x/text/encoding/internal/identifier
+golang.org/x/text/encoding/internal
 golang.org/x/text/encoding/japanese
 golang.org/x/text/encoding/korean
 golang.org/x/text/encoding/simplifiedchinese
 golang.org/x/text/encoding/traditionalchinese
 golang.org/x/text/encoding/unicode
+golang.org/x/text/language
+golang.org/x/text/internal/utf8internal
+golang.org/x/text/runes
 golang.org/x/text/internal/language
 golang.org/x/text/internal/language/compact
 golang.org/x/text/internal/tag
-golang.org/x/text/internal/utf8internal
-golang.org/x/text/language
-golang.org/x/text/runes
-golang.org/x/text/secure/bidirule
-golang.org/x/text/transform
-golang.org/x/text/unicode/bidi
-golang.org/x/text/unicode/norm
-golang.org/x/text/width
 # golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 golang.org/x/time/rate
 # google.golang.org/appengine v1.6.1
 google.golang.org/appengine
+google.golang.org/appengine/urlfetch
 google.golang.org/appengine/internal
 google.golang.org/appengine/internal/app_identity
+google.golang.org/appengine/internal/modules
+google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/internal/base
 google.golang.org/appengine/internal/datastore
 google.golang.org/appengine/internal/log
-google.golang.org/appengine/internal/modules
 google.golang.org/appengine/internal/remote_api
-google.golang.org/appengine/internal/urlfetch
-google.golang.org/appengine/urlfetch
 # gopkg.in/fsnotify.v1 v1.4.7
 gopkg.in/fsnotify.v1
 # gopkg.in/inf.v0 v0.9.1
@@ -264,10 +264,12 @@ gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.2.2
 gopkg.in/yaml.v2
 # k8s.io/api v0.0.0-20190820101039-d651a1528133 => k8s.io/api v0.0.0-20190222213804-5cb15d344471
-k8s.io/api/admission/v1beta1
+k8s.io/api/storage/v1
+k8s.io/api/core/v1
+k8s.io/api/apps/v1
+k8s.io/api/rbac/v1
 k8s.io/api/admissionregistration/v1alpha1
 k8s.io/api/admissionregistration/v1beta1
-k8s.io/api/apps/v1
 k8s.io/api/apps/v1beta1
 k8s.io/api/apps/v1beta2
 k8s.io/api/auditregistration/v1alpha1
@@ -283,73 +285,78 @@ k8s.io/api/batch/v1beta1
 k8s.io/api/batch/v2alpha1
 k8s.io/api/certificates/v1beta1
 k8s.io/api/coordination/v1beta1
-k8s.io/api/core/v1
 k8s.io/api/events/v1beta1
 k8s.io/api/extensions/v1beta1
 k8s.io/api/networking/v1
 k8s.io/api/policy/v1beta1
-k8s.io/api/rbac/v1
 k8s.io/api/rbac/v1alpha1
 k8s.io/api/rbac/v1beta1
 k8s.io/api/scheduling/v1alpha1
 k8s.io/api/scheduling/v1beta1
 k8s.io/api/settings/v1alpha1
-k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
+k8s.io/api/admission/v1beta1
 # k8s.io/apiextensions-apiserver v0.0.0-20190820104113-47893d27d7f7 => k8s.io/apiextensions-apiserver v0.0.0-20190228180357-d002e88f6236
-k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1
+k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 # k8s.io/apimachinery v0.0.0-20190820100751-ac02f8882ef6 => k8s.io/apimachinery v0.0.0-20190221213512-86fb29eff628
 k8s.io/apimachinery/pkg/api/errors
-k8s.io/apimachinery/pkg/api/meta
-k8s.io/apimachinery/pkg/api/resource
-k8s.io/apimachinery/pkg/apis/meta/internalversion
 k8s.io/apimachinery/pkg/apis/meta/v1
-k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
-k8s.io/apimachinery/pkg/apis/meta/v1beta1
-k8s.io/apimachinery/pkg/conversion
-k8s.io/apimachinery/pkg/conversion/queryparams
-k8s.io/apimachinery/pkg/fields
-k8s.io/apimachinery/pkg/labels
+k8s.io/apimachinery/pkg/api/resource
 k8s.io/apimachinery/pkg/runtime
 k8s.io/apimachinery/pkg/runtime/schema
 k8s.io/apimachinery/pkg/runtime/serializer
+k8s.io/apimachinery/pkg/types
+k8s.io/apimachinery/pkg/util/rand
+k8s.io/apimachinery/pkg/util/strategicpatch
+k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
+k8s.io/apimachinery/pkg/util/intstr
+k8s.io/apimachinery/pkg/util/wait
+k8s.io/apimachinery/pkg/util/validation/field
+k8s.io/apimachinery/pkg/conversion
+k8s.io/apimachinery/pkg/fields
+k8s.io/apimachinery/pkg/labels
+k8s.io/apimachinery/pkg/selection
+k8s.io/apimachinery/pkg/util/runtime
+k8s.io/apimachinery/pkg/watch
+k8s.io/apimachinery/pkg/util/net
+k8s.io/apimachinery/pkg/util/yaml
+k8s.io/apimachinery/pkg/api/meta
+k8s.io/apimachinery/pkg/conversion/queryparams
+k8s.io/apimachinery/pkg/util/errors
+k8s.io/apimachinery/pkg/util/json
+k8s.io/apimachinery/pkg/util/naming
+k8s.io/apimachinery/pkg/util/sets
 k8s.io/apimachinery/pkg/runtime/serializer/json
 k8s.io/apimachinery/pkg/runtime/serializer/protobuf
 k8s.io/apimachinery/pkg/runtime/serializer/recognizer
-k8s.io/apimachinery/pkg/runtime/serializer/streaming
 k8s.io/apimachinery/pkg/runtime/serializer/versioning
-k8s.io/apimachinery/pkg/selection
-k8s.io/apimachinery/pkg/types
-k8s.io/apimachinery/pkg/util/cache
-k8s.io/apimachinery/pkg/util/clock
-k8s.io/apimachinery/pkg/util/diff
-k8s.io/apimachinery/pkg/util/errors
-k8s.io/apimachinery/pkg/util/framer
-k8s.io/apimachinery/pkg/util/intstr
-k8s.io/apimachinery/pkg/util/json
 k8s.io/apimachinery/pkg/util/mergepatch
-k8s.io/apimachinery/pkg/util/naming
-k8s.io/apimachinery/pkg/util/net
-k8s.io/apimachinery/pkg/util/rand
-k8s.io/apimachinery/pkg/util/runtime
-k8s.io/apimachinery/pkg/util/sets
-k8s.io/apimachinery/pkg/util/strategicpatch
-k8s.io/apimachinery/pkg/util/uuid
-k8s.io/apimachinery/pkg/util/validation
-k8s.io/apimachinery/pkg/util/validation/field
-k8s.io/apimachinery/pkg/util/wait
-k8s.io/apimachinery/pkg/util/yaml
-k8s.io/apimachinery/pkg/version
-k8s.io/apimachinery/pkg/watch
 k8s.io/apimachinery/third_party/forked/golang/json
+k8s.io/apimachinery/pkg/runtime/serializer/streaming
+k8s.io/apimachinery/pkg/util/validation
+k8s.io/apimachinery/pkg/version
 k8s.io/apimachinery/third_party/forked/golang/reflect
+k8s.io/apimachinery/pkg/apis/meta/v1beta1
+k8s.io/apimachinery/pkg/util/clock
+k8s.io/apimachinery/pkg/util/uuid
+k8s.io/apimachinery/pkg/util/framer
+k8s.io/apimachinery/pkg/util/cache
+k8s.io/apimachinery/pkg/util/diff
+k8s.io/apimachinery/pkg/apis/meta/internalversion
 # k8s.io/client-go v11.0.0+incompatible => k8s.io/client-go v0.0.0-20190228174230-b40b2a5939e4
-k8s.io/client-go/discovery
-k8s.io/client-go/dynamic
+k8s.io/client-go/plugin/pkg/client/auth/gcp
 k8s.io/client-go/kubernetes
 k8s.io/client-go/kubernetes/scheme
+k8s.io/client-go/rest
+k8s.io/client-go/tools/clientcmd
+k8s.io/client-go/tools/reference
+k8s.io/client-go/discovery
+k8s.io/client-go/util/jsonpath
+k8s.io/client-go/tools/leaderelection
+k8s.io/client-go/tools/leaderelection/resourcelock
+k8s.io/client-go/tools/record
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1alpha1
 k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1
 k8s.io/client-go/kubernetes/typed/apps/v1
@@ -382,75 +389,68 @@ k8s.io/client-go/kubernetes/typed/settings/v1alpha1
 k8s.io/client-go/kubernetes/typed/storage/v1
 k8s.io/client-go/kubernetes/typed/storage/v1alpha1
 k8s.io/client-go/kubernetes/typed/storage/v1beta1
+k8s.io/client-go/util/flowcontrol
+k8s.io/client-go/pkg/version
+k8s.io/client-go/plugin/pkg/client/auth/exec
+k8s.io/client-go/rest/watch
+k8s.io/client-go/tools/clientcmd/api
+k8s.io/client-go/tools/metrics
+k8s.io/client-go/transport
+k8s.io/client-go/util/cert
+k8s.io/client-go/tools/auth
+k8s.io/client-go/tools/clientcmd/api/latest
+k8s.io/client-go/util/homedir
+k8s.io/client-go/dynamic
+k8s.io/client-go/util/workqueue
+k8s.io/client-go/tools/cache
+k8s.io/client-go/testing
+k8s.io/client-go/third_party/forked/golang/template
+k8s.io/client-go/restmapper
+k8s.io/client-go/util/integer
 k8s.io/client-go/pkg/apis/clientauthentication
 k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1
 k8s.io/client-go/pkg/apis/clientauthentication/v1beta1
-k8s.io/client-go/pkg/version
-k8s.io/client-go/plugin/pkg/client/auth/exec
-k8s.io/client-go/plugin/pkg/client/auth/gcp
-k8s.io/client-go/rest
-k8s.io/client-go/rest/watch
-k8s.io/client-go/restmapper
-k8s.io/client-go/testing
-k8s.io/client-go/third_party/forked/golang/template
-k8s.io/client-go/tools/auth
-k8s.io/client-go/tools/cache
-k8s.io/client-go/tools/clientcmd
-k8s.io/client-go/tools/clientcmd/api
-k8s.io/client-go/tools/clientcmd/api/latest
-k8s.io/client-go/tools/clientcmd/api/v1
-k8s.io/client-go/tools/leaderelection
-k8s.io/client-go/tools/leaderelection/resourcelock
-k8s.io/client-go/tools/metrics
-k8s.io/client-go/tools/pager
-k8s.io/client-go/tools/record
-k8s.io/client-go/tools/reference
-k8s.io/client-go/transport
-k8s.io/client-go/util/buffer
-k8s.io/client-go/util/cert
 k8s.io/client-go/util/connrotation
-k8s.io/client-go/util/flowcontrol
-k8s.io/client-go/util/homedir
-k8s.io/client-go/util/integer
-k8s.io/client-go/util/jsonpath
+k8s.io/client-go/tools/clientcmd/api/v1
+k8s.io/client-go/tools/pager
+k8s.io/client-go/util/buffer
 k8s.io/client-go/util/retry
-k8s.io/client-go/util/workqueue
 # k8s.io/klog v0.3.1
 k8s.io/klog
 # k8s.io/kube-openapi v0.0.0-20190709113604-33be087ad058
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 # sigs.k8s.io/controller-runtime v0.1.12
-sigs.k8s.io/controller-runtime/pkg/cache
-sigs.k8s.io/controller-runtime/pkg/cache/internal
-sigs.k8s.io/controller-runtime/pkg/client
-sigs.k8s.io/controller-runtime/pkg/client/apiutil
 sigs.k8s.io/controller-runtime/pkg/client/config
-sigs.k8s.io/controller-runtime/pkg/client/fake
+sigs.k8s.io/controller-runtime/pkg/manager
+sigs.k8s.io/controller-runtime/pkg/runtime/log
+sigs.k8s.io/controller-runtime/pkg/runtime/signals
+sigs.k8s.io/controller-runtime/pkg/runtime/scheme
+sigs.k8s.io/controller-runtime/pkg/client
 sigs.k8s.io/controller-runtime/pkg/controller
-sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
-sigs.k8s.io/controller-runtime/pkg/event
 sigs.k8s.io/controller-runtime/pkg/handler
-sigs.k8s.io/controller-runtime/pkg/internal/controller
-sigs.k8s.io/controller-runtime/pkg/internal/controller/metrics
-sigs.k8s.io/controller-runtime/pkg/internal/objectutil
+sigs.k8s.io/controller-runtime/pkg/reconcile
+sigs.k8s.io/controller-runtime/pkg/source
+sigs.k8s.io/controller-runtime/pkg/controller/controllerutil
+sigs.k8s.io/controller-runtime/pkg/cache
+sigs.k8s.io/controller-runtime/pkg/client/apiutil
 sigs.k8s.io/controller-runtime/pkg/internal/recorder
 sigs.k8s.io/controller-runtime/pkg/leaderelection
-sigs.k8s.io/controller-runtime/pkg/manager
 sigs.k8s.io/controller-runtime/pkg/metrics
-sigs.k8s.io/controller-runtime/pkg/patch
-sigs.k8s.io/controller-runtime/pkg/predicate
-sigs.k8s.io/controller-runtime/pkg/reconcile
 sigs.k8s.io/controller-runtime/pkg/recorder
 sigs.k8s.io/controller-runtime/pkg/runtime/inject
-sigs.k8s.io/controller-runtime/pkg/runtime/log
-sigs.k8s.io/controller-runtime/pkg/runtime/scheme
-sigs.k8s.io/controller-runtime/pkg/runtime/signals
-sigs.k8s.io/controller-runtime/pkg/source
-sigs.k8s.io/controller-runtime/pkg/source/internal
 sigs.k8s.io/controller-runtime/pkg/webhook/admission
 sigs.k8s.io/controller-runtime/pkg/webhook/admission/types
+sigs.k8s.io/controller-runtime/pkg/internal/controller
+sigs.k8s.io/controller-runtime/pkg/predicate
+sigs.k8s.io/controller-runtime/pkg/event
+sigs.k8s.io/controller-runtime/pkg/source/internal
+sigs.k8s.io/controller-runtime/pkg/client/fake
+sigs.k8s.io/controller-runtime/pkg/cache/internal
+sigs.k8s.io/controller-runtime/pkg/patch
 sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 sigs.k8s.io/controller-runtime/pkg/webhook/types
+sigs.k8s.io/controller-runtime/pkg/internal/controller/metrics
+sigs.k8s.io/controller-runtime/pkg/internal/objectutil
 # sigs.k8s.io/yaml v1.1.0
 sigs.k8s.io/yaml


### PR DESCRIPTION
This introduces the ability to run a subset of the [ocs-ci](https://github.com/red-hat-storage/ocs-ci) test suite against an ocs-operator cluster.

I also include some README.md text around this test suite. Once this PR is merged with the `make red-hat-storage-ocs-ci` make target, I can add a prow job to execute the ocs-ci tests in parallel to the developer ginkgo `functests/*` test suite. 