### PR TITLE
Bug 1849105: [release-4.5] StorageCluster: delete the default node selector labels during uninstall

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -1165,6 +1165,11 @@ func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqL
 		finalerr = fmt.Errorf("%w, %v", finalerr, err)
 	}
 
+	err = r.deleteNodeAffinityKeyFromNodes(sc, reqLogger)
+	if err != nil {
+		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+	}
+
 	return finalerr
 }
 


### PR DESCRIPTION
This is a cherry-pick of #558 .

To be merged after

#575 and #574 