### PR TITLE
Openshift ci build tools for red-hat-storage/ocs-ci execution

### DIFF
--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -4,7 +4,7 @@ RETVAL=0
 GENERATED_FILES="zz_generated.*.go"
 for file in $(find . -path ./vendor -prune -o -type f -name '*.go' -print | grep -E -v "$GENERATED_FILES"); do
 	golint -set_exit_status "$file"
-	if [[ $? -eq 1 ]]; then
+	if [[ $? -ne 0 ]]; then
 		RETVAL=1
 	fi
 done

--- a/hack/red-hat-storage-ocs-ci-tests.sh
+++ b/hack/red-hat-storage-ocs-ci-tests.sh
@@ -15,7 +15,7 @@ elif ! [ "$(cat ocs-ci/git-hash)" = "$REDHAT_OCS_CI_HASH" ]; then
 	DOWNLOAD_SRC="true"
 fi
 
-if [ -n ${DOWNLOAD_SRC} ]; then
+if [ -n "${DOWNLOAD_SRC}" ]; then
 	echo "Cloning code from $REDHAT_OCS_CI_REPO using hash $REDHAT_OCS_CI_HASH"
 	curl -L ${REDHAT_OCS_CI_REPO}/archive/${REDHAT_OCS_CI_HASH}/ocs-ci.tar.gz | tar xz ocs-ci-${REDHAT_OCS_CI_HASH}
 	mv ocs-ci-${REDHAT_OCS_CI_HASH} ocs-ci

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,0 +1,29 @@
+FROM fedora:30 as build-tools
+ENV GOPATH /go
+ARG GO_PACKAGE_PATH=github.com/openshift/ocs-operator
+
+# rpms required for building and running test suites
+RUN dnf -y install \
+    golang \
+    make \
+    tar \
+    findutils \
+    python3 \
+    && dnf clean all
+
+# get required golang tools and OC client
+RUN go get github.com/onsi/ginkgo/ginkgo && \
+    go get github.com/onsi/gomega/... && \
+    go get -u golang.org/x/lint/golint && \
+    export latest_oc_client_version=$(curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/ 2>/dev/null | grep -o \"openshift-client-linux-4.*tar.gz\" | tr -d \") && \
+    curl -JL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${latest_oc_client_version} -o oc.tar.gz && \
+    tar -xzvf oc.tar.gz && \
+    mv oc /usr/bin/oc
+
+ENV PATH=$PATH:$GOPATH/bin
+
+RUN mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/
+
+WORKDIR ${GOPATH}/src/${GO_PACKAGE_PATH}
+
+ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
In order to execute the red-hat-storage/ocs-ci test suite in prow, we need a custom build root container for openshift ci that contains python.

Changes
* Introduces openshift ci tools Docker file (prow update using this will be posted once this is merged)
* Fixes ocs-ci source caching (prevents re-downloading source locally if it already exists)
* Fixes issue with `golint` appearing to pass if the golint binary isn't present. 