### PR TITLE
encore rgw endpoint for external mode

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -2,6 +2,7 @@ package storagecluster
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -185,7 +186,8 @@ func (r *ReconcileStorageCluster) ensureExternalStorageClusterResources(instance
 				sc = scs[1]
 			} else if d.Name == cephRgwStorageClassName {
 				// Set the external rgw endpoint variable for later use on the Noobaa CR (as a label)
-				externalRgwEndpoint = d.Data[externalCephRgwEndpointKey]
+				externalRgwEndpointToBase64 := base64.StdEncoding.EncodeToString([]byte(d.Data[externalCephRgwEndpointKey]))
+				externalRgwEndpoint = externalRgwEndpointToBase64
 
 				// Setting the Endpoint for OBC StorageClass
 				sc = scs[2]

--- a/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -266,7 +266,8 @@ func assertNoobaaResource(t *testing.T, reconciler ReconcileStorageCluster) {
 	err = reconciler.client.Get(nil, request.NamespacedName, fNoobaa)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, fNoobaa.Labels[externalRgwEndpointLabelName])
-	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], "10.20.30.40:50")
+	// The endpoint is base64 encoded, the decoded value is "10.20.30.40:50"
+	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], "MTAuMjAuMzAuNDA6NTA=")
 }
 
 func getReconciler(t *testing.T, objs ...runtime.Object) ReconcileStorageCluster {


### PR DESCRIPTION
Since labels value cannot contain any `:` when Noobaa reads it when an
error like:

```
Error while reconciling: NooBaa.noobaa.io "noobaa" is invalid:
metadata.labels: Invalid value: "10.70.56.202:8080":
a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.',
and must start and end with an alphanumeric character
(e.g. 'MyValue', or 'my_value', or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
```

So let's encode the endpoint and decode it later with Nooba.

Signed-off-by: Sébastien Han <seb@redhat.com>