### PR TITLE
Align 'generate-latest-csv' script with existing env variables

### DIFF
--- a/hack/generate-latest-csv.sh
+++ b/hack/generate-latest-csv.sh
@@ -19,7 +19,7 @@ export NOOBAA_IMAGE=${NOOBAA_IMAGE:-"noobaa/noobaa-operator:2.0.9"}
 export NOOBAA_CORE_IMAGE=${NOOBAA_CORE_IMAGE:-"noobaa/noobaa-core:5.2.11"}
 export NOOBAA_DB_IMAGE=${NOOBAA_DB_IMAGE:-"centos/mongodb-36-centos7"}
 export CEPH_IMAGE=${CEPH_IMAGE:-"ceph/ceph:v14.2"}
-export OCS_IMAGE=${OCS_IMAGE:-"quay.io/ocs-dev/ocs-operator:latest"}
+export OCS_IMAGE=${OCS_IMAGE:-"${IMAGE_REGISTRY}/${REGISTRY_NAMESPACE}/ocs-operator:${IMAGE_TAG}"}
 
 echo "=== Generating DEV CSV with the following vars ==="
 echo -e "\tCSV_VERSION=$CSV_VERSION"


### PR DESCRIPTION
Minor change to make 'generate-latest-csv' script align with other 'make' scripts and avoids the usage of a new variable. Helps in building custom OCS Operator images.

Signed-off-by: Arun Kumar Mohan <arun.iiird@gmail.com>