### PR TITLE
Disable OSD portability.

### DIFF
--- a/pkg/controller/storagecluster/utils.go
+++ b/pkg/controller/storagecluster/utils.go
@@ -10,7 +10,17 @@ func newStorageClassDeviceSets(devicesets []ocsv1.StorageDeviceSet) []rook.Stora
 	var scds []rook.StorageClassDeviceSet
 
 	for _, ds := range devicesets {
-		scds = append(scds, ds.ToStorageClassDeviceSet())
+		var s rook.StorageClassDeviceSet
+		s = ds.ToStorageClassDeviceSet()
+		//
+		// Disable OSD portability, as it is creating problems with the
+		// default and currently only setting of failureDomain=host.
+		//
+		// TODO: make it dynamic when we take advantage of zones
+		//
+		s.Portable = false
+
+		scds = append(scds, s)
 	}
 
 	return scds


### PR DESCRIPTION
Since portable OSDs create problems in combination with
failureDomain=host (OSDs not spread across hosts, multiple replica on
one host, etc.), and failureDomain=host is currently the only way
we are setting failureDomain, this patch disables OSD portability.

**Note**

This is only a temporary measure until the implementation of
failuireDomain=zone ins complete with PR #150.
