### PR TITLE
Disable CephObjectStore when the cloud provider is Azure and gcp.

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -448,7 +448,7 @@ func (r *ReconcileStorageCluster) ensureCephObjectStoreUsers(instance *ocsv1.Sto
 	if err != nil {
 		return err
 	}
-	if platform == PlatformAWS {
+	if isValidCloudPlatform(platform) {
 		return nil
 	}
 

--- a/pkg/controller/storagecluster/initialization_reconciler_test.go
+++ b/pkg/controller/storagecluster/initialization_reconciler_test.go
@@ -212,7 +212,7 @@ func createUpdateRuntimeObjects(cp *CloudPlatform) []runtime.Object {
 	}
 
 	// Create 'cephobjectstoreuser' only for non-aws platforms
-	if cp.platform != PlatformAWS {
+	if !isValidCloudPlatform(cp.platform) {
 		cosu := &cephv1.CephObjectStoreUser{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "ocsinit-cephobjectstoreuser",
@@ -329,7 +329,7 @@ func assertExpectedResources(t assert.TestingT, reconciler ReconcileStorageClust
 	}
 	request.Name = "ocsinit-cephobjectstoreuser"
 	err = reconciler.client.Get(nil, request.NamespacedName, actualCosu)
-	if reconciler.platform.platform == PlatformAWS {
+	if isValidCloudPlatform(reconciler.platform.platform) {
 		assert.Error(t, err)
 	} else {
 		assert.NoError(t, err)

--- a/pkg/controller/storagecluster/platform_detection.go
+++ b/pkg/controller/storagecluster/platform_detection.go
@@ -66,9 +66,6 @@ func (p *CloudPlatform) getPlatform(c client.Client) (CloudPlatformType, error) 
 }
 
 func isValidCloudPlatform(p CloudPlatformType) bool {
-	if p == PlatformUnknown {
-		return true
-	}
 	for _, cp := range ValidCloudPlatforms {
 		if p == cp {
 			return true

--- a/pkg/controller/storagecluster/platform_detection.go
+++ b/pkg/controller/storagecluster/platform_detection.go
@@ -41,10 +41,8 @@ func (p *CloudPlatform) GetPlatform(c client.Client) (CloudPlatformType, error) 
 	}
 	p.mux.Lock()
 	defer p.mux.Unlock()
-	if !isValidCloudPlatform(p.platform) {
-		return p.getPlatform(c)
-	}
-	return p.platform, nil
+
+	return p.getPlatform(c)
 }
 
 func (p *CloudPlatform) getPlatform(c client.Client) (CloudPlatformType, error) {


### PR DESCRIPTION
when these cloud provider are used then default backing store should be used instead of rgw.