### PR TITLE
fix: OBC StorageClass for external cluster

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -203,10 +203,15 @@ func (r *ReconcileStorageCluster) newOBCStorageClass(initData *ocsv1.StorageClus
 		Provisioner:   fmt.Sprintf("%s.ceph.rook.io/bucket", initData.Namespace),
 		ReclaimPolicy: &reclaimPolicy,
 		Parameters: map[string]string{
-			"objectStoreName":      generateNameForCephObjectStore(initData),
 			"objectStoreNamespace": initData.Namespace,
 			"region":               "us-east-1",
 		},
+	}
+
+	// On external cluster, Rook-Ceph does not need the objectStoreName since no ObjectStore is deployed
+	// This is only valid on converged mode
+	if !initData.Spec.ExternalStorage.Enable {
+		retSC.Parameters["objectStoreName"] = generateNameForCephObjectStore(initData)
 	}
 	return retSC
 }


### PR DESCRIPTION
When deploying an external Rook-Ceph cluster, the OCS-operator does not
deploy an CephObjectStore CR, this means the StorageClass parameter
`objectStoreName` becomes invalid. We must remove it otherwise, the user
creation on OBC will fail.

Signed-off-by: Sébastien Han <seb@redhat.com>