### PR TITLE
Adds temporary fix for collection storagecluster

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -6,7 +6,12 @@ mkdir -p ${BASE_COLLECTION_PATH}
 # Resource List
 resources=()
 # collect storagecluster resources
-resources+=(storageclusters)
+
+# TODO: Re enable the collection of storagecluster via inspect command
+# resources+=(storageclusters)
+
+# NOTE: This is a temporary fix for collecting the storagecluster as we are not able to collect the storagecluster using the inspect command
+{ timeout 120 oc get storageclusters --all-namespaces -o yaml; } > $BASE_COLLECTION_PATH/storagecluster.yaml 2>&1
 
 # collect OB/OBC resoureces
 resources+=(objectbucketclaims)


### PR DESCRIPTION
This commit adds a temporary fix for collection storagecluster CR as
collection via inspect client is not working.

Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>