### PR TITLE
Reduce TargetSizeRatio from .5 to .49 to avoid HEALTH_WARN

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -252,7 +252,7 @@ func (r *ReconcileStorageCluster) newCephBlockPoolInstances(initData *ocsv1.Stor
 				FailureDomain: initData.Status.FailureDomain,
 				Replicated: cephv1.ReplicatedSpec{
 					Size:            3,
-					TargetSizeRatio: .5,
+					TargetSizeRatio: .49,
 				},
 			},
 		},
@@ -403,7 +403,7 @@ func (r *ReconcileStorageCluster) newCephFilesystemInstances(initData *ocsv1.Sto
 					cephv1.PoolSpec{
 						Replicated: cephv1.ReplicatedSpec{
 							Size:            3,
-							TargetSizeRatio: .5,
+							TargetSizeRatio: .49,
 						},
 						FailureDomain: initData.Status.FailureDomain,
 					},


### PR DESCRIPTION
Currently, due to a floating point imprecision in ceph, we get a
"HEALTH_WARN 1 subtrees have overcommitted pool target_size_ratio"
after deplyoing with the TargetSizeRatio of .5 (0.5 + 0.5 > 1.0..).

This will be fixed in future Ceph versions
(https://github.com/ceph/ceph/pull/33035).

In order to avoid the warning until we have the updated Ceph,
this patch lowers the ratio to 0.49.

https://bugzilla.redhat.com/show_bug.cgi?id=1807950

Signed-off-by: Michael Adam <obnox@redhat.com>