### PR TITLE
do not encode rgw label endpoint

### DIFF
--- a/pkg/controller/storagecluster/initialization_reconciler.go
+++ b/pkg/controller/storagecluster/initialization_reconciler.go
@@ -2,10 +2,10 @@ package storagecluster
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/go-logr/logr"
 	ocsv1 "github.com/openshift/ocs-operator/pkg/apis/ocs/v1"
@@ -195,8 +195,9 @@ func (r *ReconcileStorageCluster) ensureExternalStorageClusterResources(instance
 				sc = scs[1]
 			} else if d.Name == cephRgwStorageClassName {
 				// Set the external rgw endpoint variable for later use on the Noobaa CR (as a label)
-				externalRgwEndpointToBase64 := base64.StdEncoding.EncodeToString([]byte(d.Data[externalCephRgwEndpointKey]))
-				externalRgwEndpoint = externalRgwEndpointToBase64
+				// Replace the colon with an underscore, otherwise the label will be invalid
+				externalRgwEndpointReplaceColon := strings.Replace(d.Data[externalCephRgwEndpointKey], ":", "_", -1)
+				externalRgwEndpoint = externalRgwEndpointReplaceColon
 
 				// Setting the Endpoint for OBC StorageClass
 				sc = scs[2]

--- a/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -266,8 +266,8 @@ func assertNoobaaResource(t *testing.T, reconciler ReconcileStorageCluster) {
 	err = reconciler.client.Get(nil, request.NamespacedName, fNoobaa)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, fNoobaa.Labels[externalRgwEndpointLabelName])
-	// The endpoint is base64 encoded, the decoded value is "10.20.30.40:50"
-	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], "MTAuMjAuMzAuNDA6NTA=")
+	// The endpoint has its colon replaced by an underscore so that the label is valid
+	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], "10.20.30.40_50")
 }
 
 func getReconciler(t *testing.T, objs ...runtime.Object) ReconcileStorageCluster {


### PR DESCRIPTION
Instead, let's use plain but replace the colon with an underscore.
Otherwise setting the label will fail with:

```
message: 'Error while reconciling: NooBaa.noobaa.io "noobaa" is invalid: metadata.labels:
  Invalid value: "MTAuMS44LjQxOjgwODA=": a valid label must be an empty string
  or consist of alphanumeric characters, ''-'', ''_'' or ''.'', and must start
  and end with an alphanumeric character (e.g. ''MyValue'',  or ''my_value'',  or
  ''12345'', regex used for validation is ''(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?'')'
reason: ReconcileFailed
```
Fixes the issue caused by: #580 
Signed-off-by: Sébastien Han <seb@redhat.com>

Corresponding Noobaa PR: https://github.com/noobaa/noobaa-operator/pull/360