### PR TITLE
removes CSV check from CI test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ verify-generated: update-generated
 	@echo "Verifying generated code"
 	hack/verify-generated.sh
 
-ocs-operator-ci: shellcheck-test gofmt golint govet unit-test build verify-latest-csv verify-generated verify-latest-deploy-yaml
+ocs-operator-ci: shellcheck-test gofmt golint govet unit-test build verify-generated verify-latest-deploy-yaml
 
 red-hat-storage-ocs-ci:
 	@echo "Running red-hat-storage ocs-ci test suite"


### PR DESCRIPTION
removing the CSV check from ocs-operator-ci test target
to remove dev overhead of maintaining CSV even for
unrelated changes.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>