### PR TITLE
Bug 1766646: must-gather: some current.log files remains empty

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -32,4 +32,5 @@ done
 gather_noobaa_resources ${BASE_COLLECTION_PATH}
 gather_ceph_resources ${BASE_COLLECTION_PATH}
 
+find "${BASE_COLLECTION_PATH}" -empty -delete
 exit 0


### PR DESCRIPTION
This commit modifies must-gather to remove collection of empty files and directories from the dump collected.

BackPort of PR: https://github.com/openshift/ocs-operator/pull/322

Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>