### PR TITLE
Changes in the Ceph Cluster CR for external cluster

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -931,7 +931,9 @@ func newExternalCephCluster(sc *ocsv1.StorageCluster, cephImage string) *cephv1.
 			External: cephv1.ExternalSpec{
 				Enable: true,
 			},
-			DataDirHostPath: "/var/lib/rook",
+			CrashCollector: cephv1.CrashCollectorSpec{
+				Disable: true,
+			},
 		},
 	}
 	return externalCephCluster


### PR DESCRIPTION
This is the new CephCluster CR that needs to be injected:
```
apiVersion: ceph.rook.io/v1
kind: CephCluster
metadata:
  name: openshift-storage-external->>namespace can be changed according to the requirement
  namespace: openshift-storage-external
spec:
  external:
    enable: true
  crashCollector:
    disable: true
```

Signed-off-by: RAJAT SINGH <rajasing@redhat.com>