### PR TITLE
independent mode: expose rgw endpoint as a label

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -23,6 +23,13 @@ const (
 	cephFsStorageClassName       = "cephfs"
 	cephRbdStorageClassName      = "ceph-rbd"
 	cephRgwStorageClassName      = "ceph-rgw"
+	externalCephRgwEndpointKey   = "endpoint"
+)
+
+var (
+	// externalRgwEndpoint is the rgw endpoint as discovered in the Secret externalClusterDetailsSecret
+	// It is used for independent mode only. It will be passed to the Noobaa CR as a label
+	externalRgwEndpoint string
 )
 
 // ExternalResource containes a list of External Cluster Resources
@@ -177,6 +184,9 @@ func (r *ReconcileStorageCluster) ensureExternalStorageClusterResources(instance
 				// Setting the PoolName for RBD StorageClass
 				sc = scs[1]
 			} else if d.Name == cephRgwStorageClassName {
+				// Set the external rgw endpoint variable for later use on the Noobaa CR (as a label)
+				externalRgwEndpoint = d.Data[externalCephRgwEndpointKey]
+
 				// Setting the Endpoint for OBC StorageClass
 				sc = scs[2]
 			}

--- a/pkg/controller/storagecluster/noobaa_system_reconciler.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler.go
@@ -19,6 +19,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const (
+	// externalRgwEndpointLabelName is the name of the label that will be used by Noobaa to configure the S3 endpoint
+	externalRgwEndpointLabelName = "rgw-endpoint"
+)
+
 func (r *ReconcileStorageCluster) ensureNoobaaSystem(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
 	// find cephCluster
 	foundCeph := &cephv1.CephCluster{}
@@ -86,6 +91,11 @@ func (r *ReconcileStorageCluster) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *ocs
 
 	nb.Labels = map[string]string{
 		"app": "noobaa",
+	}
+	// If independent mode, we pass the endpoint value as a label to Noobaa
+	// so it can connect to the RGW S3 endpoint
+	if sc.Spec.ExternalStorage.Enable {
+		nb.Labels[externalRgwEndpointLabelName] = externalRgwEndpoint
 	}
 	nb.Spec.DBStorageClass = &storageClassName
 	nb.Spec.PVPoolDefaultStorageClass = &storageClassName

--- a/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -265,6 +265,8 @@ func assertNoobaaResource(t *testing.T, reconciler ReconcileStorageCluster) {
 	// expectation is to get an appropriate Noobaa object
 	err = reconciler.client.Get(nil, request.NamespacedName, fNoobaa)
 	assert.NoError(t, err)
+	assert.NotEmpty(t, fNoobaa.Labels[externalRgwEndpointLabelName])
+	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], "10.20.30.40:50")
 }
 
 func getReconciler(t *testing.T, objs ...runtime.Object) ReconcileStorageCluster {


### PR DESCRIPTION
When doing indepenent mode, we must instruct Noobaa where to find the
external Ceph rgw endpointhen we fetch the externalClusterDetailsSecret
Secret, we extract the Rgw StorageClass as well as its parameters.
Currently, we only have a single parameter called "endpoint", which is
used to configure OBC.
Now we also expose that endpoint as a label on the Nooba CR so Noobaa
can determine whether the endpoint is external or not.

Signed-off-by: Sébastien Han <seb@redhat.com>