### PR TITLE
Makefile: let `make` do the same as `make all`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ export GOPROXY=https://proxy.golang.org
 # Export GOROOT. Required for OPERATOR_SDK to work correctly for generate commands.
 export GOROOT=$(shell go env GOROOT)
 
+all: ocs-operator ocs-registry ocs-must-gather
+
 include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
   targets/openshift/crd-schema-gen.mk \
 )
 
 $(call add-crd-gen,ocsv1,./pkg/apis/ocs/v1,./deploy/crds,./deploy/crds)
-
-all: ocs-operator ocs-registry ocs-must-gather
 
 .PHONY: \
 	build \


### PR DESCRIPTION
The `all` target is not executed when only `make` is invoked because of the include and call directives before it. This moves the all target above the includes so that it is the first target.