### PR TITLE
Bug 1765550: Set OSD memory limits and add config map

### DIFF
--- a/pkg/controller/defaults/resources.go
+++ b/pkg/controller/defaults/resources.go
@@ -16,7 +16,7 @@ var (
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("4Gi"),
+				corev1.ResourceMemory: resource.MustParse("8Gi"),
 			},
 		},
 		"mon": corev1.ResourceRequirements{

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -32,6 +32,12 @@ import (
 	rook "github.com/rook/rook/pkg/apis/rook.io/v1alpha2"
 )
 
+const (
+	rookConfigMapName = "rook-config-override"
+	rookConfigData = `[global]
+osd_memory_target_cgroup_limit_ratio=0.5`
+)
+
 var monCount = defaults.MonCount
 
 var validTopologyLabelKeys = []string{
@@ -188,6 +194,7 @@ func (r *ReconcileStorageCluster) Reconcile(request reconcile.Request) (reconcil
 		r.ensureCephBlockPools,
 		r.ensureCephFilesystems,
 
+		r.ensureCephConfig,
 		r.ensureCephCluster,
 		r.ensureNoobaaSystem,
 	} {
@@ -490,6 +497,52 @@ func determinePlacementRack(nodes *corev1.NodeList, node corev1.Node, minRacks i
 	}
 
 	return rack
+}
+
+// ensureCephConfig ensures that a ConfigMap resource exists with its Spec in
+// the desired state.
+func (r *ReconcileStorageCluster) ensureCephConfig(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
+	ownerRef := metav1.OwnerReference{
+		UID:                sc.UID,
+		APIVersion:         sc.APIVersion,
+		Kind:               sc.Kind,
+		Name:               sc.Name,
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            rookConfigMapName,
+			Namespace:       sc.Namespace,
+			OwnerReferences: []metav1.OwnerReference{ownerRef},
+		},
+		Data: map[string]string{
+			"config": rookConfigData,
+		},
+	}
+
+	found := &corev1.ConfigMap{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: rookConfigMapName, Namespace: sc.Namespace}, found)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			reqLogger.Info("Creating Ceph ConfigMap")
+			err = r.client.Create(context.TODO(), cm); if err != nil {
+				return err
+			}
+		}
+		return err
+	}
+
+	ownerRefFound := false
+	for _, ownerRef := range found.OwnerReferences {
+		if ownerRef.UID == sc.UID {
+			ownerRefFound = true
+		}
+	}
+	val, ok := found.Data["config"]
+	if ok != true || val != rookConfigData || ownerRefFound != true {
+		reqLogger.Info("Updating Ceph ConfigMap")
+		return r.client.Update(context.TODO(), cm)
+	}
+	return nil
 }
 
 // ensureCephCluster ensures that a CephCluster resource exists with its Spec in


### PR DESCRIPTION
This change increases the memory limit for OSDs to 8GiB
and sets the memory usage cgroup limit for OSDs to 0.5.

Co-authored-by: Jose A. Rivera <jarrpa@redhat.com>
Signed-off-by: Elise Gafford <egafford@redhat.com>