### PR TITLE
Makefile: fix typo in PHONY list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ all: ocs-operator ocs-registry ocs-must-gather
 	ocs-operator \
 	ocs-must-gather \
 	operator-bundle \
-	verify-operator-bundle
+	verify-operator-bundle \
 	operator-index \
 	ocs-registry \
 	gen-release-csv \


### PR DESCRIPTION
The PHONY list was missing a backslash escaping a newline,
thereby not making all intended targets phony...

Signed-off-by: Michael Adam <obnox@redhat.com>