### PR TITLE
storageclusterinit: Do not set "pool" param for CephFS SC

### DIFF
--- a/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
+++ b/pkg/controller/storageclusterinitialization/storageclusterinitialization_controller.go
@@ -389,7 +389,6 @@ func (r *ReconcileStorageClusterInitialization) newStorageClasses(initData *ocsv
 			Parameters: map[string]string{
 				"clusterID": initData.Namespace,
 				"fsName":    fmt.Sprintf("%s-cephfilesystem", initData.Name),
-				"pool":      generateNameForCephBlockPool(initData),
 				"csi.storage.k8s.io/provisioner-secret-name":      "rook-ceph-csi",
 				"csi.storage.k8s.io/provisioner-secret-namespace": initData.Namespace,
 				"csi.storage.k8s.io/node-stage-secret-name":       "rook-ceph-csi",


### PR DESCRIPTION
The "pool" parameter of the CephFS storage class, was being set to the
block pool used by the RBD storage class. Removing the "pool" param,
makes the CephFS storage class use the default data pools created for
the CephFilesystem.

Fixes #128.