### PR TITLE
Fixing the source-manifests.sh script

### DIFF
--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -80,7 +80,7 @@ gen_args="olm-catalog gen-csv --csv-version=$TMP_CSV_VERSION"
 if [ -n "$CSV_REPLACES_VERSION" ]; then
 	gen_args="$gen_args --from-version=$CSV_REPLACES_VERSION"
 fi
-$OPERATOR_SDK "$gen_args" 2>/dev/null
+$OPERATOR_SDK $gen_args 2>/dev/null
 OCS_TMP_CSV="deploy/olm-catalog/ocs-operator/${TMP_CSV_VERSION}/ocs-operator.v${TMP_CSV_VERSION}.clusterserviceversion.yaml"
 mv $OCS_TMP_CSV $OCS_CSV
 # Make variables templated for csv-merger tool


### PR DESCRIPTION
This fixes the broken make file commands, like 'gen-latest-csv',
'source-manifests' etc

Fixes: https://github.com/openshift/ocs-operator/issues/377

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>