### PR TITLE
Add skip-range option to csv generation

### DIFF
--- a/hack/generate-unified-csv.sh
+++ b/hack/generate-unified-csv.sh
@@ -18,6 +18,7 @@ function help_txt() {
 	echo "    CEPH_IMAGE:           (required) The ceph daemon container image to be deployed with storage clusters"
 	echo "    CSV_VERSION:          (required) The ocs-operator csv version that will be generated"
 	echo "    REPLACES_CSV_VERSION       (optional) The ocs-operator csv version this new csv will be updating"
+	echo "    SKIP_RANGE                 (optional) The skip range value set for this csv"
 	echo "    ROOK_CSI_CEPH_IMAGE        (optional) Sets custom image env var on the rook deployment spec"
 	echo "    ROOK_CSI_REGISTRAR_IMAGE   (optional) Sets custom image env var on the rook deployment spec"
 	echo "    ROOK_CSI_PROVISIONER_IMAGE (optional) Sets custom image env var on the rook deployment spec"
@@ -46,6 +47,7 @@ fi
 $CSV_MERGER \
 	--csv-version=$CSV_VERSION \
 	--replaces-csv-version=$REPLACES_CSV_VERSION \
+	--skip-range="$SKIP_RANGE" \
 	--rook-csv-filepath=$ROOK_CSV \
 	--noobaa-csv-filepath=$NOOBAA_CSV \
 	--ocs-csv-filepath=$OCS_CSV \

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -47,6 +47,7 @@ type csvStrategySpec struct {
 var (
 	csvVersion         = flag.String("csv-version", "", "the unified CSV version")
 	replacesCsvVersion = flag.String("replaces-csv-version", "", "the unified CSV version this new CSV will replace")
+	skipRange          = flag.String("skip-range", "", "the CSV version skip range")
 	rookCSVStr         = flag.String("rook-csv-filepath", "", "path to rook csv yaml file")
 	noobaaCSVStr       = flag.String("noobaa-csv-filepath", "", "path to noobaa csv yaml file")
 	ocsCSVStr          = flag.String("ocs-csv-filepath", "", "path to ocs csv yaml file")
@@ -516,7 +517,10 @@ The OCS operator is the primary operator for Red Hat OpenShift Container Storage
 
 	ocsCSV.Spec.DisplayName = "Openshift Container Storage Operator"
 
-	// Set Annotatoins
+	// Set Annotations
+	if *skipRange != "" {
+		ocsCSV.Annotations["olm.skipRange"] = *skipRange
+	}
 	ocsCSV.Annotations["capabilities"] = "Full Lifecycle"
 	ocsCSV.Annotations["categories"] = "Storage"
 	ocsCSV.Annotations["alm-examples"] = `


### PR DESCRIPTION
The skip range feature is described here,  https://github.com/operator-framework/operator-lifecycle-manager/blob/98c24d9/doc/design/how-to-update-operators.md#skiprange

We need the ability to set the skipRange option on the CSV during csv generation in order to update across multiple patch level releases. 