### PR TITLE
enhance(must-gather): Adds logic to skip NotReady Nodes

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -71,6 +71,7 @@ ceph_commands+=("ceph mgr dump")
 ceph_commands+=("ceph mds stat")
 ceph_commands+=("ceph versions")
 ceph_commands+=("ceph fs dump")
+ceph_commands+=("ceph auth list")
 
 # Ceph volume commands
 ceph_volume_commands+=()
@@ -115,7 +116,7 @@ for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}')
     done
     
     # Collecting ceph prepare volume logs
-    for node in $(oc get nodes -l cluster.ocs.openshift.io/openshift-storage='' --no-headers | awk '{print $1}'); do
+    for node in $(oc get nodes -l cluster.ocs.openshift.io/openshift-storage='' --no-headers | grep -w 'Ready' | awk '{print $1}'); do
         printf "collecting prepare volume logs from node %s \n"  "${node}"
         NODE_OUTPUT_DIR=${CEPH_COLLLECTION_PATH}/namespaces/${ns}/osd_prepare_volume_logs/${node}
         mkdir -p ${NODE_OUTPUT_DIR}


### PR DESCRIPTION
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>

This commit add support to skip NotReady nodes for collecting prepare volume pod logs as those logs will not be available when node is NotReady state.