### PR TITLE
Dumping noobaa objects to debug info

### DIFF
--- a/hack/dump-debug-info.sh
+++ b/hack/dump-debug-info.sh
@@ -11,3 +11,5 @@ echo "--- StorageCluster ---"
 oc get storagecluster --all-namespaces -o yaml
 echo "--- CephCluster ---"
 oc get cephcluster --all-namespaces -o yaml
+echo "--- Noobaa ---"
+oc get noobaa --all-namespaces -o yaml


### PR DESCRIPTION
Makes it easier to debug the issue when failures are noobaa related.