### PR TITLE
Adds crombus to the owner file.

### DIFF
--- a/must-gather/OWNERS
+++ b/must-gather/OWNERS
@@ -1,4 +1,6 @@
 reviewers:
   - ashishranjan738
+  - crombus
 approvers:
   - ashishranjan738
+  - crombus


### PR DESCRIPTION
This commit adds crombus as the owner of the must-gather.

Signed-off-by: Ashish Ranjan <ashishranjan738@gmail.com>