### PR TITLE
disables InstallMode: AllNamespaces

### DIFF
--- a/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/0.0.1/ocs-operator.v0.0.1.clusterserviceversion.yaml
@@ -1311,7 +1311,7 @@ spec:
     type: SingleNamespace
   - supported: false
     type: MultiNamespace
-  - supported: true
+  - supported: false
     type: AllNamespaces
   keywords:
   - storage

--- a/hack/latest-csv-checksum.md5
+++ b/hack/latest-csv-checksum.md5
@@ -1,1 +1,1 @@
-a0f2d832f64a8003ad49c0a25ed10d52
+db657b2ff376f8dcf7cdfbe4cfdc0ad4

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -477,6 +477,26 @@ func generateUnifiedCSV() {
 	// Set api maturity
 	ocsCSV.Spec.Maturity = "alpha"
 
+	//set Install Modes
+	ocsCSV.Spec.InstallModes = []csvv1.InstallMode{
+		csvv1.InstallMode{
+			Type:      csvv1.InstallModeTypeOwnNamespace,
+			Supported: true,
+		},
+		csvv1.InstallMode{
+			Type:      csvv1.InstallModeTypeSingleNamespace,
+			Supported: true,
+		},
+		csvv1.InstallMode{
+			Type:      csvv1.InstallModeTypeMultiNamespace,
+			Supported: false,
+		},
+		csvv1.InstallMode{
+			Type:      csvv1.InstallModeTypeAllNamespaces,
+			Supported: false,
+		},
+	}
+
 	// Set maintainers
 	ocsCSV.Spec.Maintainers = []csvv1.Maintainer{
 		{


### PR DESCRIPTION
This will allow the operator to be installed only in a
single namespace as MultiNamespace is also disabled.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>