### PR TITLE
StorageCluster: delete the default node selector labels during uninstall

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -1165,6 +1165,11 @@ func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqL
 		finalerr = fmt.Errorf("%w, %v", finalerr, err)
 	}
 
+	err = r.deleteNodeAffinityKeyFromNodes(sc, reqLogger)
+	if err != nil {
+		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+	}
+
 	return finalerr
 }
 


### PR DESCRIPTION
This PR removes the default node affinity labels from the worker nodes when the StorageCluster is deleted.

 If the StorageCluster spec provided a list of node selector labels or expressions, we don't remove them because a subset of them might be used by the user for other services    too.