### PR TITLE
Fixes openshift-ci tools container group GOPATH dir permissions

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -29,7 +29,7 @@ RUN export TMP_BIN=$(mktemp -d) && \
     rm -rf ${GOPATH} ${GOCACHE} && \
     mkdir -p ${GOPATH}/src/${GO_PACKAGE_PATH}/ && \
     mkdir -p ${GOBIN} && \
-    chmod -R 757 ${GOPATH} && \
+    chmod -R 775 ${GOPATH} && \
     mv $TMP_BIN/* ${GOBIN} && \
     rm -rf $TMP_BIN
 


### PR DESCRIPTION
Openshift release executes the tools container with a randomized uid
that defaults to the root group. The tools container did not have
the proper group permissions set on the GOPATH directory which
causes builds to fail.

Related to: https://github.com/openshift/release/pull/5178