### PR TITLE
fix(must-gather): fix syntax error for noobaa gather script

### DIFF
--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -4,7 +4,7 @@
 BASE_COLLECTION_PATH=$1
 
 # Use PWD as base path if no argument is passed
-if [ "${BASE_COLLECTION_PATH}" = "" ]]; then
+if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
 fi
 


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <aranjan@redhat.com>

This commit fixes bash syntax error in noobaa gather script.