### PR TITLE
fix(functest): fixes duplicate call for must-gather functest.

### DIFF
--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -12,5 +12,3 @@ if [ $? -ne 0 ]; then
 	echo "ERROR: Functest failed."
 	exit 1
 fi
-
-must-gather/functests/functests.sh


### PR DESCRIPTION
Since the must-gather func-test is already called from the go test code we
don't need a seperate call for it from the functest.sh file.

Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>