### PR TITLE
storagecluster: Do not set ownerRefs for StorageClasses

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -101,13 +101,6 @@ func (r *ReconcileStorageCluster) newStorageClasses(initData *ocsv1.StorageClust
 		},
 	}
 
-	for _, obj := range ret {
-		err := controllerutil.SetControllerReference(initData, obj, r.scheme)
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	return ret, nil
 }
 

--- a/pkg/controller/storagecluster/initialization_reconciler_test.go
+++ b/pkg/controller/storagecluster/initialization_reconciler_test.go
@@ -173,8 +173,13 @@ func assertExpectedResources(t assert.TestingT, reconciler ReconcileStorageClust
 	expected, err := reconciler.newStorageClasses(cr)
 	assert.NoError(t, err)
 
-	assert.Equal(t, len(expected[0].OwnerReferences), 1)
-	assert.Equal(t, len(expected[1].OwnerReferences), 1)
+	// The created StorageClasses should not have any ownerReferences set. Any
+	// OwnerReference set will be a cross-namespace OwnerReference, which could
+	// lead to other child resources getting GCd.
+	// Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1755623
+	// Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1691546
+	assert.Equal(t, len(expected[0].OwnerReferences), 0)
+	assert.Equal(t, len(expected[1].OwnerReferences), 0)
 
 	assert.Equal(t, expected[0].ObjectMeta, actualSc1.ObjectMeta)
 	assert.Equal(t, expected[0].Provisioner, actualSc1.Provisioner)


### PR DESCRIPTION
The StorageClass resources are non-namespaced resources, and had their
ownerRefs set to the StorageCluster resource which is a namespaced
resource in the openshift-storage namespace. Having this sort of
cross-namespace ownerRefs, could cause the other children of the
StorageCluster to be inadverdently deleted by the GC. Ref [1][1].

Removing the ownerRefs on the StorageClass objects avoids this.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1691546