### PR TITLE
functest: increases the timeout for cluster teardown

### DIFF
--- a/pkg/deploy-manager/common.go
+++ b/pkg/deploy-manager/common.go
@@ -45,7 +45,7 @@ func (t *DeployManager) DeleteStorageClusterAndWait(namespace string) error {
 		}
 	}
 
-	timeout := 300 * time.Second
+	timeout := 600 * time.Second
 	interval := 10 * time.Second
 
 	// Wait for storagecluster and cephCluster to terminate
@@ -78,7 +78,7 @@ func (t *DeployManager) DeleteNamespaceAndWait(namespace string) error {
 		return err
 	}
 
-	timeout := 200 * time.Second
+	timeout := 600 * time.Second
 	interval := 10 * time.Second
 
 	// Wait for namespace to terminate


### PR DESCRIPTION
This commit increases the timeout for cluster teardown because pods are taking more than 200 seconds to terminate which causes teardown to get a timeout.

Signed-off-by: Ashish Ranjan <aranjan@redhat.com>