### PR TITLE
Bug 1810011: PV resize should be blocked in OCS 4.3

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -65,6 +65,7 @@ func (r *ReconcileStorageCluster) ensureStorageClasses(instance *ocsv1.StorageCl
 // on first run.
 func (r *ReconcileStorageCluster) newStorageClasses(initData *ocsv1.StorageCluster) ([]*storagev1.StorageClass, error) {
 	persistentVolumeReclaimDelete := corev1.PersistentVolumeReclaimDelete
+	allowVolumeExpansion := false
 	ret := []*storagev1.StorageClass{
 		&storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
@@ -72,6 +73,9 @@ func (r *ReconcileStorageCluster) newStorageClasses(initData *ocsv1.StorageClust
 			},
 			Provisioner:   fmt.Sprintf("%s.cephfs.csi.ceph.com", initData.Namespace),
 			ReclaimPolicy: &persistentVolumeReclaimDelete,
+			// AllowVolumeExpansion is set to False to disable expansion of OCS backed Volumes
+			// This is not supported currently.
+			AllowVolumeExpansion: &allowVolumeExpansion,
 			Parameters: map[string]string{
 				"clusterID": initData.Namespace,
 				"fsName":    fmt.Sprintf("%s-cephfilesystem", initData.Name),
@@ -87,6 +91,9 @@ func (r *ReconcileStorageCluster) newStorageClasses(initData *ocsv1.StorageClust
 			},
 			Provisioner:   fmt.Sprintf("%s.rbd.csi.ceph.com", initData.Namespace),
 			ReclaimPolicy: &persistentVolumeReclaimDelete,
+			// AllowVolumeExpansion is set to False to disable expansion of OCS backed Volumes
+			// This is not supported currently.
+			AllowVolumeExpansion: &allowVolumeExpansion,
 			Parameters: map[string]string{
 				"clusterID":                 initData.Namespace,
 				"pool":                      generateNameForCephBlockPool(initData),


### PR DESCRIPTION
AllowVolumeExpansion is set to False to disable expansion of OCS backed Volumes
This is not supported currently. User created OCS backed StorageClass will not
inherit this change.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>