### PR TITLE
Dump stdout of source containers when executing source-manifests.sh for CSV gen

### DIFF
--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -50,9 +50,9 @@ fi
 noobaa_dump_crds_cmd="crd yaml"
 noobaa_dump_csv_cmd="olm csv yaml"
 echo "Dumping Noobaa csv using command: $IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_csv_cmd"
-($IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_csv_cmd) > $NOOBAA_CSV
+($IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_csv_cmd) | tee $NOOBAA_CSV
 echo "Dumping Noobaa crds using command: $IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_crds_cmd"
-($IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_crds_cmd) > $OUTDIR_CRDS/noobaa-crd.yaml
+($IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_crds_cmd) | tee $OUTDIR_CRDS/noobaa-crd.yaml
 
 # ==== DUMP ROOK YAMLS ====
 rook_template_dir="/etc/ceph-csv-templates"
@@ -60,13 +60,13 @@ rook_csv_template="rook-ceph-ocp.vVERSION.clusterserviceversion.yaml.in"
 rook_crds_dir=$rook_template_dir/crds
 crd_list=$(mktemp)
 echo "Dumping rook csv using command: $IMAGE_RUN_CMD --entrypoint=cat $ROOK_IMAGE $rook_template_dir/$rook_csv_template"
-$IMAGE_RUN_CMD --entrypoint=cat $ROOK_IMAGE $rook_template_dir/$rook_csv_template > $ROOK_CSV
+$IMAGE_RUN_CMD --entrypoint=cat $ROOK_IMAGE $rook_template_dir/$rook_csv_template | tee $ROOK_CSV
 echo "Listing rook crds using command: $IMAGE_RUN_CMD --entrypoint=ls $ROOK_IMAGE -1 $rook_crds_dir/"
-$IMAGE_RUN_CMD --entrypoint=ls $ROOK_IMAGE -1 $rook_crds_dir/ > $crd_list
+$IMAGE_RUN_CMD --entrypoint=ls $ROOK_IMAGE -1 $rook_crds_dir/ | tee $crd_list
 for i in $(cat $crd_list); do
 	crd_file=$(printf ${rook_crds_dir}/$i | tr -d '[:space:]')
 	echo "Dumping rook crd $crd_file using command: $IMAGE_RUN_CMD --entrypoint=cat $ROOK_IMAGE $crd_file"
-	($IMAGE_RUN_CMD --entrypoint=cat $ROOK_IMAGE $crd_file) > $OUTDIR_CRDS/$(basename $crd_file)
+	($IMAGE_RUN_CMD --entrypoint=cat $ROOK_IMAGE $crd_file) | tee $OUTDIR_CRDS/$(basename $crd_file)
 done;
 rm -f $crd_list
 


### PR DESCRIPTION
This allows us to have visibility into what the container's dumping CSV contents are actually dumping which will help when debugging errors. 

Addresses comment by @b-ranto [here](https://github.com/openshift/ocs-operator/pull/180#discussion_r330888592)