### PR TITLE
[hotfix CI] pass the pvc name as expected by rook to StorageCluster

### DIFF
--- a/pkg/deploy-manager/storagecluster.go
+++ b/pkg/deploy-manager/storagecluster.go
@@ -123,6 +123,9 @@ func DefaultStorageCluster() (*ocsv1.StorageCluster, error) {
 					},
 
 					DataPVCTemplate: k8sv1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "data",
+						},
 						Spec: k8sv1.PersistentVolumeClaimSpec{
 							StorageClassName: &storageClassName,
 							AccessModes:      []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},


### PR DESCRIPTION
This is to fill the required fields expected by rook to create
OSDs on PVC.

Temporary fix until we have a new Rook release that contains the fix.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>