### PR TITLE
Improve `make cluster-deploy` and `make cluster-clean`

### DIFF
--- a/functests/setup_teardown.go
+++ b/functests/setup_teardown.go
@@ -20,9 +20,6 @@ func BeforeTestSuiteSetup() {
 	err = t.DeployOCSWithOLM(ocsRegistryImage, localStorageRegistryImage)
 	gomega.Expect(err).To(gomega.BeNil())
 
-	err = t.WaitForOCSOperator()
-	gomega.Expect(err).To(gomega.BeNil())
-
 	err = t.StartDefaultStorageCluster()
 	gomega.Expect(err).To(gomega.BeNil())
 

--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -1,14 +1,66 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 source hack/common.sh
 
-echo "Deleting ocs-operator manifests"
-# even though we alter the deploy-with-olm.yaml in cluster-deploy,
-# the object names and namespaces remain the same, which allows us
-# to clean the cluster using the original manifest.
-oc delete --ignore-not-found -f deploy/deploy-with-olm.yaml
+set +e
+
+# Remove finalizers from all cephclusters, to not block the cleanup
+echo "Removing cephcluster finalizers"
+$OCS_OC_PATH get cephcluster -n openshift-storage -o=custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,FINALIZERS:.metadata.finalizers --no-headers | grep cephcluster.ceph.rook.io | while read p; do
+    arr=($p)
+    name="${arr[0]}"
+    namespace="${arr[1]}"
+    $OCS_OC_PATH patch cephcluster $name -n $namespace --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]'
+done
+
+echo "Delete all storageclusterinitializations"
+$OCS_OC_PATH -n openshift-storage delete storagecluster,storageclusterinitialization --cascade=false --all
+
+echo "Deleting noobaa objects"
+$OCS_OC_PATH -n openshift-storage delete noobaa --all
+
+echo "Deleting noobaa-core stateful set"
+$OCS_OC_PATH -n openshift-storage delete --ignore-not-found statefulset noobaa-core
+
+echo "Delete all noobaa-core related pods"
+$OCS_OC_PATH -n openshift-storage delete pods -l "noobaa-core"
+
+# delete ceph clusters and storage clusters
+echo "Deleting all storageclusters and cephclusters"
+$OCS_OC_PATH -n openshift-storage delete cephcluster --all
+
+set -e
+
+echo "Deleting noobaa-operator"
+$OCS_OC_PATH -n openshift-storage delete --ignore-not-found deployment noobaa-operator
+
+echo "Deleting rook-operator"
+$OCS_OC_PATH -n openshift-storage delete --ignore-not-found deployment rook-operator
+
+echo "Deleting ocs-operator"
+$OCS_OC_PATH -n openshift-storage delete --ignore-not-found deployment ocs-operator
+
+echo "Deleting subscriptions"
+$OCS_OC_PATH -n openshift-storage delete subscription --all
+
+echo "Deleting all remaining deployments"
+$OCS_OC_PATH -n openshift-storage delete deployments --all
+
+echo "Deleting all remaining daemonsets"
+$OCS_OC_PATH -n openshift-storage delete daemonsets --all
+
+echo "Deleting all remaining pods"
+$OCS_OC_PATH -n openshift-storage delete pods --all
+
+echo "Deleting all PVCs and PVs"
+$OCS_OC_PATH -n openshift-storage delete pvc,pv --all
+
+# clean up any remaining objects installed in the deploy manifests such as
+# namespaces, operator groups, and resources outside of the openshift-storage namespace.
+echo "Deleting remaining ocs-operator manifests"
+$OCS_OC_PATH delete --ignore-not-found -f deploy/deploy-with-olm.yaml
 
 echo "Waiting on namespaces to disappear"
 # We wait for the namespaces to disappear because that signals
@@ -16,15 +68,15 @@ echo "Waiting on namespaces to disappear"
 # might fail if all cluster artifacts haven't finished being removed.
 managed_namespaces=(openshift-storage local-storage)
 for i in ${managed_namespaces[@]}; do
-	if [ -n "$(oc get namespace | grep "${i} ")" ]; then
+	if [ -n "$($OCS_OC_PATH get namespace | grep "${i} ")" ]; then
 		echo "Deleting namespace ${i}"
-		oc delete --ignore-not-found namespace ${i}
+		$OCS_OC_PATH delete --ignore-not-found namespace ${i}
 
 		current_time=0
 		sample=10
 		timeout=120
 		echo "Waiting for ${i} namespace to disappear ..."
-		while [ -n "$(oc get namespace | grep "${i} ")" ]; do
+		while [ -n "$($OCS_OC_PATH get namespace | grep "${i} ")" ]; do
 			sleep $sample
 			current_time=$((current_time + sample))
 			if [[ $current_time -gt $timeout ]]; then

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -20,11 +20,13 @@ REDHAT_OCS_CI_TEST_EXPRESSION="${REDHAT_OCS_CI_TEST_EXPRESSION:-$REDHAT_OCS_CI_D
 REDHAT_OCS_CI_PYTHON_BINARY="${REDHAT_OCS_CI_PYTHON_BINARY:-python3.7}"
 REDHAT_OCS_CI_FORCE_TOOL_POD_INSTALL="${REDHAT_OCS_CI_FORCE_TOOL_POD_INSTALL:-false}"
 
+# This env var allows developers to point to a custom oc tool that isn't in $PATH
+# defaults to just using the 'oc' binary provided in $PATH
+OCS_OC_PATH="${OCS_OC_PATH:-oc}"
 
 NOOBAA_CSV="$OUTDIR_TEMPLATES/noobaa-csv.yaml"
 ROOK_CSV="$OUTDIR_TEMPLATES/rook-csv.yaml.in"
 OCS_CSV="$OUTDIR_TEMPLATES/ocs-operator.csv.yaml.in"
-
 
 DEFAULT_IMAGE_REGISTRY="quay.io"
 DEFAULT_REGISTRY_NAMESPACE="ocs-dev"

--- a/pkg/deploy-manager/subscription.go
+++ b/pkg/deploy-manager/subscription.go
@@ -323,7 +323,7 @@ func (t *DeployManager) DeployOCSWithOLM(ocsRegistryImage string, localStorageRe
 func (t *DeployManager) waitForOCSOperator() error {
 	deployments := []string{"ocs-operator", "rook-ceph-operator", "noobaa-operator"}
 
-	timeout := 300 * time.Second
+	timeout := 1000 * time.Second
 	interval := 10 * time.Second
 
 	lastReason := ""

--- a/tools/cluster-deploy/cluster-deploy.go
+++ b/tools/cluster-deploy/cluster-deploy.go
@@ -41,12 +41,6 @@ func main() {
 		panic(err)
 	}
 
-	log.Printf("Waiting for ocs-operator to come online")
-	err = t.WaitForOCSOperator()
-	if err != nil {
-		panic(err)
-	}
-
 	log.Printf("Starting default storage cluster")
 	err = t.StartDefaultStorageCluster()
 	if err != nil {


### PR DESCRIPTION
The setup time in `make cluster-deploy` has been improved by waiting to post the ocs subscription until after the catalog source is available. This improves the response time for how quickly the olm process the subscription.

The `make cluster-clean` script now completely removes everything related to `make cluster-up` by clearing the cephcluster finalizers and forcing all resources to be terminated. 