### PR TITLE
Delete the storageclasses during uninstall

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -181,26 +181,16 @@ func (r *ReconcileStorageCluster) Reconcile(request reconcile.Request) (reconcil
 		}
 
 		if contains(instance.GetFinalizers(), storageClusterFinalizer) {
-			err = r.setRookCleanupPolicy(instance, reqLogger)
+			err = r.deleteResources(instance, reqLogger)
 			if err != nil {
 				return reconcile.Result{}, err
 			}
-			isDeleted, err := r.deleteResources(instance, reqLogger)
-			if err != nil {
-				// If the dependencies failed to delete because of errors, retry again
+			reqLogger.Info("Removing finalizer")
+			// Once all finalizers have been removed, the object will be deleted
+			instance.ObjectMeta.Finalizers = remove(instance.ObjectMeta.Finalizers, storageClusterFinalizer)
+			if err := r.client.Update(context.TODO(), instance); err != nil {
+				reqLogger.Error(err, "Failed to remove finalizer from storagecluster")
 				return reconcile.Result{}, err
-			}
-			if isDeleted {
-				reqLogger.Info("Removing finalizer")
-				// Once all finalizers have been removed, the object will be deleted
-				instance.ObjectMeta.Finalizers = remove(instance.ObjectMeta.Finalizers, storageClusterFinalizer)
-				if err := r.client.Update(context.TODO(), instance); err != nil {
-					reqLogger.Error(err, "Failed to remove finalizer from storagecluster")
-					return reconcile.Result{}, err
-				}
-			} else {
-				// Watch resources and events and reconcile.
-				return reconcile.Result{}, nil
 			}
 		}
 		reqLogger.Info("Object is terminated, skipping reconciliation")
@@ -1141,10 +1131,25 @@ func (r *ReconcileStorageCluster) setRookCleanupPolicy(instance *ocsv1.StorageCl
 	return nil
 }
 
-func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqLogger logr.Logger) (bool, error) {
+// deleteResources is the function where the storageClusterFinalizer is handled
+// Every function that is called within this function
+// 1. should be idempotent
+// 2. should wrap the finalerr with its own err
+// 3. optionally set a state variable for other calls which might depend on it
+// If this function returns a nil finalerr, the finalizer is removed.
+func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqLogger logr.Logger) (finalerr error) {
+
+	err := r.setRookCleanupPolicy(sc, reqLogger)
+	if err != nil {
+		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+	}
 	// NoobaaSystem is dependent upon ceph for volume provisioning.
 	// We want to make sure we delete noobaasystem before we delete cephcluster, to get a clean uninstall.
-	return r.deleteNoobaaSystems(sc, reqLogger)
+	_, err = r.deleteNoobaaSystems(sc, reqLogger)
+	if err != nil {
+		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+	}
+	return finalerr
 }
 
 // Checks whether a string is contained within a slice

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -1149,6 +1149,12 @@ func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqL
 	if err != nil {
 		finalerr = fmt.Errorf("%w, %v", finalerr, err)
 	}
+
+	err = r.deleteStorageClasses(sc, reqLogger)
+	if err != nil {
+		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+	}
+
 	return finalerr
 }
 

--- a/pkg/controller/storagecluster/uninstall_reconciler.go
+++ b/pkg/controller/storagecluster/uninstall_reconciler.go
@@ -1,0 +1,46 @@
+package storagecluster
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	ocsv1 "github.com/openshift/ocs-operator/pkg/apis/ocs/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// deleteStorageClasses deletes the storageClasses that the ocs-operator created
+func (r *ReconcileStorageCluster) deleteStorageClasses(instance *ocsv1.StorageCluster, reqLogger logr.Logger) error {
+
+	scs, err := r.newStorageClasses(instance)
+	if err != nil {
+		reqLogger.Error(err, fmt.Sprintf("Unable to determine the StorageClass names"))
+		return nil
+	}
+	for _, sc := range scs {
+		existing := storagev1.StorageClass{}
+		err := r.client.Get(context.TODO(), types.NamespacedName{Name: sc.Name, Namespace: sc.Namespace}, &existing)
+
+		switch {
+		case err == nil:
+			if existing.DeletionTimestamp != nil {
+				reqLogger.Info(fmt.Sprintf("StorageClass %s is already marked for deletion", existing.Name))
+				break
+			}
+
+			reqLogger.Info(fmt.Sprintf("Deleting StorageClass %s", sc.Name))
+			existing.ObjectMeta.OwnerReferences = sc.ObjectMeta.OwnerReferences
+			sc.ObjectMeta = existing.ObjectMeta
+
+			err = r.client.Delete(context.TODO(), sc)
+			if err != nil {
+				reqLogger.Error(err, fmt.Sprintf("Ignoring error deleting the StorageClass %s", existing.Name))
+			}
+		case errors.IsNotFound(err):
+			reqLogger.Info(fmt.Sprintf("StorageClass %s not found, nothing to do", sc.Name))
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
At the time of installation, storageclasses are created for ceph-rbd and cephfs. We remove the same in the uninstall stage.

Failure to delete them is not considered fatal and does not block the uninstallation.