### PR TITLE
storagecluster: Append "-rook-ceph" to name of created CephCluster

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -683,7 +683,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string) *cephv1.CephClus
 
 	cephCluster := &cephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sc.Name,
+			Name:      sc.Name + "-rook-ceph",
 			Namespace: sc.Namespace,
 			Labels:    labels,
 		},

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -9,8 +9,8 @@ import (
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -306,7 +306,7 @@ func TestEnsureCephClusterCreate(t *testing.T) {
 
 	expected := newCephCluster(mockStorageCluster, "")
 	actual := newCephCluster(mockStorageCluster, "")
-	err = reconciler.client.Get(nil, mockStorageClusterRequest.NamespacedName, actual)
+	err = reconciler.client.Get(nil, types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected.ObjectMeta.Name, actual.ObjectMeta.Name)
 	assert.Equal(t, expected.ObjectMeta.Namespace, actual.ObjectMeta.Namespace)
@@ -326,7 +326,7 @@ func TestEnsureCephClusterUpdate(t *testing.T) {
 
 	expected := newCephCluster(mockStorageCluster, "")
 	actual := newCephCluster(mockStorageCluster, "")
-	err = reconciler.client.Get(nil, mockStorageClusterRequest.NamespacedName, actual)
+	err = reconciler.client.Get(nil, types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected.ObjectMeta.Name, actual.ObjectMeta.Name)
 	assert.Equal(t, expected.ObjectMeta.Namespace, actual.ObjectMeta.Namespace)
@@ -369,7 +369,7 @@ func TestStorageClusterCephClusterCreation(t *testing.T) {
 	sc.Spec.StorageDeviceSets = mockDeviceSets
 
 	actual := newCephCluster(sc, "")
-	assert.Equal(t, sc.Name, actual.Name)
+	assert.Equal(t, sc.Name+"-rook-ceph", actual.Name)
 	assert.Equal(t, sc.Namespace, actual.Namespace)
 	pvcSpec := actual.Spec.Mon.VolumeClaimTemplate.Spec
 	assert.Equal(t, mockDeviceSets[0].DataPVCTemplate.Spec.StorageClassName, pvcSpec.StorageClassName)
@@ -471,7 +471,7 @@ func TestStorageClusterFinalizer(t *testing.T) {
 	noobaa := &v1alpha1.NooBaa{}
 	err = reconciler.client.Get(nil, namespacedName, noobaa)
 	assert.NoError(t, err)
-	assert.Equal(t, noobaa.Name,  noobaaMock.Name)
+	assert.Equal(t, noobaa.Name, noobaaMock.Name)
 
 	// Issue a delete
 	now := metav1.Now()
@@ -553,4 +553,3 @@ func createFakeScheme(t *testing.T) *runtime.Scheme {
 	}
 	return scheme
 }
-


### PR DESCRIPTION
This hopefully helps fix the failures in long running, idle clusters.