### PR TITLE
If Docker is not found, use podman to build the containers.

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -7,7 +7,14 @@ GO111MODULE="on"
 GOPROXY="https://proxy.golang.org"
 GOROOT="${GOROOT:-go env GOROOT}"
 
-IMAGE_BUILD_CMD="${IMAGE_BUILD_CMD:-docker}"
+IMAGE_BUILD_CMD="${IMAGE_BUILD_CMD}"
+if [ -z "$IMAGE_BUILD_CMD" ]; then
+    IMAGE_BUILD_CMD=$(command -v docker || echo "")
+fi
+if [ -z "$IMAGE_BUILD_CMD" ]; then
+    IMAGE_BUILD_CMD=$(command -v podman || echo "")
+fi
+
 IMAGE_RUN_CMD="${IMAGE_RUN_CMD:-${IMAGE_BUILD_CMD} run --rm -it}"
 
 OUTDIR="build/_output"


### PR DESCRIPTION
You can still override the command using IMAGE_BUILD_CMD environment variable.
If it's not set, it tries to look for the docker command.
If it's not available, it'll try to use podman.

Tested 'make' on Fedora 32, without Docker.

Signed-off-by: Yaniv Kaul <ykaul@redhat.com>