### PR TITLE
[WIP]enhance(must-gather): Removes dependency ocp's must-gather

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -354,6 +354,7 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/noobaa/noobaa-operator/v2 v2.0.7 h1:ah6qg2Zd4Ls1bp+NPeaVFNk7GDm3tg+1oA3kJb0S7M8=
 github.com/noobaa/noobaa-operator/v2 v2.0.7/go.mod h1:V/v8kmrSqXI+XnNkeg5Yvt25wP9TM4mpLSwsv4DtSLE=
+github.com/noobaa/noobaa-operator/v2 v2.0.8 h1:kT5LQTiC9CLCOIqwhGIju5K/6Pk5wdudZGlz4V8/VPc=
 github.com/noobaa/noobaa-operator/v2 v2.0.8/go.mod h1:V/v8kmrSqXI+XnNkeg5Yvt25wP9TM4mpLSwsv4DtSLE=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.4.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/must-gather/Centos-Base.repo
+++ b/must-gather/Centos-Base.repo
@@ -1,6 +1,0 @@
-[centos]
-name=CentOS-7
-baseurl=http://ftp.heanet.ie/pub/centos/7/os/x86_64/
-enabled=1
-gpgcheck=1
-gpgkey=http://ftp.heanet.ie/pub/centos/7/os/x86_64/RPM-GPG-KEY-CentOS-7

--- a/must-gather/collection-scripts/buildconfigs.sh
+++ b/must-gather/collection-scripts/buildconfigs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="buildconfigs"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of buildconfigs"
+
+api_group="build.openshift.io"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/builds.sh
+++ b/must-gather/collection-scripts/builds.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="builds"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of builds"
+
+api_group="build.openshift.io"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+{ timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml; } 2>&1

--- a/must-gather/collection-scripts/ceph_commands.sh
+++ b/must-gather/collection-scripts/ceph_commands.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ceph commands is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ceph commands is not passed. Exiting."
+    exit 0
+fi
+
+# Ceph commands
+ceph_commands=()
+ceph_commands+=("ceph status")
+ceph_commands+=("ceph health detail")
+ceph_commands+=("ceph osd tree")
+ceph_commands+=("ceph osd stat")
+ceph_commands+=("ceph osd dump")
+ceph_commands+=("ceph mon stat")
+ceph_commands+=("ceph mon dump")
+ceph_commands+=("ceph df")
+ceph_commands+=("ceph report")
+ceph_commands+=("ceph osd df tree")
+ceph_commands+=("ceph fs ls")
+ceph_commands+=("ceph pg dump")
+ceph_commands+=("ceph osd crush show-tunables")
+ceph_commands+=("ceph osd crush dump")
+ceph_commands+=("ceph mgr dump")
+ceph_commands+=("ceph mds stat")
+ceph_commands+=("ceph versions")
+ceph_commands+=("ceph fs dump")
+ceph_commands+=("ceph auth list")
+
+# Ceph volume commands
+ceph_volume_commands+=()
+ceph_volume_commands+=("ceph-volume lvm list")
+
+ceph_commands_output_dir="${base_collection_path}/must_gather_commands"
+mkdir -p "${ceph_commands_output_dir}"
+ceph_commands_json_output_dir="${ceph_commands_output_dir}/json_output"
+mkdir -p "${ceph_commands_json_output_dir}"
+
+# Collecting output of ceph commands
+cpu_numbers=$(nproc 2>/dev/null || echo 4)
+helper_pod_status=$(timeout 120 oc get pods "${HOSTNAME}"-helper -n "${namespace}" -o jsonpath="{.status.phase}")
+if [ "${helper_pod_status}" = "Running" ]; then
+    for ((i = 0; i < ${#ceph_commands[@]}; i++)); do
+        while true; do
+            if [ "$(jobs -rp | wc -l)" -lt "${cpu_numbers}" ]; then break; fi
+            sleep 3
+        done
+        printf " -> Fetching output for '%s' from %s pod\n"  "${ceph_commands[$i]}" "${HOSTNAME}-helper"
+        ceph_command_output_file=${ceph_commands_output_dir}/${ceph_commands[$i]// /_}
+        ceph_command_json_output_file=${ceph_commands_json_output_dir}/${ceph_commands[$i]// /_}_--format_json-pretty
+        { timeout 120 oc -n "${namespace}" exec  "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15"  >> "${ceph_command_output_file}"; } 2>/dev/null &
+        { timeout 120 oc -n "${namespace}" exec  "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15 --format json-pretty" >> "${ceph_command_json_output_file}"; } 2>/dev/null & 
+    done
+fi
+wait
+
+# Collecting output of ceph volume commands
+for ((i = 0; i < ${#ceph_volume_commands[@]}; i++)); do
+    for osd_pod in $(timeout 120 oc get pods -n "${namespace}" -l app=rook-ceph-osd --no-headers | grep -w "Running" | awk '{print $1}'); do
+        while true; do
+            if [ "$(jobs -rp | wc -l)" -lt "${cpu_numbers}" ]; then break; fi
+            sleep 3
+        done
+        printf " -> Fetching output for '%s' from %s pod\n"  "${ceph_volume_commands[$i]}" "${osd_pod}"
+        ceph_volume_command_output_file=${COMMAND_OUTPUT_DIR}/${ceph_volume_commands[$i]// /_}
+        { timeout 120 oc -n "${namespace}" exec "${osd_pod}" -- bash -c "${ceph_volume_commands[$i]}" >> "${ceph_volume_command_output_file}"; } 2>/dev/null &
+    done
+done
+wait
+
+# Collecting ceph prepare volume logs
+for node in $(timeout 120 oc get nodes -l cluster.ocs.openshift.io/openshift-storage='' --no-headers | grep -w 'Ready' | awk '{print $1}'); do
+    while true; do
+        if [ "$(jobs -rp | wc -l)" -lt "${cpu_numbers}" ]; then break; fi
+        sleep 3
+    done
+    printf " -> Fetching prepare volume logs from node: %s \n"  "${node}"
+    node_output_collection_path=${base_collection_path}/osd_prepare_volume_logs/${node}
+    mkdir -p "${node_output_collection_path}"
+    { timeout 120 oc debug  nodes/"${node}" -- bash -c "test -f /host/var/lib/rook/log/${namespace}/ceph-volume.log && cat /host/var/lib/rook/log/${namespace}/ceph-volume.log" > "${node_output_collection_path}"/ceph-volume.log; } 2>/dev/null &
+done
+wait

--- a/must-gather/collection-scripts/cephblockpools.sh
+++ b/must-gather/collection-scripts/cephblockpools.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+resource="cephblockpools"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf ${resource}-collector.sh
+
+api_group="ceph.rook.io"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+
+
+# Collection jsonpath
+collection_jsonpath="{range .items[*]}"
+collection_jsonpath="${collection_jsonpath}echo ' -> Fetching dump for {@.metadata.name} cephblockpool';"
+collection_jsonpath="${collection_jsonpath}timeout 120 oc get -n ${namespace} ${resource} {@.metadata.name} -o yaml > "
+collection_jsonpath="${collection_jsonpath}${base_collection_path}/{@.metadata.name}.yaml;"
+collection_jsonpath="${collection_jsonpath}{end}"
+
+# echo $collection_jsonpath   
+
+# Generating the collector script
+timeout 120 oc get ${resource} -n "${namespace}" -o jsonpath="${collection_jsonpath}" >> ${resource}-collector.sh
+
+# Executing the collector script
+chmod +x ${resource}-collector.sh
+./${resource}-collector.sh
+rm ${resource}-collector.sh

--- a/must-gather/collection-scripts/cephclusters.sh
+++ b/must-gather/collection-scripts/cephclusters.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+resource="cephclusters"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf ${resource}-collector.sh
+
+api_group="ceph.rook.io"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+
+
+# Collection jsonpath
+collection_jsonpath="{range .items[*]}"
+collection_jsonpath="${collection_jsonpath}echo ' -> Fetching dump for {@.metadata.name} cephcluster';"
+collection_jsonpath="${collection_jsonpath}timeout 120 oc get -n ${namespace} ${resource} {@.metadata.name} -o yaml > "
+collection_jsonpath="${collection_jsonpath}${base_collection_path}/{@.metadata.name}.yaml;"
+collection_jsonpath="${collection_jsonpath}{end}"
+
+# echo $collection_jsonpath   
+
+# Generating the collector script
+timeout 120 oc get ${resource} -n "${namespace}" -o jsonpath="${collection_jsonpath}" >> ${resource}-collector.sh
+
+# Executing the collector script
+chmod +x ${resource}-collector.sh
+./${resource}-collector.sh
+rm ${resource}-collector.sh

--- a/must-gather/collection-scripts/cephfilesystems.sh
+++ b/must-gather/collection-scripts/cephfilesystems.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+resource="cephfilesystems"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf ${resource}-collector.sh
+
+api_group="ceph.rook.io"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+
+
+# Collection jsonpath
+collection_jsonpath="{range .items[*]}"
+collection_jsonpath="${collection_jsonpath}echo ' -> Fetching dump for {@.metadata.name} cephfilesystem';"
+collection_jsonpath="${collection_jsonpath}timeout 120 oc get -n ${namespace} ${resource} {@.metadata.name} -o yaml > "
+collection_jsonpath="${collection_jsonpath}${base_collection_path}/{@.metadata.name}.yaml;"
+collection_jsonpath="${collection_jsonpath}{end}"
+
+# echo $collection_jsonpath   
+
+# Generating the collector script
+timeout 120 oc get ${resource} -n "${namespace}" -o jsonpath="${collection_jsonpath}" >> ${resource}-collector.sh
+
+# Executing the collector script
+chmod +x ${resource}-collector.sh
+./${resource}-collector.sh
+rm ${resource}-collector.sh

--- a/must-gather/collection-scripts/cephobjectstores.sh
+++ b/must-gather/collection-scripts/cephobjectstores.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+resource="cephobjectstores"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf ${resource}-collector.sh
+
+api_group="ceph.rook.io"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+
+
+# Collection jsonpath
+collection_jsonpath="{range .items[*]}"
+collection_jsonpath="${collection_jsonpath}echo ' -> Fetching dump for {@.metadata.name} cephobjectstore';"
+collection_jsonpath="${collection_jsonpath}timeout 120 oc get -n ${namespace} ${resource} {@.metadata.name} -o yaml > "
+collection_jsonpath="${collection_jsonpath}${base_collection_path}/{@.metadata.name}.yaml;"
+collection_jsonpath="${collection_jsonpath}{end}"
+
+# echo $collection_jsonpath   
+
+# Generating the collector script
+timeout 120 oc get ${resource} -n "${namespace}" -o jsonpath="${collection_jsonpath}" >> ${resource}-collector.sh
+
+# Executing the collector script
+chmod +x ${resource}-collector.sh
+./${resource}-collector.sh
+rm ${resource}-collector.sh

--- a/must-gather/collection-scripts/cephobjectstoreusers.sh
+++ b/must-gather/collection-scripts/cephobjectstoreusers.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+resource="cephobjectstoreusers"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf ${resource}-collector.sh
+
+api_group="ceph.rook.io"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+
+
+# Collection jsonpath
+collection_jsonpath="{range .items[*]}"
+collection_jsonpath="${collection_jsonpath}echo ' -> Fetching dump for {@.metadata.name} cephobjectstoreuser';"
+collection_jsonpath="${collection_jsonpath}timeout 120 oc get -n ${namespace} ${resource} {@.metadata.name} -o yaml > "
+collection_jsonpath="${collection_jsonpath}${base_collection_path}/{@.metadata.name}.yaml;"
+collection_jsonpath="${collection_jsonpath}{end}"
+
+# echo $collection_jsonpath   
+
+# Generating the collector script
+timeout 120 oc get ${resource} -n "${namespace}" -o jsonpath="${collection_jsonpath}" >> ${resource}-collector.sh
+
+# Executing the collector script
+chmod +x ${resource}-collector.sh
+./${resource}-collector.sh
+rm ${resource}-collector.sh

--- a/must-gather/collection-scripts/clusterserviceversion.sh
+++ b/must-gather/collection-scripts/clusterserviceversion.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="clusterserviceversion"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of clusterserviceversions"
+
+api_group="operators.coreos.com"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/configmaps.sh
+++ b/must-gather/collection-scripts/configmaps.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+resource="configmaps"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf collector.sh
+
+echo " -> Fetching dump of configmaps"
+
+api_group="core"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/cronjobs.sh
+++ b/must-gather/collection-scripts/cronjobs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="cronjobs"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of cronjobs"
+
+api_group="batch"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/daemonsets.sh
+++ b/must-gather/collection-scripts/daemonsets.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="daemonsets"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of daemonsets"
+
+api_group="apps"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/deploymentconfigs.sh
+++ b/must-gather/collection-scripts/deploymentconfigs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="deploymentconfigs"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of deploymentconfigs"
+
+api_group="apps.openshift.io"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/deployments.sh
+++ b/must-gather/collection-scripts/deployments.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="deployments"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of deployments"
+
+api_group="apps"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/events.sh
+++ b/must-gather/collection-scripts/events.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+resource="events"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf collector.sh
+
+echo " -> Fetching dump of events"
+
+api_group="core"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -2,14 +2,15 @@
 BASE_COLLECTION_PATH="/must-gather"
 mkdir -p ${BASE_COLLECTION_PATH}
 
-echo "Collecting operator pod logs"
+echo " -> Fetching operator pod logs"
 operatorPodLogCollectionPath="${BASE_COLLECTION_PATH}/namespaces"
-operatorPodLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name};oc logs {@.metadata.name}  --all-containers -n {@.metadata.namespace} &> ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name}/{@.metadata.name}.log;{end}"
-operatorPodPreviousLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name};oc logs {@.metadata.name} -p --all-containers -n {@.metadata.namespace} &> ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name}/{@.metadata.name}-previous.log;{end}"
-oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}" >> collector.sh
-oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}" >> collector.sh
-oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}" >> collector.sh
-oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}" >> collector.sh
+operatorPodLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name};timeout 120 oc logs {@.metadata.name}  --all-containers -n {@.metadata.namespace} &> ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name}/{@.metadata.name}.log;{end}"
+operatorPodPreviousLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name};timeout 120 oc logs {@.metadata.name} -p --all-containers -n {@.metadata.namespace} &> ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name}/{@.metadata.name}-previous.log;{end}"
+
+{ timeout 120 oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}" >> collector.sh; } > /dev/null 2>&1
+{ timeout 120 oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}" >> collector.sh; } > /dev/null 2>&1
+{ timeout 120 oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}" >> collector.sh; } > /dev/null 2>&1
+{ timeout 120 oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}" >> collector.sh; } > /dev/null 2>&1
 chmod +x collector.sh
 ./collector.sh
 # Resource List
@@ -24,8 +25,9 @@ resources+=(objectbuckets)
 # Add general resources to list if necessary 
 
 # Run the Collection of Resources using must-gather
-for resource in ${resources[@]}; do
-    oc adm --dest-dir=${BASE_COLLECTION_PATH} inspect ${resource} --all-namespaces
+for resource in "${resources[@]}"; do
+    echo " -> Fetching dump for ${resource}"
+    { timeout 120 oc adm --dest-dir=${BASE_COLLECTION_PATH} inspect "${resource}" --all-namespaces ;} > /dev/null 2>&1
 done
 
 # Call other gather scripts

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -6,7 +6,7 @@ BASE_COLLECTION_PATH=$1
 if [ "${BASE_COLLECTION_PATH}" = "" ]; then
     BASE_COLLECTION_PATH=$(pwd)
 fi
-
+  
 CEPH_COLLECTION_PATH="${BASE_COLLECTION_PATH}/ceph"
 POD_TEMPLATE="/templates/pod.template"
 
@@ -18,114 +18,63 @@ safe_replace () {
 
 apply_helper_pod() {
     < ${POD_TEMPLATE} safe_replace "NAMESPACE" "$1" | safe_replace "IMAGE_NAME" "$2" | safe_replace "MUST_GATHER" "$HOSTNAME" > pod_helper.yaml
-    oc apply -f pod_helper.yaml
+    timeout 120 oc apply -f pod_helper.yaml > /dev/null 2>&1
 }
 
-# Ceph resources
-ceph_resources=()
-ceph_resources+=(cephblockpools)
-ceph_resources+=(cephclusters)
-ceph_resources+=(cephfilesystems)
-ceph_resources+=(cephobjectstores)
-ceph_resources+=(cephobjectstoreusers)
-
-# Ceph commands
-ceph_commands=()
-ceph_commands+=("ceph status")
-ceph_commands+=("ceph health detail")
-ceph_commands+=("ceph osd tree")
-ceph_commands+=("ceph osd stat")
-ceph_commands+=("ceph osd dump")
-ceph_commands+=("ceph mon stat")
-ceph_commands+=("ceph mon dump")
-ceph_commands+=("ceph df")
-ceph_commands+=("ceph report")
-ceph_commands+=("ceph osd df tree")
-ceph_commands+=("ceph fs ls")
-ceph_commands+=("ceph pg dump")
-ceph_commands+=("ceph osd crush show-tunables")
-ceph_commands+=("ceph osd crush dump")
-ceph_commands+=("ceph mgr dump")
-ceph_commands+=("ceph mds stat")
-ceph_commands+=("ceph versions")
-ceph_commands+=("ceph fs dump")
-ceph_commands+=("ceph auth list")
-
-# Ceph volume commands
-ceph_volume_commands+=()
-ceph_volume_commands+=("ceph-volume lvm list")
-
-# Inspecting ceph related custom resources for all namespaces 
-for resource in "${ceph_resources[@]}"; do
-    oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces
-done
-
 # Inspecting the namespace where ceph-cluster is installed
-for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}'); do
-    operatorImage=$(oc get pods -l app=rook-ceph-operator -n openshift-storage -o jsonpath="{range .items[*]}{@.spec.containers[0].image}+{end}" | tr "+" "\n" | head -n1)
+for ns in $(timeout 120 oc get cephcluster --all-namespaces --no-headers | awk '{print $1}'); do
+    CEPH_NS_COLLECTION_PATH=${CEPH_COLLECTION_PATH}/namespaces/${ns}
+    echo " -> Fetching dump for ${ns} namespace"
+
+    operatorImage=$(timeout 120 oc get pods -l app=rook-ceph-operator -n openshift-storage -o jsonpath="{range .items[*]}{@.spec.containers[0].image}+{end}" | tr "+" "\n" | head -n1)
     if [ "${operatorImage}" = "" ]; then
         echo "Not able to find the rook's operator image. Skipping collection of ceph command output"  
     else
         apply_helper_pod "$ns" "$operatorImage"
     fi
-    
 
-    oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect ns/"${ns}"
-    oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect csv -n "${ns}"
-    # collecting non running pods
-    for npod in $(oc get pods --field-selector=status.phase!=Running --no-headers -n "${ns}" | awk '{print $1}'); do
-      { oc get pods "${npod}" -n "${ns}" -o jsonpath="{range @.spec.initContainers[*]}mkdir -p ${CEPH_COLLECTION_PATH}/namespaces/${ns}/pods/${npod}/{@.name}/{@.name}/logs;oc logs ${npod} -n ${ns} -c {@.name} >> ${CEPH_COLLECTION_PATH}/namespaces/${ns}/pods/${npod}/{@.name}/{@.name}/logs/current.log;{end}"; oc get pods "${npod}" -n "${ns}" -o jsonpath="{range @.spec.initContainers[*]}mkdir -p ${CEPH_COLLECTION_PATH}/namespaces/${ns}/pods/${npod}/{@.name}/{@.name}/logs;oc logs -p ${npod} -n ${ns} -c {@.name} >> ${CEPH_COLLECTION_PATH}/namespaces/${ns}/pods/${npod}/{@.name}/{@.name}/logs/previous.log;{end}"; } >> pod_collector.sh
-      { oc get pods "${npod}" -n "${ns}" -o jsonpath="{range @.spec.containers[*]}mkdir -p ${CEPH_COLLECTION_PATH}/namespaces/${ns}/pods/${npod}/{@.name}/{@.name}/logs;oc logs ${npod} -n ${ns} -c {@.name} >> ${CEPH_COLLECTION_PATH}/namespaces/${ns}/pods/${npod}/{@.name}/{@.name}/logs/current.log;{end}"; oc get pods "${npod}" -n "${ns}" -o jsonpath="{range @.spec.containers[*]}mkdir -p ${CEPH_COLLECTION_PATH}/namespaces/${ns}/pods/${npod}/{@.name}/{@.name}/logs;oc logs -p ${npod} -n ${ns} -c {@.name} >> ${CEPH_COLLECTION_PATH}/namespaces/${ns}/pods/${npod}/{@.name}/{@.name}/logs/previous.log;{end}"; } >> pod_collector.sh
-    done
-    chmod +x pod_collector.sh
-    ./pod_collector.sh
-    rm -rf pod_collector.sh
-   
-    COMMAND_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/namespaces/${ns}/must_gather_commands
-    COMMAND_JSON_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/namespaces/${ns}/must_gather_commands/json_output
-    mkdir -p "${COMMAND_OUTPUT_DIR}"
-    mkdir -p "${COMMAND_JSON_OUTPUT_DIR}"
+    # Registering ceph collection scripts for dump collection
+    cephblockpools.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    cephclusters.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    cephfilesystems.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    cephobjectstores.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    cephobjectstoreusers.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+
+    # Registering openshift collection scripts for dump collection
+    pods.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    configmaps.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    events.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    persistentvolumeclaims.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    secrets.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    services.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    replicationcontrollers.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    deploymentconfigs.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    daemonsets.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    replicasets.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    statefulsets.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    horizontalpodautoscalers.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    cronjobs.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    jobs.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    buildconfigs.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    builds.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    imagestreams.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    routes.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    deployments.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+    clusterserviceversion.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
 
     if [ "${operatorImage}" != "" ]; then
         for i in {1..50}
         do
-            if [ "$(oc get pods  "${HOSTNAME}"-helper -n "${ns}" -o jsonpath='{.status.phase}')" = "Running" ]; then
-                echo "Helper pod got deployed successfully."
+            if [ "$(timeout 120 oc get pods  "${HOSTNAME}"-helper -n "${ns}" -o jsonpath='{.status.phase}')" = "Running" ]; then
+                echo " -> Helper pod got deployed successfully for ${ns} namespace"
                 break
             fi
-            echo "Waiting for helper pod to come up in ${ns} namespace. Retrying ${i}"
+            echo " -> Waiting for helper pod to come up in ${ns} namespace. Retrying ${i}"
             sleep 5
         done
-
-        # Collecting output of ceph commands
-        for ((i = 0; i < ${#ceph_commands[@]}; i++)); do
-            printf "collecting command output for: %s\n"  "${ceph_commands[$i]}"
-            COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_commands[$i]// /_}
-            oc -n "${ns}" exec --request-timeout=60 "${HOSTNAME}"-helper -- ${ceph_commands[$i]} --connect-timeout=15 >> "${COMMAND_OUTPUT_FILE}"
-            JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${ceph_commands[$i]// /_}_--format_json-pretty
-            oc -n "${ns}" exec --request-timeout=60 "${HOSTNAME}"-helper -- ${ceph_commands[$i]} --connect-timeout=15 --format json-pretty >> "${JSON_COMMAND_OUTPUT_FILE}"
-        done
-    fi
-
-    # Collecting output of ceph volume commands
-    for ((i = 0; i < ${#ceph_volume_commands[@]}; i++)); do
-        printf "collecting command output for: %s\n"  "${ceph_volume_commands[$i]}"
-        for osdPod in $(oc get pods -n "${ns}" -l app=rook-ceph-osd --no-headers | awk '{print $1}'); do
-            pod_status=$(oc get po "${osdPod}" -n "${ns}" -o jsonpath='{.status.phase}')
-            if [ "${pod_status}" != "Running" ]; then
-                continue
-            fi
-            COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_volume_commands[$i]// /_}
-            oc -n "${ns}" exec --request-timeout=60 "${osdPod}" -- ${ceph_volume_commands[$i]} >> "${COMMAND_OUTPUT_FILE}"
-        done
-    done
-    
-    # Collecting ceph prepare volume logs
-    for node in $(oc get nodes -l cluster.ocs.openshift.io/openshift-storage='' --no-headers | grep -w 'Ready' | awk '{print $1}'); do
-        printf "collecting prepare volume logs from node %s \n"  "${node}"
-        NODE_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/namespaces/${ns}/osd_prepare_volume_logs/${node}
-        mkdir -p "${NODE_OUTPUT_DIR}"
-        oc debug  nodes/"${node}" -- bash -c "test -f /host/var/lib/rook/log/${ns}/ceph-volume.log && cat /host/var/lib/rook/log/${ns}/ceph-volume.log" > "${NODE_OUTPUT_DIR}"/ceph-volume.log
-    done
-    oc delete -f pod_helper.yaml
+        ceph_commands.sh "${CEPH_NS_COLLECTION_PATH}" "${ns}"
+        echo " -> Deleting helper pod for ${ns} namespace"
+        timeout 120 oc delete -f pod_helper.yaml > /dev/null 2>&1
+    fi    
 done
+

--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 
@@ -9,7 +8,7 @@ if [ "${BASE_COLLECTION_PATH}" = "" ]; then
 fi
 
 NOOBAA_COLLLECTION_PATH="${BASE_COLLECTION_PATH}/noobaa"
-mkdir -p ${NOOBAA_COLLLECTION_PATH}
+mkdir -p "${NOOBAA_COLLLECTION_PATH}"
 
 noobaa_resources=()
 
@@ -18,19 +17,21 @@ noobaa_resources+=(backingstore)
 noobaa_resources+=(bucketclass)
 
 # Run the Collection of NooBaa Resources using must-gather
-for resource in ${noobaa_resources[@]}; do
-    oc adm --dest-dir=${NOOBAA_COLLLECTION_PATH} inspect ${resource} --all-namespaces
+for resource in "${noobaa_resources[@]}"; do
+    echo " -> Fetching dump for ${resource}"
+    timeout 120 oc adm --dest-dir="${NOOBAA_COLLLECTION_PATH}" inspect "${resource}" --all-namespaces > /dev/null 2>&1
 done
 
 # Collect logs for all noobaa pods using oc logs
 # get all namespaces that contain any noobaa pod
 NOOBAA_PODS_LABEL='app in (noobaa)'
-for ns in $(oc get pod --all-namespaces -l "${NOOBAA_PODS_LABEL}" | grep -v NAMESPACE | awk '{print $1}' | uniq)
+for ns in $(timeout 120 oc get pod --all-namespaces -l "${NOOBAA_PODS_LABEL}" | grep -v NAMESPACE | awk '{print $1}' | uniq)
 do
     #get logs for all pods with label app=noobaa
-    for pod in $(oc -n ${ns} get pod -l "${NOOBAA_PODS_LABEL}" | grep -v NAME | awk '{print $1}'); do
+    for pod in $(timeout 120 oc -n "${ns}" get pod -l "${NOOBAA_PODS_LABEL}" | grep -v NAME | awk '{print $1}'); do
         LOG_DIR=${NOOBAA_COLLLECTION_PATH}/logs/${ns}
-        mkdir -p ${LOG_DIR}
-        oc -n ${ns} logs --all-containers ${pod} &> ${LOG_DIR}/${pod}.log
+        mkdir -p "${LOG_DIR}"
+        echo " -> Fetching ${pod} pod logs"
+        { timeout 120 oc -n "${ns}" logs --all-containers "${pod}" &> "${LOG_DIR}"/"${pod}".log; } > /dev/null 2>&1
     done
 done

--- a/must-gather/collection-scripts/horizontalpodautoscalers.sh
+++ b/must-gather/collection-scripts/horizontalpodautoscalers.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="horizontalpodautoscalers"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of horizontalpodautoscalers"
+
+api_group="autoscaling"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/imagestreams.sh
+++ b/must-gather/collection-scripts/imagestreams.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="imagestreams"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of imagestreams"
+
+api_group="image.openshift.io"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/jobs.sh
+++ b/must-gather/collection-scripts/jobs.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="jobs"
+alias
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of jobs"
+
+api_group="batch"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/persistentvolumeclaims.sh
+++ b/must-gather/collection-scripts/persistentvolumeclaims.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+resource="persistentvolumeclaims"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf collector.sh
+
+echo " -> Fetching dump of persistentvolumeclaims"
+
+api_group="core"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/pods.sh
+++ b/must-gather/collection-scripts/pods.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+resource="pods"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf collector.sh
+
+api_group="core"
+if [ "${api_group}" != "" ]; then 
+    core_base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+core_base_collection_path="${core_base_collection_path}/${resource}"
+mkdir -p "${core_base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${core_base_collection_path}"/${resource}.yaml 2>&1
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+
+function dump_pod {
+    pod_name=${1}
+    touch "${pod_name}"-init-collector.sh && chmod +x "${pod_name}"-init-collector.sh        
+    touch "${pod_name}"-collector.sh && chmod +x "${pod_name}"-collector.sh
+    # Executing the collector script
+
+    # Collection jsonpath for init containers
+    initcontainer_collection_jsonpath="{range @.spec.initContainers[*]}"
+    initcontainer_collection_jsonpath="${initcontainer_collection_jsonpath}mkdir -p ${base_collection_path}/${pod_name}/{@.name}/logs && "
+    initcontainer_collection_jsonpath="${initcontainer_collection_jsonpath}timeout 120 oc logs ${pod_name} -n ${namespace} -c {@.name} > ${base_collection_path}/${pod_name}/{@.name}/logs/current.log 2>&1 & "
+    initcontainer_collection_jsonpath="${initcontainer_collection_jsonpath}mkdir -p ${base_collection_path}/${pod_name}/{@.name}/logs && "
+    initcontainer_collection_jsonpath="${initcontainer_collection_jsonpath}timeout 120 oc logs -p ${pod_name} -n ${namespace} -c {@.name} > ${base_collection_path}/${pod_name}/{@.name}/logs/previous.log 2>&1 & "
+    initcontainer_collection_jsonpath="${initcontainer_collection_jsonpath}{end}"
+    
+    # Collection jsonpath for containers
+    container_collection_jsonpath="{range @.spec.containers[*]}"
+    container_collection_jsonpath="${container_collection_jsonpath}mkdir -p ${base_collection_path}/${pod_name}/{@.name}/logs && "
+    container_collection_jsonpath="${container_collection_jsonpath}timeout 120 oc logs ${pod_name} -n ${namespace} -c {@.name} > ${base_collection_path}/${pod_name}/{@.name}/logs/current.log 2>&1 & "
+    container_collection_jsonpath="${container_collection_jsonpath}mkdir -p ${base_collection_path}/${pod_name}/{@.name}/logs && "
+    container_collection_jsonpath="${container_collection_jsonpath}timeout 120 oc logs -p ${pod_name} -n ${namespace} -c {@.name} > ${base_collection_path}/${pod_name}/{@.name}/logs/previous.log 2>&1 & "
+    container_collection_jsonpath="${container_collection_jsonpath}{end}"
+
+    timeout 120 oc get pods "${pod_name}" -n "${namespace}" -o jsonpath="${initcontainer_collection_jsonpath}" >> "${pod_name}"-init-collector.sh & 
+    timeout 120 oc get pods "${pod_name}" -n "${namespace}" -o jsonpath="${container_collection_jsonpath}" >> "${pod_name}"-collector.sh &
+    wait
+    echo "wait" >> "${pod_name}"-init-collector.sh
+    echo "wait" >> "${pod_name}"-collector.sh
+    ./"${pod_name}"-init-collector.sh &
+    ./"${pod_name}"-collector.sh &
+    wait
+    rm "${pod_name}"-init-collector.sh
+    rm "${pod_name}"-collector.sh
+}
+
+# Generating the collector script
+cpu_numbers=$(nproc 2>/dev/null || echo 4)
+for pod in $(timeout 120 oc get pods --no-headers -n "${namespace}" | awk '{print $1}'); do
+    while true; do
+        if [ "$(jobs -rp | wc -l)" -lt "${cpu_numbers}" ]; then break; fi
+        sleep 3
+    done
+    echo " -> Fetching dump for ${pod} pod"
+    mkdir -p "${base_collection_path}"/"${pod}"
+    timeout 120 oc get ${resource} "${pod}" -n "${namespace}" -o yaml > "${base_collection_path}"/"${pod}"/"${pod}".yaml 2>&1 &
+    timeout 120 oc describe ${resource} "${pod}" -n "${namespace}" > "${base_collection_path}"/"${pod}"/describe.yaml 2>&1 &
+    dump_pod "${pod}" &
+done
+wait

--- a/must-gather/collection-scripts/replicasets.sh
+++ b/must-gather/collection-scripts/replicasets.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="replicasets"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of replicasets"
+
+api_group="apps"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/replicationcontrollers.sh
+++ b/must-gather/collection-scripts/replicationcontrollers.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+resource="replicationcontrollers"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf collector.sh
+
+echo " -> Fetching dump of replicationcontrollers"
+
+api_group="core"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/routes.sh
+++ b/must-gather/collection-scripts/routes.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="routes"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of routes"
+
+api_group="route.openshift.io"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/secrets.sh
+++ b/must-gather/collection-scripts/secrets.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+resource="secrets"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of secrets"
+
+api_group="core"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/services.sh
+++ b/must-gather/collection-scripts/services.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+resource="services"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+# removing previous collector files
+rm -rf collector.sh
+
+echo " -> Fetching dump of services"
+
+api_group="core"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+base_collection_path="${base_collection_path}/${resource}"
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1

--- a/must-gather/collection-scripts/statefulsets.sh
+++ b/must-gather/collection-scripts/statefulsets.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+resource="statefulsets"
+
+base_collection_path=$1
+namespace=$2
+if [ "${base_collection_path}" = "" ];then
+    echo "Base collection path for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+if [ "${namespace}" = "" ];then
+    echo "Namespace for ${resource} is not passed. Exiting."
+    exit 0
+fi
+
+echo " -> Fetching dump of statefulsets"
+
+api_group="apps"
+if [ "${api_group}" != "" ]; then 
+    base_collection_path="${base_collection_path}/${api_group}"
+fi
+
+mkdir -p "${base_collection_path}"
+timeout 120 oc get ${resource} -n "${namespace}" -o yaml > "${base_collection_path}"/${resource}.yaml 2>&1


### PR DESCRIPTION
This commit removes the dependency of OCP's must-gather as OCP's must-gather client doesn't collect logs for the non-running pods. This PR changes OCS must-gather to use oc CLI for collecting the dump.
-> This PR also implements multithreading for collecting pod logs in ocs-must-gather which will help execution faster.
-> This PR also adds a more granular level of logging in the must-gather scripts.
-> This PR also adds a timeout of 120s for each `oc` call which ensures that must-gather is not stuck if due to network failure.

Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>