### PR TITLE
Add more resources to RGW #334

### DIFF
--- a/pkg/controller/defaults/resources.go
+++ b/pkg/controller/defaults/resources.go
@@ -41,12 +41,12 @@ var (
 		},
 		"rgw": corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
-				corev1.ResourceMemory: resource.MustParse("2Gi"),
+				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 		},
 		"mgr": corev1.ResourceRequirements{


### PR DESCRIPTION
This change changes the resources for the 'rgw' pod from 1 CPU / 2Gi memory to 2 CPUs / 4Gi memory.
solves https://github.com/openshift/ocs-operator/issues/334