### PR TITLE
Makefile: run deps-update when go.mod changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ all: ocs-operator ocs-registry ocs-must-gather
 	deps-update
 
 deps-update:
+	@echo "Running deps-update"
 	go mod tidy && go mod vendor
 
 operator-sdk:

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,8 @@ all: ocs-operator ocs-registry ocs-must-gather
 	update-generated \
 	ocs-operator-ci \
 	red-hat-storage-ocs-ci \
-	unit-test
+	unit-test \
+	deps-update
 
 deps-update:
 	go mod tidy && go mod vendor

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ operator-sdk:
 
 ocs-operator-openshift-ci-build: build
 
-build:
+build: deps-update
 	@echo "Building the ocs-operator binary"
 	mkdir -p build/_output/bin
 	env GOOS=$(TARGET_GOOS) GOARCH=$(TARGET_GOARCH) go build -i -ldflags="-s -w" -mod=vendor -o build/_output/bin/ocs-operator ./cmd/manager


### PR DESCRIPTION
Whenever go.mod is changed, it is required that deps-update is run.
Change the Makefile to make it automatic.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>