### PR TITLE
Temporarily set StorageClassDeviceSet.portable to false

### DIFF
--- a/pkg/apis/ocs/v1/storagecluster_types.go
+++ b/pkg/apis/ocs/v1/storagecluster_types.go
@@ -108,7 +108,9 @@ func (ds *StorageDeviceSet) ToStorageClassDeviceSet() rookalpha.StorageClassDevi
 		Placement:            ds.Placement,
 		Config:               ds.Config.ToMap(),
 		VolumeClaimTemplates: []corev1.PersistentVolumeClaim{ds.DataPVCTemplate},
-		Portable:             ds.Portable,
+		// TODO: Setting this to false as a temporary workaround,
+		// remove later
+		Portable: false,
 	}
 }
 


### PR DESCRIPTION
Since portable OSDs create problems in combination with failureDomain=host,
and failureDomain=host is currently the only way we are setting failureDomain,
this patch disables OSD portability.

This is an alternative proposal to #172. PR #150 will revert this.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>