### PR TITLE
creates default rook-ceph-operator-config ConfigMap

### DIFF
--- a/deploy/crds/ocs.openshift.io_ocsinitializations_crd.yaml
+++ b/deploy/crds/ocs.openshift.io_ocsinitializations_crd.yaml
@@ -128,6 +128,8 @@ spec:
                   uid:
                     description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                     type: string
+            rookCephOperatorConfigCreated:
+              type: boolean
             sCCsCreated:
               type: boolean
   version: v1

--- a/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -57,7 +57,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:4.5.0
-    createdAt: "2020-05-28 11:53:07"
+    createdAt: "2020-06-01 09:21:18"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/export-script: |-

--- a/deploy/olm-catalog/ocs-operator/manifests/ocsinitialization.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/ocsinitialization.crd.yaml
@@ -127,6 +127,8 @@ spec:
                     type: string
                 type: object
               type: array
+            rookCephOperatorConfigCreated:
+              type: boolean
             sCCsCreated:
               type: boolean
           type: object

--- a/hack/latest-csv-checksum.md5
+++ b/hack/latest-csv-checksum.md5
@@ -1,1 +1,1 @@
-1ec0e560394a4e91bbaa38d75b7e3dd8
+cc46dbd440d6b057ce5ccae183cd7e5f

--- a/pkg/apis/ocs/v1/ocsinitialization_types.go
+++ b/pkg/apis/ocs/v1/ocsinitialization_types.go
@@ -37,9 +37,10 @@ type OCSInitializationStatus struct {
 	// operator. Object references will be added to this list after they have
 	// been created AND found in the cluster.
 	// +optional
-	RelatedObjects []corev1.ObjectReference `json:"relatedObjects,omitempty"`
-	ErrorMessage   string                   `json:"errorMessage,omitempty"`
-	SCCsCreated    bool                     `json:"sCCsCreated,omitempty"`
+	RelatedObjects                []corev1.ObjectReference `json:"relatedObjects,omitempty"`
+	ErrorMessage                  string                   `json:"errorMessage,omitempty"`
+	SCCsCreated                   bool                     `json:"sCCsCreated,omitempty"`
+	RookCephOperatorConfigCreated bool                     `json:"rookCephOperatorConfigCreated,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
Creating a rook-ceph-operator-config ConfigMap with default
operator configs which is picked up by rook. We do not
update this ConfigMap and is left upto the admin. To reset
to defaults, configmap must be deleted and reconcile must
be retriggered by deleting ocsinit object.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>