### PR TITLE
Add openshift ci build root container /etc/passwd permissions

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -13,10 +13,11 @@ OUTDIR_CLUSTER_DEPLOY_MANIFESTS="$OUTDIR/cluster-deploy-manifests"
 
 DEPLOY_YAML_PATH="deploy/deploy-with-olm.yaml"
 
-REDHAT_OCS_CI_REPO="https://github.com/red-hat-storage/ocs-ci"
-REDHAT_OCS_CI_HASH="e84e06c42cbf3121137fbd94476e2c88aa62d520"
-REDHAT_OCS_CI_TEST_EXPRESSION="TestOSCBasics or TestPvCreation or TestRawBlockPV or TestReclaimPolicy or TestCreateSCSameName or TestBasicPVCOperations or TestVerifyAllFieldsInScYamlWithOcDescribe"
-REDHAT_OCS_CI_PYTHON_BINARY="python3.7"
+REDHAT_OCS_CI_DEFAULT_TEST_EXPRESSION="TestOSCBasics or TestPvCreation or TestRawBlockPV or TestReclaimPolicy or TestCreateSCSameName or TestBasicPVCOperations or TestVerifyAllFieldsInScYamlWithOcDescribe"
+REDHAT_OCS_CI_REPO="${REDHAT_OCS_CI_REPO:-https://github.com/red-hat-storage/ocs-ci}"
+REDHAT_OCS_CI_HASH="${REDHAT_OCS_CI_HASH:-e84e06c42cbf3121137fbd94476e2c88aa62d520}"
+REDHAT_OCS_CI_TEST_EXPRESSION="${REDHAT_OCS_CI_TEST_EXPRESSION:-$REDHAT_OCS_CI_DEFAULT_TEST_EXPRESSION}"
+REDHAT_OCS_CI_PYTHON_BINARY="${REDHAT_OCS_CI_PYTHON_BINARY:-python3.7}"
 
 NOOBAA_CSV="$OUTDIR_TEMPLATES/noobaa-csv.yaml"
 ROOK_CSV="$OUTDIR_TEMPLATES/rook-csv.yaml.in"

--- a/hack/red-hat-storage-ocs-ci-tests.sh
+++ b/hack/red-hat-storage-ocs-ci-tests.sh
@@ -34,6 +34,13 @@ echo "$REDHAT_OCS_CI_HASH" > git-hash
 mkdir -p fakecluster/auth
 cp $KUBECONFIG fakecluster/auth/kubeconfig
 
+# Openshift CI runs this test within a pod with a randomized uid
+# ocs-ci expects this randomized user to exist in the /etc/passwd file
+# so we need to dynamically create an entry for the user
+if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
+	echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+fi
+
 # Create a Python virtual environment for the tests to execute with.
 echo "Using $REDHAT_OCS_CI_PYTHON_BINARY"
 $REDHAT_OCS_CI_PYTHON_BINARY -m venv .venv

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -33,6 +33,11 @@ RUN export TMP_BIN=$(mktemp -d) && \
     mv $TMP_BIN/* ${GOBIN} && \
     rm -rf $TMP_BIN
 
+# openshift ci runs with a randomized uid. We need the ability
+# to create a /etc/passwd entry for this random user in order
+# to execute the ocs-ci python testsuite successfully
+RUN chmod g+rw /etc/passwd
+
 WORKDIR ${GOPATH}/src/${GO_PACKAGE_PATH}
 
 ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
The latest attempt to run `make red-hat-storage-ocs-ci` Openshift CI in prow revealed an issue with the randomized uid Openshift CI uses when executing the e2e test. ocs-ci expects an entry in /etc/passwd to exist for the user, but since the user is random there is no entry.

To address this, this PR dynamically updates the /etc/passwd file when we detect Openshift CI is executing ocs-ci tests.  I also made the ocs-ci related ENV VARS dynamic so I can alter those variables in the prow config in order to test out different ocs-ci source versions. 

**Changes** 
* adds /etc/passwd permissions to Dockerfile.tools
* makes ocs-ci environment variables dynamic