### PR TITLE
enhance(must-gather): updates scripts to collect logs in a debug.log

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.1.0
 	github.com/go-openapi/spec v0.19.2
-	github.com/go-openapi/validate v0.18.0 // indirect
 	github.com/noobaa/noobaa-operator/v2 v2.0.8
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -2,7 +2,7 @@
 BASE_COLLECTION_PATH="/must-gather"
 mkdir -p ${BASE_COLLECTION_PATH}
 
-echo "Collecting operator pod logs"
+echo "collecting operator pod logs" | tee -a  ${BASE_COLLECTION_PATH}/gather-debug.log
 operatorPodLogCollectionPath="${BASE_COLLECTION_PATH}/namespaces"
 operatorPodLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name};oc logs {@.metadata.name}  --all-containers -n {@.metadata.namespace} &> ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name}/{@.metadata.name}.log;{end}"
 operatorPodPreviousLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name};oc logs {@.metadata.name} -p --all-containers -n {@.metadata.namespace} &> ${operatorPodLogCollectionPath}/{@.metadata.namespace}/logs/{@.metadata.name}/{@.metadata.name}-previous.log;{end}"
@@ -11,9 +11,9 @@ operatorPodPreviousLogCollectionJSONPath="{range .items[*]}mkdir -p ${operatorPo
     timeout 120 oc get pods --all-namespaces -l 'name in (local-storage-operator,ocs-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}";
     timeout 120 oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodLogCollectionJSONPath}";
     timeout 120 oc get pods --all-namespaces -l 'app in (noobaa,rook-ceph-operator)' -o jsonpath="${operatorPodPreviousLogCollectionJSONPath}";
-} >> collector.sh
+} >> collector.sh 2>>${BASE_COLLECTION_PATH}/gather-debug.log
 chmod +x collector.sh
-./collector.sh
+{ ./collector.sh; } >> ${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
 # Resource List
 resources=()
 # collect storagecluster resources
@@ -27,13 +27,14 @@ resources+=(objectbuckets)
 
 # Run the Collection of Resources using must-gather
 for resource in "${resources[@]}"; do
-    echo "Collection dump of ${resource}"
-    timeout 120 oc adm --dest-dir=${BASE_COLLECTION_PATH} inspect ${resource} --all-namespaces
+    echo "collecting dump of ${resource}" | tee -a  ${BASE_COLLECTION_PATH}/gather-debug.log
+    { timeout 120 oc adm --dest-dir=${BASE_COLLECTION_PATH} inspect "${resource}" --all-namespaces; } >> ${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
 done
 
 # Call other gather scripts
 gather_noobaa_resources ${BASE_COLLECTION_PATH}
 gather_ceph_resources ${BASE_COLLECTION_PATH}
 
-find "${BASE_COLLECTION_PATH}" -empty -delete
+echo "deleting empty files" >> ${BASE_COLLECTION_PATH}/gather-debug.log
+find "${BASE_COLLECTION_PATH}" -empty -delete >> ${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
 exit 0

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -57,23 +57,23 @@ ceph_volume_commands+=("ceph-volume lvm list")
 
 # Inspecting ceph related custom resources for all namespaces 
 for resource in "${ceph_resources[@]}"; do
-    echo "Collecting dump ${resource}"
-    timeout 120 oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces
+    echo "collecting dump ${resource}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    { timeout 120 oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 # Inspecting the namespace where ceph-cluster is installed
 for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}'); do
     operatorImage=$(oc get pods -l app=rook-ceph-operator -n openshift-storage -o jsonpath="{range .items[*]}{@.spec.containers[0].image}+{end}" | tr "+" "\n" | head -n1)
     if [ "${operatorImage}" = "" ]; then
-        echo "Not able to find the rook's operator image. Skipping collection of ceph command output"  
+        echo "not able to find the rook's operator image. Skipping collection of ceph command output" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
     else
         apply_helper_pod "$ns" "$operatorImage"
     fi
     
-    echo "Collecting dump of namespace"
-    timeout 120 oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect ns/"${ns}" 
-    echo "Collecting dump of clusterresourceversion"
-    timeout 120 oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect csv -n "${ns}"
+    echo "collecting dump of namespace" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    timeout 300 oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect ns/"${ns}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    echo "collecting dump of clusterresourceversion" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    timeout 120 oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect csv -n "${ns}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     # collecting non running pods
     for npod in $(oc get pods --no-headers -n "${ns}" | grep -v -w 'Running' | awk '{print $1}'); do
       {
@@ -86,7 +86,7 @@ for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}')
 
     done
     chmod +x pod_collector.sh
-    ./pod_collector.sh
+    { ./pod_collector.sh; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     rm -rf pod_collector.sh
    
     COMMAND_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/namespaces/${ns}/must_gather_commands
@@ -98,42 +98,42 @@ for ns in $(oc get cephcluster --all-namespaces --no-headers | awk '{print $1}')
         for i in {1..50}
         do
             if [ "$(oc get pods  "${HOSTNAME}"-helper -n "${ns}" -o jsonpath='{.status.phase}')" = "Running" ]; then
-                echo "Helper pod got deployed successfully."
+                echo "helper pod got deployed successfully." | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
                 break
             fi
-            echo "Waiting for helper pod to come up in ${ns} namespace. Retrying ${i}"
+            echo "waiting for helper pod to come up in ${ns} namespace. Retrying ${i}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
             sleep 5
         done
 
         # Collecting output of ceph commands
         for ((i = 0; i < ${#ceph_commands[@]}; i++)); do
-            printf "collecting command output for: %s\n"  "${ceph_commands[$i]}"
+            printf "collecting command output for: %s\n"  "${ceph_commands[$i]}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_commands[$i]// /_}
             JSON_COMMAND_OUTPUT_FILE=${COMMAND_JSON_OUTPUT_DIR}/${ceph_commands[$i]// /_}_--format_json-pretty
-            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15" >> "${COMMAND_OUTPUT_FILE}"; } 2>/dev/null
-            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15 --format json-pretty" >> "${JSON_COMMAND_OUTPUT_FILE}"; } 2>/dev/null
+            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15" >> "${COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15 --format json-pretty" >> "${JSON_COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
         done
     fi
 
     # Collecting output of ceph volume commands
     for ((i = 0; i < ${#ceph_volume_commands[@]}; i++)); do
-        printf "collecting command output for: %s\n"  "${ceph_volume_commands[$i]}"
+        printf "collecting command output for: %s\n"  "${ceph_volume_commands[$i]}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
         for osdPod in $(oc get pods -n "${ns}" -l app=rook-ceph-osd --no-headers | awk '{print $1}'); do
             pod_status=$(oc get po "${osdPod}" -n "${ns}" -o jsonpath='{.status.phase}')
             if [ "${pod_status}" != "Running" ]; then
                 continue
             fi
             COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/${ceph_volume_commands[$i]// /_}
-            { timeout 120 oc -n "${ns}" exec "${osdPod}" -- bash -c "${ceph_volume_commands[$i]}" >> "${COMMAND_OUTPUT_FILE}"; } 2>/dev/null
+            { timeout 120 oc -n "${ns}" exec "${osdPod}" -- bash -c "${ceph_volume_commands[$i]}" >> "${COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
         done
     done
     
     # Collecting ceph prepare volume logs
     for node in $(oc get nodes -l cluster.ocs.openshift.io/openshift-storage='' --no-headers | grep -w 'Ready' | awk '{print $1}'); do
-        printf "collecting prepare volume logs from node %s \n"  "${node}"
+        printf "collecting prepare volume logs from node %s \n"  "${node}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
         NODE_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/namespaces/${ns}/osd_prepare_volume_logs/${node}
         mkdir -p "${NODE_OUTPUT_DIR}"
-        { timeout 120 oc debug nodes/"${node}" -- bash -c "test -f /host/var/lib/rook/log/${ns}/ceph-volume.log && cat /host/var/lib/rook/log/${ns}/ceph-volume.log" > "${NODE_OUTPUT_DIR}"/ceph-volume.log; } 2>/dev/null
+        { timeout 120 oc debug nodes/"${node}" -- bash -c "test -f /host/var/lib/rook/log/${ns}/ceph-volume.log && cat /host/var/lib/rook/log/${ns}/ceph-volume.log" > "${NODE_OUTPUT_DIR}"/ceph-volume.log; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     done
     oc delete -f pod_helper.yaml
 done

--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -19,8 +19,8 @@ noobaa_resources+=(bucketclass)
 
 # Run the Collection of NooBaa Resources using must-gather
 for resource in "${noobaa_resources[@]}"; do
-    echo "Collecting dump of ${resource}"
-    timeout 120 oc adm --dest-dir=${NOOBAA_COLLLECTION_PATH} inspect ${resource} --all-namespaces
+    echo "collecting dump of ${resource}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    { timeout 120 oc adm --dest-dir="${NOOBAA_COLLLECTION_PATH}" inspect "${resource}" --all-namespaces; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 # Collect logs for all noobaa pods using oc logs
@@ -30,8 +30,9 @@ for ns in $(oc get pod --all-namespaces -l "${NOOBAA_PODS_LABEL}" | grep -v NAME
 do
     #get logs for all pods with label app=noobaa
     for pod in $(oc -n ${ns} get pod -l "${NOOBAA_PODS_LABEL}" | grep -v NAME | awk '{print $1}'); do
+        echo "collecting dump of ${pod} pod from ${ns}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
         LOG_DIR=${NOOBAA_COLLLECTION_PATH}/logs/${ns}
         mkdir -p ${LOG_DIR}
-        timeout 120 oc -n ${ns} logs --all-containers ${pod} &> ${LOG_DIR}/${pod}.log
+        { timeout 120 oc -n "${ns}" logs --all-containers "${pod}" &> "${LOG_DIR}"/"${pod}".log; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     done
 done


### PR DESCRIPTION
This commit updates must-gather to redirect unwanted logs must-gather script to a gather-debug.logs file. This reduces the verbosity of must-gather and preserves debugging logs of ocs-must-gather.

Fixes https://github.com/openshift/ocs-operator/issues/330
Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>