### PR TITLE
Bug 1775432- sets mon_osd_full_ratio=.85 & mon_osd_nearfull_ratio =.75

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -33,7 +33,11 @@ import (
 
 const (
 	rookConfigMapName = "rook-config-override"
-	rookConfigData    = `[osd]
+	rookConfigData    = `
+[global]
+mon_osd_full_ratio = .85
+mon_osd_nearfull_ratio = .75
+[osd]
 osd_memory_target_cgroup_limit_ratio = 0.5
 `
 	monCountOverrideEnvVar = "MON_COUNT_OVERRIDE"


### PR DESCRIPTION
"rook-config-override" ConfigMap after changes,
```yaml
data:
  config: |

    [global]
    mon_osd_full_ratio = .85
    mon_osd_nearfull_ratio = .75
    [osd]
    osd_memory_target_cgroup_limit_ratio = 0.5
```

```bash
sh-4.2# ceph osd dump | grep full
full_ratio 0.85
nearfull_ratio 0.75
```
Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>