### PR TITLE
Adding Testcase to check accuracy of the data

### DIFF
--- a/functests/common.go
+++ b/functests/common.go
@@ -41,11 +41,8 @@ func WaitForJobSucceeded(k8sClient *kubernetes.Clientset, jobName string, jobNam
 			return nil
 		}
 		return fmt.Errorf("Waiting on job %s/%s to succeed when it is currently %d", jobName, jobNamespace, job.Status.Succeeded)
-<<<<<<< HEAD
-	}, 200*time.Second, 1*time.Second).Should(gomega.Succeed())
-=======
-	}, 200*time.Second, 1*time.Second).ShouldNot(gomega.HaveOccurred())
->>>>>>> 8e9e938f57bfc8e455a85e8df90b1f4e6da2c12b
+	},
+		200*time.Second, 1*time.Second).Should(gomega.Succeed())
 }
 
 // GetRandomPVC returns a pvc with a randomized name
@@ -100,15 +97,12 @@ func GetDataValidatorJob(pvc string) *k8sbatchv1.Job {
 								},
 							},
 							Command: []string{"/bin/sh", "-c"},
-<<<<<<< HEAD
 							Args: []string{"dd if=/dev/zero of=/tmp/random.img bs=512 count=1", //This command creates new file named random.img
 								"md5VAR1=$(md5sum /tmp/random.img | awk '{ print $1 }')",  //calculates md5sum of random.img in pod and stores it in a variable
 								"cp /tmp/random.img /data/random.img",                     //copies random.img file to pvc's mountpoint
 								"md5VAR2=$(md5sum /data/random.img | awk '{ print $1 }')", //calculates md5sum of file random.img
-								"if [[ \"$md5VAR1\" != \"$md5VAR2\" ]];then exit 1; fi"},  //compares the md5sum of random.img file
-=======
-							Args:    []string{"dd if=/dev/zero of=/tmp/random.img bs=512 count=1;md5VAR1=$(md5sum /tmp/random.img | awk '{ print $1 }');cp /tmp/random.img /data/random.img;md5VAR2=$(md5sum /data/random.img | awk '{ print $1 }');if [[ \"$md5VAR1\" != \"$md5VAR2\" ]];then exit 1; fi"},
->>>>>>> 8e9e938f57bfc8e455a85e8df90b1f4e6da2c12b
+								"if [[ \"$md5VAR1\" != \"$md5VAR2\" ]];then exit 1; fi",   //compares the md5sum of random.img file
+							},
 						},
 					},
 					Volumes: []k8sv1.Volume{

--- a/functests/common.go
+++ b/functests/common.go
@@ -97,11 +97,12 @@ func GetDataValidatorJob(pvc string) *k8sbatchv1.Job {
 								},
 							},
 							Command: []string{"/bin/sh", "-c"},
-							Args: []string{"dd if=/dev/zero of=/tmp/random.img bs=512 count=1", //This command creates new file named random.img
-								"md5VAR1=$(md5sum /tmp/random.img | awk '{ print $1 }')",  //calculates md5sum of random.img in pod and stores it in a variable
+							Args: []string{
+								"dd if=/dev/zero of=/tmp/random.img bs=512 count=1",       //This command creates new file named random.img
+								"md5VAR1=$(md5sum /tmp/random.img | awk '{ print $1 }')",  //calculates md5sum of random.img and stores it in a variable
 								"cp /tmp/random.img /data/random.img",                     //copies random.img file to pvc's mountpoint
 								"md5VAR2=$(md5sum /data/random.img | awk '{ print $1 }')", //calculates md5sum of file random.img
-								"if [[ \"$md5VAR1\" != \"$md5VAR2\" ]];then exit 1; fi",   //compares the md5sum of random.img file
+								"if [[ \"$md5VAR1\" != \"$md5VAR2\" ]];then exit 1; fi",   //compares the md5sum of random.img file with previous one
 							},
 						},
 					},

--- a/functests/common.go
+++ b/functests/common.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	k8sbatchv1 "k8s.io/api/batch/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -26,6 +27,21 @@ func WaitForPVCBound(k8sClient *kubernetes.Clientset, pvcName string, pvcNamespa
 		}
 		return fmt.Errorf("Waiting on pvc %s/%s to reach bound state when it is currently %s", pvcNamespace, pvcName, pvc.Status.Phase)
 	}, 200*time.Second, 1*time.Second).ShouldNot(gomega.HaveOccurred())
+}
+
+// WaitForJobSucceeded waits for a Job with a given name and namespace to succeed until 200 seconds
+func WaitForJobSucceeded(k8sClient *kubernetes.Clientset, jobName string, jobNamespace string) {
+	gomega.Eventually(func() error {
+		job, err := k8sClient.BatchV1().Jobs(jobNamespace).Get(jobName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+
+		if job.Status.Succeeded > 0 {
+			return nil
+		}
+		return fmt.Errorf("Waiting on job %s/%s to succeed when it is currently %d", jobName, jobNamespace, job.Status.Succeeded)
+	}, 200*time.Second, 1*time.Second).Should(gomega.Succeed())
 }
 
 // GetRandomPVC returns a pvc with a randomized name
@@ -56,4 +72,50 @@ func GetRandomPVC(storageClass string, quantity string) *k8sv1.PersistentVolumeC
 	}
 
 	return pvc
+}
+
+// GetDataValidatorJob returns the spec of a job
+func GetDataValidatorJob(pvc string) *k8sbatchv1.Job {
+	randomName := "test-job-" + rand.String(12)
+	job := &k8sbatchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: randomName,
+		},
+		Spec: k8sbatchv1.JobSpec{
+			Template: k8sv1.PodTemplateSpec{
+				Spec: k8sv1.PodSpec{
+					RestartPolicy: k8sv1.RestartPolicyNever,
+					Containers: []k8sv1.Container{
+						k8sv1.Container{
+							Name:  randomName,
+							Image: "busybox",
+							VolumeMounts: []k8sv1.VolumeMount{
+								k8sv1.VolumeMount{
+									MountPath: "/data",
+									Name:      "volume-to-debug",
+								},
+							},
+							Command: []string{"/bin/sh", "-c"},
+							Args: []string{"dd if=/dev/zero of=/tmp/random.img bs=512 count=1", //This command creates new file named random.img
+								"md5VAR1=$(md5sum /tmp/random.img | awk '{ print $1 }')",  //calculates md5sum of random.img in pod and stores it in a variable
+								"cp /tmp/random.img /data/random.img",                     //copies random.img file to pvc's mountpoint
+								"md5VAR2=$(md5sum /data/random.img | awk '{ print $1 }')", //calculates md5sum of file random.img
+								"if [[ \"$md5VAR1\" != \"$md5VAR2\" ]];then exit 1; fi"},  //compares the md5sum of random.img file
+						},
+					},
+					Volumes: []k8sv1.Volume{
+						k8sv1.Volume{
+							Name: "volume-to-debug",
+							VolumeSource: k8sv1.VolumeSource{
+								PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: pvc,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return job
 }

--- a/functests/data_validation_test.go
+++ b/functests/data_validation_test.go
@@ -1,0 +1,71 @@
+package functests_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	tests "github.com/openshift/ocs-operator/functests"
+	deploymanager "github.com/openshift/ocs-operator/pkg/deploy-manager"
+	k8sbatchv1 "k8s.io/api/batch/v1"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var _ = Describe("job creation", func() {
+	var k8sClient *kubernetes.Clientset
+
+	BeforeEach(func() {
+		RegisterFailHandler(Fail)
+
+		deployManager, err := deploymanager.NewDeployManager()
+		Expect(err).To(BeNil())
+
+		k8sClient = deployManager.GetK8sClient()
+	})
+
+	Describe("rbd", func() {
+		var namespace string
+		var pvc *k8sv1.PersistentVolumeClaim
+		var job *k8sbatchv1.Job
+
+		BeforeEach(func() {
+			namespace = tests.TestNamespace
+			pvc = tests.GetRandomPVC(tests.StorageClassRBD, "1Gi")
+			job = tests.GetDataValidatorJob(pvc.GetName())
+		})
+
+		AfterEach(func() {
+			err := k8sClient.BatchV1().Jobs(namespace).Delete(job.GetName(), &metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				Expect(err).To(BeNil())
+			}
+			err = k8sClient.CoreV1().PersistentVolumeClaims(namespace).Delete(pvc.Name, &metav1.DeleteOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				Expect(err).To(BeNil())
+			}
+		})
+		Context("Create job with pvc", func() {
+			It("and verify the data integrity", func() {
+				By("Creating PVC")
+				_, err := k8sClient.CoreV1().PersistentVolumeClaims(namespace).Create(pvc)
+				Expect(err).To(BeNil())
+
+				By("Verifying PVC reaches BOUND phase")
+				tests.WaitForPVCBound(k8sClient, pvc.Name, namespace)
+
+				By("Creating job")
+				_, err = k8sClient.BatchV1().Jobs(namespace).Create(job)
+				Expect(err).To(BeNil())
+
+				By("Verifying job succeeds in data validation")
+				tests.WaitForJobSucceeded(k8sClient, job.GetName(), namespace)
+
+				finalJob, err := k8sClient.BatchV1().Jobs(namespace).Get(job.GetName(), metav1.GetOptions{})
+				Expect(err).To(BeNil())
+				Expect(finalJob.Status.Succeeded).NotTo(BeZero())
+			})
+		})
+	})
+})


### PR DESCRIPTION
Changed common.go file to add the pod Busybox specs into the file. 
~ ~ ~
[ The main purpose of adding pod specs in common.go  : 
Writing a test case in which a busybox pod will be deployed, PVC will be created. Once pod and pvc are created, the file will be generated in the busybox pod, after copying the generated file to the mount point, md5 of both the files will be calculated. Cross checking md5 will be helpful to know if the data populated is corrupted or not.]