### PR TITLE
Bug 1775567: must-gather stuck at "Collecting operator pod logs"

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -6,10 +6,12 @@ echo "Collecting operator pod logs"
 operatorPodLogCollectionPath="${BASE_COLLECTION_PATH}/namespaces"
 operatorPodLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name};oc logs {@.metadata.name}  --all-containers -n {@.metadata.namespace} &> ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name}/{@.metadata.name}.log;{end}"
 operatorPodPreviousLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name};oc logs {@.metadata.name} -p --all-containers -n {@.metadata.namespace} &> ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name}/{@.metadata.name}-previous.log;{end}"
-oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}" >> collector.sh
-oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}" >> collector.sh
-oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}" >> collector.sh
-oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}" >> collector.sh
+{
+    timeout 120 oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}";
+    timeout 120 oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}";
+    timeout 120 oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}";
+    timeout 120 oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}";
+} >> collector.sh
 chmod +x collector.sh
 ./collector.sh
 # Resource List
@@ -24,8 +26,9 @@ resources+=(objectbuckets)
 # Add general resources to list if necessary 
 
 # Run the Collection of Resources using must-gather
-for resource in ${resources[@]}; do
-    openshift-must-gather --base-dir=${BASE_COLLECTION_PATH} inspect ${resource} --all-namespaces
+for resource in "${resources[@]}"; do
+    echo "Collection dump of ${resource}"
+    timeout 120 openshift-must-gather --base-dir=${BASE_COLLECTION_PATH} inspect "${resource}" --all-namespaces
 done
 
 # Call other gather scripts

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -57,7 +57,8 @@ ceph_volume_commands+=("ceph-volume lvm list")
 
 # Inspecting ceph related custom resources for all namespaces 
 for resource in "${ceph_resources[@]}"; do
-    openshift-must-gather --base-dir=${CEPH_COLLECTION_PATH} inspect ${resource} --all-namespaces
+    echo "Collecting dump ${resource}"
+    timeout 120 openshift-must-gather --base-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces
 done
 
 # Inspecting the namespace where ceph-cluster is installed
@@ -68,10 +69,11 @@ for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}')
     else
         apply_helper_pod $ns $operatorImage
     fi
-
-    openshift-must-gather --base-dir=${CEPH_COLLECTION_PATH} inspect ns/${ns}
-    openshift-must-gather --base-dir=${CEPH_COLLECTION_PATH} inspect csv -n ${ns}
     
+    echo "Collecting dump of namespace"
+    timeout 120 openshift-must-gather --base-dir="${CEPH_COLLECTION_PATH}" inspect ns/"${ns}" 
+    echo "Collecting dump of clusterresourceversion"
+    timeout 120 openshift-must-gather --base-dir="${CEPH_COLLECTION_PATH}" inspect csv -n "${ns}"
     # collecting non running pods
     for npod in $(oc get pods --field-selector=status.phase!=Running --no-headers -n ${ns} | awk '{print $1}'); do
       oc get pods ${npod} -n ${ns} -o jsonpath="{range @.spec.initContainers[*]}mkdir -p ${CEPH_COLLECTION_PATH}/namespaces/${ns}/pods/${npod}/{@.name}/{@.name}/logs;oc logs ${npod} -n ${ns} -c {@.name} >> ${CEPH_COLLECTION_PATH}/namespaces/${ns}/pods/${npod}/{@.name}/{@.name}/logs/current.log;{end}" >> pod_collector.sh
@@ -103,9 +105,9 @@ for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}')
         for ((i = 0; i < ${#ceph_commands[@]}; i++)); do
             printf "collecting command output for: %s\n"  "${ceph_commands[$i]}"
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_commands[$i]// /_}
-            oc -n ${ns} exec --request-timeout=60 ${HOSTNAME}-helper -- ${ceph_commands[$i]} --connect-timeout=15 >> ${COMMAND_OUTPUT_FILE}
             JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${ceph_commands[$i]// /_}_--format_json-pretty
-            oc -n ${ns} exec --request-timeout=60 ${HOSTNAME}-helper -- ${ceph_commands[$i]} --connect-timeout=15 --format json-pretty >> ${JSON_COMMAND_OUTPUT_FILE}
+            timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- "${ceph_commands[$i]}" --connect-timeout=15 >> "${COMMAND_OUTPUT_FILE}" 2>/dev/null
+            timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- "${ceph_commands[$i]}" --connect-timeout=15 --format json-pretty >> "${JSON_COMMAND_OUTPUT_FILE}" 2>/dev/null
         done
     fi
 
@@ -118,7 +120,7 @@ for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}')
                 continue
             fi
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_volume_commands[$i]// /_}
-            oc -n ${ns} exec --request-timeout=60 ${osdPod} -- ${ceph_volume_commands[$i]} >> ${COMMAND_OUTPUT_FILE}
+            timeout 120 oc -n "${ns}" exec "${osdPod}" -- ${ceph_volume_commands[$i]} >> "${COMMAND_OUTPUT_FILE}" 2>/dev/null
         done
     done
     
@@ -126,8 +128,8 @@ for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}')
     for node in $(oc get nodes -l cluster.ocs.openshift.io/openshift-storage='' --no-headers | grep -w 'Ready' | awk '{print $1}'); do
         printf "collecting prepare volume logs from node %s \n"  "${node}"
         NODE_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/namespaces/${ns}/osd_prepare_volume_logs/${node}
-        mkdir -p ${NODE_OUTPUT_DIR}
-        oc debug nodes/${node} -- bash -c "test -f /host/var/lib/rook/log/${ns}/ceph-volume.log && cat /host/var/lib/rook/log/${ns}/ceph-volume.log" > ${NODE_OUTPUT_DIR}/ceph-volume.log
+        mkdir -p "${NODE_OUTPUT_DIR}"
+        timeout 120 oc debug nodes/"${node}" -- bash -c "test -f /host/var/lib/rook/log/${ns}/ceph-volume.log && cat /host/var/lib/rook/log/${ns}/ceph-volume.log" > "${NODE_OUTPUT_DIR}"/ceph-volume.log 2>/dev/null
     done
     oc delete -f pod_helper.yaml
 done

--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -18,8 +18,9 @@ noobaa_resources+=(backingstore)
 noobaa_resources+=(bucketclass)
 
 # Run the Collection of NooBaa Resources using must-gather
-for resource in ${noobaa_resources[@]}; do
-    openshift-must-gather --base-dir=${NOOBAA_COLLLECTION_PATH} inspect ${resource} --all-namespaces
+for resource in "${noobaa_resources[@]}"; do
+    echo "Collecting dump of ${resource}"
+    timeout 120 openshift-must-gather --base-dir=${NOOBAA_COLLLECTION_PATH} inspect ${resource} --all-namespaces
 done
 
 # Collect logs for all noobaa pods using oc logs
@@ -31,6 +32,6 @@ do
     for pod in $(oc -n ${ns} get pod -l "${NOOBAA_PODS_LABEL}" | grep -v NAME | awk '{print $1}'); do
         LOG_DIR=${NOOBAA_COLLLECTION_PATH}/logs/${ns}
         mkdir -p ${LOG_DIR}
-        oc -n ${ns} logs --all-containers ${pod} &> ${LOG_DIR}/${pod}.log
+        timeout 120 oc -n ${ns} logs --all-containers ${pod} &> ${LOG_DIR}/${pod}.log
     done
 done


### PR DESCRIPTION
This commit adds timeouts to `oc` invokes which makes sure that must-gather is not stuck due to network failure and improves logging of the must-gather.

BackPort of PR #327
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>