### PR TITLE
[WIP] BZ- 1780002: OCS operator should proceed with rook upgrade even if ceph health is not ok

### DIFF
--- a/pkg/controller/util/status.go
+++ b/pkg/controller/util/status.go
@@ -115,19 +115,6 @@ func SetCompleteCondition(conditions *[]conditionsv1.Condition, reason string, m
 // This will only look for negative conditions: !Available, Degraded, Progressing
 func MapCephClusterNegativeConditions(conditions *[]conditionsv1.Condition, found *cephv1.CephCluster) {
 	switch found.Status.State {
-	case cephv1.ClusterStateCreating:
-		conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
-			Type:    conditionsv1.ConditionProgressing,
-			Status:  corev1.ConditionTrue,
-			Reason:  "ClusterStateCreating",
-			Message: fmt.Sprintf("CephCluster is creating: %v", string(found.Status.Message)),
-		})
-		conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
-			Type:    conditionsv1.ConditionUpgradeable,
-			Status:  corev1.ConditionFalse,
-			Reason:  "ClusterStateCreating",
-			Message: fmt.Sprintf("CephCluster is creating: %v", string(found.Status.Message)),
-		})
 	case cephv1.ClusterStateUpdating:
 		conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
 			Type:    conditionsv1.ConditionProgressing,


### PR DESCRIPTION
-The readiness probe fails for OCS opeartor (Readiness probe failed: stat: cannot stat '/tmp/operator-sdk-ready)when the Ceph cluster is in "Creating" phase. This causes ocs not to send upgrade request to rook. 
-Since rook is already designed to delay the updating the cluster if its not health, we can have ocs ignore the ceph cluster health.
-This change involves not adding 'conditions' to the ocs when cephCluster 'status.State' has value 'Creating', so that '/tmp/operator-sdk-ready' would be created.

PS: This is not ready for review yet. 

Signed-off-by: Santosh Pillai <sapillai@redhat.com>