### PR TITLE
fix(ocs-operator): Fixes panic of ocs-operator when running vmware

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -495,36 +495,42 @@ func determinePlacementRack(nodes *corev1.NodeList, node corev1.Node, minRacks i
 		}
 	}
 
-	for rack := range nodeRacks.Labels {
-		nodeNames := nodeRacks.Labels[rack]
-		if len(nodeNames) == 0 {
-			rackList = append(rackList, rack)
-			continue
-		}
+	if len(targetAZ) > 0 {
+		for rack := range nodeRacks.Labels {
+			nodeNames := nodeRacks.Labels[rack]
+			if len(nodeNames) == 0 {
+				rackList = append(rackList, rack)
+				continue
+			}
 
-		validRack := false
-		for _, nodeName := range nodeNames {
-			for _, n := range nodes.Items {
-				if n.Name == nodeName {
-					for label, value := range n.Labels {
-						for _, key := range validTopologyLabelKeys {
-							if strings.Contains(label, key) && strings.Contains(label, "zone") && value == targetAZ {
-								validRack = true
+			validRack := false
+			for _, nodeName := range nodeNames {
+				for _, n := range nodes.Items {
+					if n.Name == nodeName {
+						for label, value := range n.Labels {
+							for _, key := range validTopologyLabelKeys {
+								if strings.Contains(label, key) && strings.Contains(label, "zone") && value == targetAZ {
+									validRack = true
+									break
+								}
+							}
+							if validRack {
 								break
 							}
 						}
-						if validRack {
-							break
-						}
+						break
 					}
+				}
+				if validRack {
 					break
 				}
 			}
 			if validRack {
-				break
+				rackList = append(rackList, rack)
 			}
 		}
-		if validRack {
+	} else {
+		for rack := range nodeRacks.Labels {
 			rackList = append(rackList, rack)
 		}
 	}


### PR DESCRIPTION
This commit fixes the panic of the ocs-operator when running in an vmware based ocp cluster. The operator crashes because its not able to assign a valid rack to the nodes as nodes in vmware based ocp cluster doesn't have any valid topology keys (https://github.com/openshift/ocs-operator/blob/master/pkg/controller/storagecluster/reconcile.go#L46-L50). So the current work around is to assign a rack with min number of nodes to the new node if the operator is not able to find a valid rack based on the topology key checks(https://github.com/openshift/ocs-operator/blob/master/pkg/controller/storagecluster/reconcile.go#L498-L530).

Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>