### PR TITLE
Fix GOPATH dir permissions for build root container

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,5 +1,7 @@
 FROM fedora:30 as build-tools
 ENV GOPATH /go
+ENV GOBIN /go/bin
+ENV GOCACHE /go/.cache
 ARG GO_PACKAGE_PATH=github.com/openshift/ocs-operator
 
 # rpms required for building and running test suites
@@ -22,7 +24,14 @@ RUN go get github.com/onsi/ginkgo/ginkgo && \
 
 ENV PATH=$PATH:$GOPATH/bin
 
-RUN mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/
+RUN export TMP_BIN=$(mktemp -d) && \
+    mv $GOBIN/* $TMP_BIN/ && \
+    rm -rf ${GOPATH} ${GOCACHE} && \
+    mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/ && \
+    mkdir -p ${GOBIN} && \
+    chmod -R 757 ${GOPATH} && \
+    mv $TMP_BIN/* ${GOBIN} && \
+    rm -rf $TMP_BIN
 
 WORKDIR ${GOPATH}/src/${GO_PACKAGE_PATH}
 


### PR DESCRIPTION
The openshift-ci build-root container wasn't working in CI because the GOPATH was only accessible to root. Openshift-ci is running this container as a non-root pod, which prevented builds from working.

I changed the permissions on the GOPATH directory tree now so that all users have access.

If you want to this build-root container yourself locally, run the following

```
docker build -f openshift-ci/Dockerfile.tools -t ocs-build-tools:latest
docker run --rm -v $(pwd):/go/src/github.com/openshift/ocs-operator -it ocs-build-tools:latest
make build
```

We can use this container as a basis for dockerized make targets in the future. 