### PR TITLE
fix: tear down failure in CI

### DIFF
--- a/functests/setup_teardown.go
+++ b/functests/setup_teardown.go
@@ -69,4 +69,3 @@ func BeforeUpgradeTestSuiteSetup() {
 	err = t.StartDefaultStorageCluster()
 	gomega.Expect(err).To(gomega.BeNil())
 }
-

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.1
 	github.com/go-openapi/spec v0.19.2
-	github.com/go-openapi/validate v0.18.0 // indirect
 	github.com/noobaa/noobaa-operator/v2 v2.0.8
 	github.com/onsi/ginkgo v1.10.1
 	github.com/onsi/gomega v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -65,7 +65,9 @@ github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3Ee
 github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9/ZjdUKyjop4mf3Qdd+1TvvltAvM3m8=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
+github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/prometheus-operator v0.29.0 h1:Moi4klbr1xUVaofWzlaM12mxwCL294GiLW2Qj8ku0sY=
 github.com/coreos/prometheus-operator v0.29.0/go.mod h1:SO+r5yZUacDFPKHfPoUjI3hMsH+ZUdiuNNhuSq3WoSg=
@@ -349,6 +351,7 @@ github.com/openshift/cloud-credential-operator v0.0.0-20190614194054-1ccced634f6
 github.com/openshift/custom-resource-status v0.0.0-20190801200128-4c95b3a336cd/go.mod h1:5FN5ZOa6szVg6C3kB6PbSL6VHAbX5+HpLvGZhUCJmKs=
 github.com/openshift/custom-resource-status v0.0.0-20190812200727-7961da9a2eb7 h1:p5YcnpKhd5Urp8UqVu1tLATSU+kSfLlcZhlnSwHR4qU=
 github.com/openshift/custom-resource-status v0.0.0-20190812200727-7961da9a2eb7/go.mod h1:5FN5ZOa6szVg6C3kB6PbSL6VHAbX5+HpLvGZhUCJmKs=
+github.com/openshift/custom-resource-status v0.0.0-20190822192428-e62f2f3b79f3 h1:XuAys09+XqT5/FjdR23G/UtbBLII89dFe9XIi73EKIQ=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
 github.com/openzipkin/zipkin-go v0.1.3/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=

--- a/pkg/deploy-manager/common.go
+++ b/pkg/deploy-manager/common.go
@@ -6,6 +6,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
 	utilwait "k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -27,9 +28,52 @@ func (t *DeployManager) CreateNamespace(namespace string) error {
 	return nil
 }
 
+// DeleteStorageClusterAndWait deletes a storageClusterCR and waits on it to terminate
+func (t *DeployManager) DeleteStorageClusterAndWait(namespace string) error {
+	err := t.deleteStorageCluster()
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	cephClusters, err := t.rookClient.CephV1().CephClusters(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	for _, cephCluster := range cephClusters.Items {
+		_, err = t.rookClient.CephV1().CephClusters(namespace).Patch(cephCluster.GetName(), types.JSONPatchType, []byte(finalizerRemovalPatch))
+		if err != nil {
+			return err
+		}
+	}
+
+	timeout := 300 * time.Second
+	interval := 10 * time.Second
+
+	// Wait for storagecluster and cephCluster to terminate
+	err = utilwait.PollImmediate(interval, timeout, func() (done bool, err error) {
+		cephClusters, err := t.rookClient.CephV1().CephClusters(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+		if len(cephClusters.Items) != 0 {
+			return false, nil
+		}
+		_, err = t.getStorageCluster()
+		if !errors.IsNotFound(err) {
+			return false, nil
+		}
+		return true, nil
+	})
+
+	return err
+}
+
 // DeleteNamespaceAndWait deletes a namespace and waits on it to terminate
 func (t *DeployManager) DeleteNamespaceAndWait(namespace string) error {
-	err := t.k8sClient.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{})
+	err := t.DeleteStorageClusterAndWait(namespace)
+	if err != nil {
+		return err
+	}
+	err = t.k8sClient.CoreV1().Namespaces().Delete(namespace, &metav1.DeleteOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}


### PR DESCRIPTION
This commit fixes teardown failure in CI by adding an additional step to clean up storageCluster before deleting the namespace.

Signed-off-by: Ashish Ranjan <aranjan@redhat.com>