### PR TITLE
storagecluster: Use correct CephCluster name when ...

### DIFF
--- a/pkg/controller/storagecluster/generate.go
+++ b/pkg/controller/storagecluster/generate.go
@@ -6,6 +6,14 @@ import (
 	ocsv1 "github.com/openshift/ocs-operator/pkg/apis/ocs/v1"
 )
 
+func generateNameForCephCluster(initData *ocsv1.StorageCluster) string {
+	return generateNameForCephClusterFromString(initData.Name)
+}
+
+func generateNameForCephClusterFromString(name string) string {
+	return fmt.Sprintf("%s-cephcluster", name)
+}
+
 func generateNameForCephFilesystem(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-cephfilesystem", initData.Name)
 }

--- a/pkg/controller/storagecluster/noobaa_system_reconciler.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler.go
@@ -34,7 +34,7 @@ func (r *ReconcileStorageCluster) ensureNoobaaSystem(sc *ocsv1.StorageCluster, r
 
 	// find cephCluster
 	foundCeph := &cephv1.CephCluster{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: sc.Name, Namespace: sc.Namespace}, foundCeph)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: generateNameForCephCluster(sc), Namespace: sc.Namespace}, foundCeph)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			reqLogger.Info("Waiting on ceph cluster to be created before starting noobaa")
@@ -135,7 +135,7 @@ func (r *ReconcileStorageCluster) deleteNoobaaSystems(sc *ocsv1.StorageCluster, 
 	if err != nil {
 		if errors.IsNotFound(err) {
 			pvcs := &corev1.PersistentVolumeClaimList{}
-			opts := []client.ListOption {
+			opts := []client.ListOption{
 				client.InNamespace(sc.Namespace),
 				client.MatchingLabels(map[string]string{"noobaa-core": "noobaa"}),
 			}
@@ -155,7 +155,7 @@ func (r *ReconcileStorageCluster) deleteNoobaaSystems(sc *ocsv1.StorageCluster, 
 	}
 
 	isOwned := false
-	for _, ref := range  noobaa.GetOwnerReferences() {
+	for _, ref := range noobaa.GetOwnerReferences() {
 		if ref.Name == sc.Name && ref.Kind == sc.Kind {
 			isOwned = true
 			break

--- a/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -47,7 +47,7 @@ func TestEnsureNooBaaSystem(t *testing.T) {
 
 	cephCluster := cephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      namespacedName.Name,
+			Name:      generateNameForCephClusterFromString(namespacedName.Name),
 			Namespace: namespacedName.Namespace,
 		},
 	}

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -683,7 +683,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string) *cephv1.CephClus
 
 	cephCluster := &cephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sc.Name + "-rook-ceph",
+			Name:      generateNameForCephCluster(sc),
 			Namespace: sc.Namespace,
 			Labels:    labels,
 		},

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -39,8 +39,8 @@ var mockStorageCluster = &api.StorageCluster{
 		Kind: "StorageCluster",
 	},
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      "storage-test",
-		Namespace: "storage-test-ns",
+		Name:      mockStorageClusterRequest.Name,
+		Namespace: mockStorageClusterRequest.Namespace,
 	},
 
 	Status: api.StorageClusterStatus{
@@ -51,6 +51,19 @@ var mockStorageCluster = &api.StorageCluster{
 		CephFilesystemsCreated:      true,
 	},
 }
+
+var mockCephCluster = &rookCephv1.CephCluster{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      generateNameForCephCluster(mockStorageCluster),
+		Namespace: mockStorageCluster.Namespace,
+	},
+}
+
+var mockCephClusterNamespacedName = types.NamespacedName{
+	Name:      generateNameForCephCluster(mockStorageCluster),
+	Namespace: mockStorageCluster.Namespace,
+}
+
 var mockStorageClusterInit = &api.StorageClusterInitialization{
 	TypeMeta: metav1.TypeMeta{
 		Kind: "StorageClusterInitialization",
@@ -177,14 +190,11 @@ func TestNonWatchedReconcileWithNoCephClusterType(t *testing.T) {
 }
 
 func TestNonWatchedReconcileWithTheCephClusterType(t *testing.T) {
-	cephMock := &rookCephv1.CephCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "storage-test",
-			Namespace: "storage-test-ns",
-		},
-	}
-	cephMock.Status.State = rookCephv1.ClusterStateCreated
-	reconciler := createFakeStorageClusterReconciler(t, mockStorageCluster, mockStorageClusterInit, cephMock)
+	cc := &rookCephv1.CephCluster{}
+	mockCephCluster.DeepCopyInto(cc)
+	cc.Status.State = rookCephv1.ClusterStateCreated
+
+	reconciler := createFakeStorageClusterReconciler(t, mockStorageCluster, mockStorageClusterInit, cc)
 	result, err := reconciler.Reconcile(mockStorageClusterRequest)
 	assert.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, result)
@@ -294,19 +304,17 @@ func TestFailureDomain(t *testing.T) {
 }
 
 func TestEnsureCephClusterCreate(t *testing.T) {
-	cephMock := &rookCephv1.CephCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "doesn't exist",
-			Namespace: "storage-test-ns",
-		},
-	}
-	reconciler := createFakeStorageClusterReconciler(t, mockStorageCluster, cephMock)
+	cc := &rookCephv1.CephCluster{}
+	mockCephCluster.DeepCopyInto(cc)
+	cc.ObjectMeta.Name = "doesn't exist"
+
+	reconciler := createFakeStorageClusterReconciler(t, mockStorageCluster, cc)
 	err := reconciler.ensureCephCluster(mockStorageCluster, reconciler.reqLogger)
 	assert.NoError(t, err)
 
 	expected := newCephCluster(mockStorageCluster, "")
 	actual := newCephCluster(mockStorageCluster, "")
-	err = reconciler.client.Get(nil, types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, actual)
+	err = reconciler.client.Get(nil, mockCephClusterNamespacedName, actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected.ObjectMeta.Name, actual.ObjectMeta.Name)
 	assert.Equal(t, expected.ObjectMeta.Namespace, actual.ObjectMeta.Namespace)
@@ -314,19 +322,13 @@ func TestEnsureCephClusterCreate(t *testing.T) {
 }
 
 func TestEnsureCephClusterUpdate(t *testing.T) {
-	cephMock := &rookCephv1.CephCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "storage-test",
-			Namespace: "storage-test-ns",
-		},
-	}
-	reconciler := createFakeStorageClusterReconciler(t, cephMock)
+	reconciler := createFakeStorageClusterReconciler(t, mockCephCluster)
 	err := reconciler.ensureCephCluster(mockStorageCluster, reconciler.reqLogger)
 	assert.NoError(t, err)
 
 	expected := newCephCluster(mockStorageCluster, "")
 	actual := newCephCluster(mockStorageCluster, "")
-	err = reconciler.client.Get(nil, types.NamespacedName{Name: expected.Name, Namespace: expected.Namespace}, actual)
+	err = reconciler.client.Get(nil, mockCephClusterNamespacedName, actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected.ObjectMeta.Name, actual.ObjectMeta.Name)
 	assert.Equal(t, expected.ObjectMeta.Namespace, actual.ObjectMeta.Namespace)
@@ -369,7 +371,7 @@ func TestStorageClusterCephClusterCreation(t *testing.T) {
 	sc.Spec.StorageDeviceSets = mockDeviceSets
 
 	actual := newCephCluster(sc, "")
-	assert.Equal(t, sc.Name+"-rook-ceph", actual.Name)
+	assert.Equal(t, generateNameForCephCluster(sc), actual.Name)
 	assert.Equal(t, sc.Namespace, actual.Namespace)
 	pvcSpec := actual.Spec.Mon.VolumeClaimTemplate.Spec
 	assert.Equal(t, mockDeviceSets[0].DataPVCTemplate.Spec.StorageClassName, pvcSpec.StorageClassName)
@@ -423,14 +425,11 @@ func TestStorageClassDeviceSetCreation(t *testing.T) {
 }
 
 func TestStorageClusterInitConditions(t *testing.T) {
-	cephMock := &rookCephv1.CephCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "storage-test",
-			Namespace: "storage-test-ns",
-		},
-	}
-	cephMock.Status.State = rookCephv1.ClusterStateCreated
-	reconciler := createFakeStorageClusterReconciler(t, mockStorageCluster, mockStorageClusterInit, cephMock)
+	cc := &rookCephv1.CephCluster{}
+	mockCephCluster.DeepCopyInto(cc)
+	cc.Status.State = rookCephv1.ClusterStateCreated
+
+	reconciler := createFakeStorageClusterReconciler(t, mockStorageCluster, mockStorageClusterInit, cc)
 	result, err := reconciler.Reconcile(mockStorageClusterRequest)
 	assert.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, result)


### PR DESCRIPTION
... waiting for CephCluster to create NooBaa. Without this, the
contoller will not create a NooBaa resource.

New generator functions have been added to create the prefixed
CephCluster name, and these functions are used wherever the name of the
CephCluster is required.

The unit tests also have been updated to use new mock objects for
CephCluster created with the above functions.