### PR TITLE
Bug 1798571: ob and obc will move to owned instead of required

### DIFF
--- a/deploy/olm-catalog/ocs-operator/4.3.0/objectbucket.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/4.3.0/objectbucket.crd.yaml
@@ -1,0 +1,127 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbuckets.objectbucket.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.storageClassName
+    description: StorageClass
+    name: Storage-Class
+    type: string
+  - JSONPath: .spec.claimRef.namespace
+    description: ClaimNamespace
+    name: Claim-Namespace
+    type: string
+  - JSONPath: .spec.claimRef.name
+    description: ClaimName
+    name: Claim-Name
+    type: string
+  - JSONPath: .spec.reclaimPolicy
+    description: ReclaimPolicy
+    name: Reclaim-Policy
+    type: string
+  - JSONPath: .status.phase
+    description: Phase
+    name: Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: objectbucket.io
+  names:
+    kind: ObjectBucket
+    listKind: ObjectBucketList
+    plural: objectbuckets
+    shortNames:
+    - ob
+    - obs
+    singular: objectbucket
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object metadata.
+          type: object
+        spec:
+          description: Specification of the desired behavior of the bucket.
+          properties:
+            additionalState:
+              additionalProperties:
+                type: string
+              description: additionalState gives providers a location to set proprietary
+                config values (tenant, namespace, etc)
+              type: object
+            claimRef:
+              description: ObjectReference to ObjectBucketClaim
+              type: object
+            endpoint:
+              description: Endpoint contains all connection relevant data that an
+                app may require for accessing the bucket
+              properties:
+                additionalConfig:
+                  additionalProperties:
+                    type: string
+                  description: AdditionalConfig gives providers a location to set
+                    proprietary config values (tenant, namespace, etc)
+                  type: object
+                bucketHost:
+                  description: Bucket address hostname
+                  type: string
+                bucketName:
+                  description: Bucket name
+                  type: string
+                bucketPort:
+                  description: Bucket address port
+                  type: integer
+                region:
+                  description: Bucket region
+                  type: string
+                subRegion:
+                  description: Bucket sub-region
+                  type: string
+              type: object
+            reclaimPolicy:
+              description: Describes a policy for end-of-life maintenance of ObjectBucket.
+              enum:
+              - Delete
+              - Retain
+              - Recycle
+              type: string
+            storageClassName:
+              description: StorageClass names the StorageClass object representing
+                the desired provisioner and parameters
+              type: string
+          required:
+          - storageClassName
+          type: object
+        status:
+          description: Most recently observed status of the bucket.
+          properties:
+            phase:
+              description: ObjectBucketStatusPhase is set by the controller to save
+                the state of the provisioning process
+              enum:
+              - Bound
+              - Released
+              - Failed
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ocs-operator/4.3.0/objectbucketclaim.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/4.3.0/objectbucketclaim.crd.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: objectbucketclaims.objectbucket.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.storageClassName
+    description: StorageClass
+    name: Storage-Class
+    type: string
+  - JSONPath: .status.phase
+    description: Phase
+    name: Phase
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  group: objectbucket.io
+  names:
+    kind: ObjectBucketClaim
+    listKind: ObjectBucketClaimList
+    plural: objectbucketclaims
+    shortNames:
+    - obc
+    - obcs
+    singular: objectbucketclaim
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object metadata.
+          type: object
+        spec:
+          description: Specification of the desired behavior of the claim.
+          properties:
+            additionalConfig:
+              additionalProperties:
+                type: string
+              description: AdditionalConfig gives providers a location to set proprietary
+                config values (tenant, namespace, etc)
+              type: object
+            bucketName:
+              description: BucketName (not recommended) the name of the bucket. Caution!
+                In-store bucket names may collide across namespaces.  If you define
+                the name yourself, try to make it as unique as possible.
+              type: string
+            generateBucketName:
+              description: GenerateBucketName (recommended) a prefix for a bucket
+                name to be followed by a hyphen and 5 random characters. Protects
+                against in-store name collisions.
+              type: string
+            storageClassName:
+              description: StorageClass names the StorageClass object representing
+                the desired provisioner and parameters
+              type: string
+          required:
+          - storageClassName
+          type: object
+        status:
+          description: Most recently observed status of the claim.
+          properties:
+            phase:
+              description: ObjectBucketClaimStatusPhase is set by the controller to
+                save the state of the provisioning process
+              enum:
+              - Pending
+              - Bound
+              - Released
+              - Failed
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ocs-operator/4.3.0/ocs-operator.v4.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/4.3.0/ocs-operator.v4.3.0.clusterserviceversion.yaml
@@ -57,7 +57,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:4.3.0
-    createdAt: "2020-03-02 09:18:44"
+    createdAt: "2020-03-10 11:37:57"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operatorframework.io/cluster-monitoring: "true"
@@ -347,11 +347,12 @@ spec:
         name: statefulsets.apps
         version: v1
       version: v1alpha1
-    required:
-    - description: Claim a bucket just like claiming a PV. Automate you app bucket
-        provisioning by creating OBC with your app deployment. A secret and configmap
-        (name=claim) will be created with access details for the app pods.
-      displayName: ObjectBucketClaim
+    - description: |-
+        [This resource is not intended to be created or managed by users.]
+
+
+        Claim a bucket just like claiming a PV. Automate you app bucket provisioning by creating OBC with your app deployment. A secret and configmap (name=claim) will be created with access details for the app pods.
+      displayName: '[Internal] ObjectBucketClaim'
       kind: ObjectBucketClaim
       name: objectbucketclaims.objectbucket.io
       resources:
@@ -368,9 +369,12 @@ spec:
         name: statefulsets.apps
         version: v1
       version: v1alpha1
-    - description: Used under-the-hood. Created per ObjectBucketClaim and keeps provisioning
-        information.
-      displayName: ObjectBucket
+    - description: |-
+        [This resource is not intended to be created or managed by users.]
+
+
+        Used under-the-hood. Created per ObjectBucketClaim and keeps provisioning information.
+      displayName: '[Internal] ObjectBucket'
       kind: ObjectBucket
       name: objectbuckets.objectbucket.io
       resources:

--- a/hack/latest-csv-checksum.md5
+++ b/hack/latest-csv-checksum.md5
@@ -1,1 +1,1 @@
-e8dc70034b45b0a1dc04cab7ba06a27c
+12bf436d362a0eef2ceaf5ef48e3f086

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -439,7 +439,15 @@ func generateUnifiedCSV() *csvv1.ClusterServiceVersion {
 			templateStrategySpec.Permissions = append(templateStrategySpec.Permissions, permissions...)
 
 			ocsCSV.Spec.CustomResourceDefinitions.Owned = append(ocsCSV.Spec.CustomResourceDefinitions.Owned, csvStruct.Spec.CustomResourceDefinitions.Owned...)
-			ocsCSV.Spec.CustomResourceDefinitions.Required = append(ocsCSV.Spec.CustomResourceDefinitions.Required, csvStruct.Spec.CustomResourceDefinitions.Required...)
+
+			for _, definition := range csvStruct.Spec.CustomResourceDefinitions.Required {
+				// Move ob and obc to Owned list instead ot Required
+				if definition.Name == "objectbucketclaims.objectbucket.io" || definition.Name == "objectbuckets.objectbucket.io" {
+					ocsCSV.Spec.CustomResourceDefinitions.Owned = append(ocsCSV.Spec.CustomResourceDefinitions.Owned, definition)
+				} else {
+					ocsCSV.Spec.CustomResourceDefinitions.Required = append(ocsCSV.Spec.CustomResourceDefinitions.Owned, definition)
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Cherry pick commit from PR #424
As part of not being dependent on community operators BZ1798571