### PR TITLE
fix(must-gather): Adds support to collect storagecluster resources

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -2,10 +2,10 @@
 BASE_COLLECTION_PATH="/must-gather"
 mkdir -p ${BASE_COLLECTION_PATH}
 
-# TODO: Resources commnon to both noobaa and ceph can be collected here
-
 # Resource List
 resources=()
+# collect storagecluster resources
+resources+=(storageclusters)
 
 # collect OB/OBC resoureces
 resources+=(objectbucketclaims)

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -2,6 +2,16 @@
 BASE_COLLECTION_PATH="/must-gather"
 mkdir -p ${BASE_COLLECTION_PATH}
 
+echo "Collecting operator pod logs"
+operatorPodLogCollectionPath="${BASE_COLLECTION_PATH}/namespaces"
+operatorPodLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name};oc logs {@.metadata.name}  --all-containers -n {@.metadata.namespace} &> ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name}/{@.metadata.name}.log;{end}"
+operatorPodPreviousLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name};oc logs {@.metadata.name} -p --all-containers -n {@.metadata.namespace} &> ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name}/{@.metadata.name}-previous.log;{end}"
+oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}" >> collector.sh
+oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}" >> collector.sh
+oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}" >> collector.sh
+oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}" >> collector.sh
+chmod +x collector.sh
+./collector.sh
 # Resource List
 resources=()
 # collect storagecluster resources

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -79,7 +79,7 @@ done
 # Inspecting the namespace where ceph-cluster is installed
 for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}'); do
     openshift-must-gather --base-dir=${CEPH_COLLLECTION_PATH} inspect ns/${ns}
-    if [ $(generate_config ${ns}) -eq 1 ]; then 
+    if [ $(generate_config ${ns}) -eq 1 ]; then
         continue
     fi
     COMMAND_OUTPUT_DIR=${CEPH_COLLLECTION_PATH}/namespaces/${ns}/must_gather_commands


### PR DESCRIPTION
This commit modifies the gather scripts to collect logs irrespective of ceph cluster. Since OCP must-gather is unable to fecth logs from namespaces like openshift-storage, local-storage

Signed-off-by: Rajat Singh <rajasing@redhat.com>