### PR TITLE
Use _ (underscore) instead of space char in oc command output filenames

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -45,7 +45,8 @@ commands+=("get infrastructures.config -oyaml")
 # Run the Collection of Resources to list
 for command in "${commands[@]}"; do
      echo "collecting oc command ${command}" | tee -a ${BASE_COLLECTION_PATH}/gather-debug.log
-     timeout 120 oc ${command}  >> ${BASE_COLLECTION_PATH}/oc_output/"${command}"
+     COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/oc_output/${command// /_}
+     timeout 120 oc ${command} >> "${COMMAND_OUTPUT_FILE}"
 done
 
 # Call other gather scripts


### PR DESCRIPTION
In must-gather logs, file-names containing the output of 'oc' commands have space char, which makes analyzing difficult through shell prompt. 
Use underscore (_) char in oc command output file-names, similar to what we have for the ceph commands.

Fixes BZ #1828714

Signed-off-by: Ashish Singh <assingh@redhat.com>