### PR TITLE
Bug 1767408: storagecluster: Set correct Store for CephObjectStoreUser

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -319,7 +319,7 @@ func (r *ReconcileStorageCluster) newCephObjectStoreUserInstances(initData *ocsv
 			},
 			Spec: cephv1.ObjectStoreUserSpec{
 				DisplayName: initData.Name,
-				Store:       initData.Name,
+				Store:       generateNameForCephObjectStore(initData),
 			},
 		},
 	}


### PR DESCRIPTION
The Store was being set to StorageCluster.Name instead of the name of
the CephObjectStore that is created.

Signed-off-by: Kaushal M <kshlmster@gmail.com>