### PR TITLE
refactor(must-gather): Make use oc adm inspect

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-must-gather:4.2.0
+FROM quay.io/openshift/origin-must-gather:latest
 
 RUN sed -i 's/enabled=1/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager.conf \
     && cat /etc/yum/pluginconf.d/subscription-manager.conf \

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -25,7 +25,7 @@ resources+=(objectbuckets)
 
 # Run the Collection of Resources using must-gather
 for resource in ${resources[@]}; do
-    openshift-must-gather --base-dir=${BASE_COLLECTION_PATH} inspect ${resource} --all-namespaces
+    oc adm --dest-dir=${BASE_COLLECTION_PATH} inspect ${resource} --all-namespaces
 done
 
 # Call other gather scripts

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -78,12 +78,12 @@ ceph_volume_commands+=("ceph-volume lvm list")
 
 # Inspecting ceph related custom resources for all namespaces 
 for resource in ${ceph_resources[@]}; do
-    openshift-must-gather --base-dir=${CEPH_COLLLECTION_PATH} inspect ${resource} --all-namespaces
+    oc adm --dest-dir=${CEPH_COLLLECTION_PATH} inspect ${resource} --all-namespaces
 done
 
 # Inspecting the namespace where ceph-cluster is installed
 for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}'); do
-    openshift-must-gather --base-dir=${CEPH_COLLLECTION_PATH} inspect ns/${ns}
+    oc adm --dest-dir=${CEPH_COLLLECTION_PATH} inspect ns/${ns}
     if [ $(generate_config ${ns}) -eq 1 ]; then
         continue
     fi

--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -19,7 +19,7 @@ noobaa_resources+=(bucketclass)
 
 # Run the Collection of NooBaa Resources using must-gather
 for resource in ${noobaa_resources[@]}; do
-    openshift-must-gather --base-dir=${NOOBAA_COLLLECTION_PATH} inspect ${resource} --all-namespaces
+    oc adm --dest-dir=${NOOBAA_COLLLECTION_PATH} inspect ${resource} --all-namespaces
 done
 
 # Collect logs for all noobaa pods using oc logs


### PR DESCRIPTION
Signed-off-by: ashishranjan738 <aranjan@redhat.com>

This commit refactors the gather scripts to `oc adm inspect` command for
collecting the resources as `openshift-must-gather inspect` is getting depricated.