### PR TITLE
storagecluster: give the cephfs metadata pool the right failureDomain

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -389,6 +389,7 @@ func (r *ReconcileStorageCluster) newCephFilesystemInstances(initData *ocsv1.Sto
 					Replicated: cephv1.ReplicatedSpec{
 						Size: 3,
 					},
+					FailureDomain: initData.Status.FailureDomain,
 				},
 				DataPools: []cephv1.PoolSpec{
 					cephv1.PoolSpec{


### PR DESCRIPTION
By omission, only the data pool(s) had received the configured failure
domain. This patch adds the same failure domain to the metadata pool.

Signed-off-by: Michael Adam <obnox@redhat.com>