### PR TITLE
Bug 1849105: [release-4.5] StorageCluster: remove node taints during uninstall

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -1170,6 +1170,11 @@ func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqL
 		finalerr = fmt.Errorf("%w, %v", finalerr, err)
 	}
 
+	err = r.deleteNodeTaint(sc, reqLogger)
+	if err != nil {
+		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+	}
+
 	return finalerr
 }
 


### PR DESCRIPTION
This is a cherry-pick of #560 

To be merged after

#575 
#574 
#576 