### PR TITLE
tests: Capture ocs-must-gather on e2e failures

### DIFF
--- a/hack/dump-debug-info.sh
+++ b/hack/dump-debug-info.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-	
+source hack/common.sh
+
 echo "dumping debug information"
 echo "--- PODS ----"
 oc get pods -n openshift-storage
@@ -13,3 +14,11 @@ echo "--- CephCluster ---"
 oc get cephcluster --all-namespaces -o yaml
 echo "--- Noobaa ---"
 oc get noobaa --all-namespaces -o yaml
+
+echo "Running ocs-must-gather"
+MUST_GATHER_DIR="ocs-must-gather"
+if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
+  MUST_GATHER_DIR="/tmp/artifacts/ocs-must-gather"
+fi
+mkdir -p $MUST_GATHER_DIR
+oc adm must-gather --image "$MUST_GATHER_FULL_IMAGE_NAME" --dest-dir "$MUST_GATHER_DIR"


### PR DESCRIPTION
The ocs-must-gather logs and files will be collected whenever a e2e test
job fails (functest/red-hat-storage-ocs-ci). They will be added to the
artifacts of the prow job and be accessible from the job status page.