### PR TITLE
Bug 1847875: [release-4.5] independent mode: expose rgw endpoint as a label

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -23,6 +23,13 @@ const (
 	cephFsStorageClassName       = "cephfs"
 	cephRbdStorageClassName      = "ceph-rbd"
 	cephRgwStorageClassName      = "ceph-rgw"
+	externalCephRgwEndpointKey   = "endpoint"
+)
+
+var (
+	// externalRgwEndpoint is the rgw endpoint as discovered in the Secret externalClusterDetailsSecret
+	// It is used for independent mode only. It will be passed to the Noobaa CR as a label
+	externalRgwEndpoint string
 )
 
 // ExternalResource containes a list of External Cluster Resources
@@ -177,6 +184,9 @@ func (r *ReconcileStorageCluster) ensureExternalStorageClusterResources(instance
 				// Setting the PoolName for RBD StorageClass
 				sc = scs[1]
 			} else if d.Name == cephRgwStorageClassName {
+				// Set the external rgw endpoint variable for later use on the Noobaa CR (as a label)
+				externalRgwEndpoint = d.Data[externalCephRgwEndpointKey]
+
 				// Setting the Endpoint for OBC StorageClass
 				sc = scs[2]
 			}

--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -2,6 +2,7 @@ package storagecluster
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -185,7 +186,8 @@ func (r *ReconcileStorageCluster) ensureExternalStorageClusterResources(instance
 				sc = scs[1]
 			} else if d.Name == cephRgwStorageClassName {
 				// Set the external rgw endpoint variable for later use on the Noobaa CR (as a label)
-				externalRgwEndpoint = d.Data[externalCephRgwEndpointKey]
+				externalRgwEndpointToBase64 := base64.StdEncoding.EncodeToString([]byte(d.Data[externalCephRgwEndpointKey]))
+				externalRgwEndpoint = externalRgwEndpointToBase64
 
 				// Setting the Endpoint for OBC StorageClass
 				sc = scs[2]

--- a/pkg/controller/storagecluster/noobaa_system_reconciler.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler.go
@@ -19,6 +19,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+const (
+	// externalRgwEndpointLabelName is the name of the label that will be used by Noobaa to configure the S3 endpoint
+	externalRgwEndpointLabelName = "rgw-endpoint"
+)
+
 func (r *ReconcileStorageCluster) ensureNoobaaSystem(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
 	// find cephCluster
 	foundCeph := &cephv1.CephCluster{}
@@ -86,6 +91,11 @@ func (r *ReconcileStorageCluster) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *ocs
 
 	nb.Labels = map[string]string{
 		"app": "noobaa",
+	}
+	// If independent mode, we pass the endpoint value as a label to Noobaa
+	// so it can connect to the RGW S3 endpoint
+	if sc.Spec.ExternalStorage.Enable {
+		nb.Labels[externalRgwEndpointLabelName] = externalRgwEndpoint
 	}
 	nb.Spec.DBStorageClass = &storageClassName
 	nb.Spec.PVPoolDefaultStorageClass = &storageClassName

--- a/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -265,6 +265,8 @@ func assertNoobaaResource(t *testing.T, reconciler ReconcileStorageCluster) {
 	// expectation is to get an appropriate Noobaa object
 	err = reconciler.client.Get(nil, request.NamespacedName, fNoobaa)
 	assert.NoError(t, err)
+	assert.NotEmpty(t, fNoobaa.Labels[externalRgwEndpointLabelName])
+	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], "10.20.30.40:50")
 }
 
 func getReconciler(t *testing.T, objs ...runtime.Object) ReconcileStorageCluster {

--- a/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -266,7 +266,8 @@ func assertNoobaaResource(t *testing.T, reconciler ReconcileStorageCluster) {
 	err = reconciler.client.Get(nil, request.NamespacedName, fNoobaa)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, fNoobaa.Labels[externalRgwEndpointLabelName])
-	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], "10.20.30.40:50")
+	// The endpoint is base64 encoded, the decoded value is "10.20.30.40:50"
+	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], "MTAuMjAuMzAuNDA6NTA=")
 }
 
 func getReconciler(t *testing.T, objs ...runtime.Object) ReconcileStorageCluster {


### PR DESCRIPTION
cherry-pick of #569 and #580