### PR TITLE
enhance(must-gather): This PR changes sed delimiter and also the must-gather base image to 4.2.0

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-must-gather:4.2
+FROM quay.io/openshift/origin-must-gather:4.2.0
 
 RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager.conf \
     && cat /etc/yum/pluginconf.d/subscription-manager.conf \

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -15,8 +15,9 @@ CEPH_CONFIG_FILE="/etc/ceph/ceph.conf"
 CEPH_CONFIG_TEMPLATE="/templates/ceph.conf.template"
 CEPH_KEYRING_TEMPLATE="/templates/keyring.template"
 
+SED_DELIMITER=$(echo -en "\001");
 safe_replace () {
-    sed "s/${1//\//\\\/}/${2//\//\\\/}/g"
+    sed "s${SED_DELIMITER}${1}${SED_DELIMITER}${2}${SED_DELIMITER}g"
 }
 
 generate_config() {


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <aranjan@redhat.com>

-> This PR changes the sed delimiter to \001 which is less probable to occur in the ceph config.
-> This PR changes base image version of ocs-must-gather to 4.2.0 as 4.2 image is not coming with the must-gather 4.2 cli which breaks upstream build.