### PR TITLE
Bug 1771844: storagecluster: Use correct CephCluster name when ...

### DIFF
--- a/pkg/controller/storagecluster/generate.go
+++ b/pkg/controller/storagecluster/generate.go
@@ -6,6 +6,14 @@ import (
 	ocsv1 "github.com/openshift/ocs-operator/pkg/apis/ocs/v1"
 )
 
+func generateNameForCephCluster(initData *ocsv1.StorageCluster) string {
+	return generateNameForCephClusterFromString(initData.Name)
+}
+
+func generateNameForCephClusterFromString(name string) string {
+	return fmt.Sprintf("%s-cephcluster", name)
+}
+
 func generateNameForCephFilesystem(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-cephfilesystem", initData.Name)
 }

--- a/pkg/controller/storagecluster/noobaa_system_reconciler.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler.go
@@ -32,7 +32,7 @@ func (r *ReconcileStorageCluster) ensureNoobaaSystem(sc *ocsv1.StorageCluster, r
 
 	// find cephCluster
 	foundCeph := &cephv1.CephCluster{}
-	err = r.client.Get(context.TODO(), types.NamespacedName{Name: sc.Name, Namespace: sc.Namespace}, foundCeph)
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: generateNameForCephCluster(sc), Namespace: sc.Namespace}, foundCeph)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			reqLogger.Info("Waiting on ceph cluster to be created before starting noobaa")

--- a/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -47,7 +47,7 @@ func TestEnsureNooBaaSystem(t *testing.T) {
 
 	cephCluster := cephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      namespacedName.Name,
+			Name:      generateNameForCephClusterFromString(namespacedName.Name),
 			Namespace: namespacedName.Namespace,
 		},
 	}

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -645,7 +645,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string) *cephv1.CephClus
 
 	cephCluster := &cephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sc.Name + "-rook-ceph",
+			Name:      generateNameForCephCluster(sc),
 			Namespace: sc.Namespace,
 			Labels:    labels,
 		},


### PR DESCRIPTION
... waiting for CephCluster to create NooBaa. Without this, the
contoller will not create a NooBaa resource.

New generator functions have been added to create the prefixed
CephCluster name, and these functions are used wherever the name of the
CephCluster is required.

The unit tests also have been updated to use new mock objects for
CephCluster created with the above functions.

Backport of #290.