### PR TITLE
BZ-1788492: Adding pod anti affinity for zones on mon and mds pods

### DIFF
--- a/pkg/controller/defaults/placements.go
+++ b/pkg/controller/defaults/placements.go
@@ -35,6 +35,28 @@ var (
 			},
 		},
 
+		"mon": rook.Placement{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+					corev1.WeightedPodAffinityTerm{
+						Weight: 100,
+						PodAffinityTerm: corev1.PodAffinityTerm{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									metav1.LabelSelectorRequirement{
+										Key:      "app",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"rook-ceph-mon"},
+									},
+								},
+							},
+							TopologyKey: "kubernetes.io/hostname",
+						},
+					},
+				},
+			},
+		},
+
 		"osd": rook.Placement{
 			NodeAffinity: &corev1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{

--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -409,7 +409,7 @@ func (r *ReconcileStorageCluster) newCephFilesystemInstances(initData *ocsv1.Sto
 				MetadataServer: cephv1.MetadataServerSpec{
 					ActiveCount:   1,
 					ActiveStandby: true,
-					Placement:     defaults.DaemonPlacements["mds"],
+					Placement:     getCephDaemonPlacements(initData, "mds"),
 					Resources:     defaults.GetDaemonResources("mds", initData.Spec.Resources),
 				},
 			},

--- a/pkg/controller/storagecluster/initialization_reconciler_test.go
+++ b/pkg/controller/storagecluster/initialization_reconciler_test.go
@@ -73,6 +73,15 @@ func TestInitStorageClusterResourcesCreation(t *testing.T) {
 		},
 		Status: api.StorageClusterStatus{
 			FailureDomain: "zone",
+			NodeTopologies: &api.NodeTopologyMap{
+				Labels: map[string]api.TopologyLabelValues{
+					zoneTopologyLabel: []string{
+						"zone1",
+						"zone2",
+						"zone3",
+					},
+				},
+			},
 		},
 	}
 	request := reconcile.Request{
@@ -98,6 +107,15 @@ func TestInitStorageClusterResourcesUpdate(t *testing.T) {
 		},
 		Status: api.StorageClusterStatus{
 			FailureDomain: "zone",
+			NodeTopologies: &api.NodeTopologyMap{
+				Labels: map[string]api.TopologyLabelValues{
+					zoneTopologyLabel: []string{
+						"zone1",
+						"zone2",
+						"zone3",
+					},
+				},
+			},
 		},
 	}
 	request := reconcile.Request{

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -726,6 +726,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int) *
 			},
 			Placement: rook.PlacementSpec{
 				"all": defaults.DaemonPlacements["all"],
+				"mon": getCephDaemonPlacements(sc, "mon"),
 			},
 			Resources: newCephDaemonResources(sc.Spec.Resources),
 			ContinueUpgradeAfterChecksEvenIfNotHealthy: true,
@@ -889,6 +890,22 @@ func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqL
 	// NoobaaSystem is dependent upon ceph for volume provisioning.
 	// We want to make sure we delete noobaasystem before we delete cephcluster, to get a clean uninstall.
 	return r.deleteNoobaaSystems(sc, reqLogger)
+}
+
+//getCephDaemonPlacements returns placement configuration for ceph components with appropriate topology
+func getCephDaemonPlacements(sc *ocsv1.StorageCluster, component string) rook.Placement {
+	placement := rook.Placement{}
+	in := defaults.DaemonPlacements[component]
+	(&in).DeepCopyInto(&placement)
+	topologyMap := sc.Status.NodeTopologies
+	if topologyMap != nil {
+		topologyKey := determineFailureDomain(sc)
+		topologyKey, _ = topologyMap.GetKeyValues(topologyKey)
+		podAffinityTerms := placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		podAffinityTerms[0].PodAffinityTerm.TopologyKey = topologyKey
+	}
+
+	return placement
 }
 
 // Checks whether a string is contained within a slice


### PR DESCRIPTION
More than one mon or mds pods are randomly coming up on the same Availability Zone. 

This PR adds `topologyKey: failure-domain.beta.kubernetes.io/zone` podAntiAffinity to Mon and MDS placement spec. 