### PR TITLE
Expose noobaa endpoint resource management to OCS operator

### DIFF
--- a/pkg/controller/defaults/resources.go
+++ b/pkg/controller/defaults/resources.go
@@ -9,7 +9,7 @@ var (
 	// DaemonResources map contains the default resource requirements for the
 	// various OCS daemons
 	DaemonResources = map[string]corev1.ResourceRequirements{
-		"osd": corev1.ResourceRequirements{
+		"osd": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -19,7 +19,7 @@ var (
 				corev1.ResourceMemory: resource.MustParse("8Gi"),
 			},
 		},
-		"mon": corev1.ResourceRequirements{
+		"mon": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
@@ -29,7 +29,7 @@ var (
 				corev1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		},
-		"mds": corev1.ResourceRequirements{
+		"mds": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("3"),
 				corev1.ResourceMemory: resource.MustParse("8Gi"),
@@ -39,7 +39,7 @@ var (
 				corev1.ResourceMemory: resource.MustParse("8Gi"),
 			},
 		},
-		"rgw": corev1.ResourceRequirements{
+		"rgw": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -49,7 +49,7 @@ var (
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 		},
-		"mgr": corev1.ResourceRequirements{
+		"mgr": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("3Gi"),
@@ -59,7 +59,7 @@ var (
 				corev1.ResourceMemory: resource.MustParse("3Gi"),
 			},
 		},
-		"noobaa-core": corev1.ResourceRequirements{
+		"noobaa-core": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -69,7 +69,7 @@ var (
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 		},
-		"noobaa-db": corev1.ResourceRequirements{
+		"noobaa-db": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
@@ -79,9 +79,19 @@ var (
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 		},
-		"noobaa-db-vol": corev1.ResourceRequirements{
+		"noobaa-db-vol": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceStorage: resource.MustParse("50Gi"),
+			},
+		},
+		"noobaa-endpoint": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("2Gi"),
 			},
 		},
 	}

--- a/pkg/controller/defaults/resources.go
+++ b/pkg/controller/defaults/resources.go
@@ -61,22 +61,22 @@ var (
 		},
 		"noobaa-core": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
+				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("4Gi"),
 			},
 		},
 		"noobaa-db": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("4Gi"),
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("4Gi"),
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("500Mi"),
 			},
 		},
 		"noobaa-db-vol": {

--- a/pkg/controller/storagecluster/noobaa_system_reconciler.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler.go
@@ -75,6 +75,7 @@ func (r *ReconcileStorageCluster) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *ocs
 	coreResources := defaults.GetDaemonResources("noobaa-core", sc.Spec.Resources)
 	dbResources := defaults.GetDaemonResources("noobaa-db", sc.Spec.Resources)
 	dBVolumeResources := defaults.GetDaemonResources("noobaa-db-vol", sc.Spec.Resources)
+	endpointResources := defaults.GetDaemonResources("noobaa-endpoint", sc.Spec.Resources)
 
 	nb.Labels = map[string]string{
 		"app": "noobaa",
@@ -88,6 +89,16 @@ func (r *ReconcileStorageCluster) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *ocs
 	nb.Spec.DBVolumeResources = &dBVolumeResources
 	nb.Spec.Image = &r.noobaaCoreImage
 	nb.Spec.DBImage = &r.noobaaDBImage
+
+	if nb.Spec.Endpoints == nil {
+		nb.Spec.Endpoints = &nbv1.EndpointsSpec{
+			MinCount:  1,
+			MaxCount:  1,
+			Resources: &endpointResources,
+		}
+	} else {
+		nb.Spec.Endpoints.Resources = &endpointResources
+	}
 
 	return nil
 }

--- a/pkg/deploy-manager/storagecluster.go
+++ b/pkg/deploy-manager/storagecluster.go
@@ -86,27 +86,31 @@ func DefaultStorageCluster() (*ocsv1.StorageCluster, error) {
 			// Setting empty ResourceLists to prevent ocs-operator from setting the
 			// default resource requirements
 			Resources: map[string]corev1.ResourceRequirements{
-				"mon": corev1.ResourceRequirements{
+				"mon": {
 					Requests: corev1.ResourceList{},
 					Limits:   corev1.ResourceList{},
 				},
-				"mds": corev1.ResourceRequirements{
+				"mds": {
 					Requests: corev1.ResourceList{},
 					Limits:   corev1.ResourceList{},
 				},
-				"rgw": corev1.ResourceRequirements{
+				"rgw": {
 					Requests: corev1.ResourceList{},
 					Limits:   corev1.ResourceList{},
 				},
-				"mgr": corev1.ResourceRequirements{
+				"mgr": {
 					Requests: corev1.ResourceList{},
 					Limits:   corev1.ResourceList{},
 				},
-				"noobaa-core": corev1.ResourceRequirements{
+				"noobaa-core": {
 					Requests: corev1.ResourceList{},
 					Limits:   corev1.ResourceList{},
 				},
-				"noobaa-db": corev1.ResourceRequirements{
+				"noobaa-db": {
+					Requests: corev1.ResourceList{},
+					Limits:   corev1.ResourceList{},
+				},
+				"noobaa-endpoint": {
 					Requests: corev1.ResourceList{},
 					Limits:   corev1.ResourceList{},
 				},


### PR DESCRIPTION
A NooBaa CR can describe memory and CPU resource management (requests/limits) for deployed NooBaa endpoints.

This PR exposes these options in the StorageCluster CR and add reconcile code to update the NooBaa CR accordingly  

Fixes #403 