### PR TITLE
Bug 1763070: give cephfs metadata pool the right failure domain

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -389,6 +389,7 @@ func (r *ReconcileStorageCluster) newCephFilesystemInstances(initData *ocsv1.Sto
 					Replicated: cephv1.ReplicatedSpec{
 						Size: 3,
 					},
+					FailureDomain: initData.Status.FailureDomain,
 				},
 				DataPools: []cephv1.PoolSpec{
 					cephv1.PoolSpec{


### PR DESCRIPTION
Backport of PR #266 .