### PR TITLE
Properly append LabelSelector

### DIFF
--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -335,8 +335,7 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster) []rook.StorageClassDevi
 						Operator: corev1.NodeSelectorOpIn,
 						Values:   []string{topologyKeyValues[topologyIndex]},
 					}
-					nodeSelectorTerms := placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-					nodeSelectorTerms[0].MatchExpressions = append(nodeSelectorTerms[0].MatchExpressions, nodeZoneSelector)
+					appendNodeRequirements(&placement, nodeZoneSelector)
 				}
 			} else {
 				placement = ds.Placement

--- a/pkg/controller/storagecluster/placement.go
+++ b/pkg/controller/storagecluster/placement.go
@@ -20,11 +20,17 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookv1.Placement {
 		in := defaults.DaemonPlacements[component]
 		(&in).DeepCopyInto(&placement)
 	}
-	if sc.Spec.LabelSelector == nil {
+
+	// If no placement is specified for the given component and the
+	// StorageCluster has no label selector, set the default node
+	// affinity.
+	if placement.NodeAffinity == nil && sc.Spec.LabelSelector == nil {
 		placement.NodeAffinity = defaults.DefaultNodeAffinity
-	} else {
-		// If the StorageCluster specifies a label selector, append it to the
-		// node affinity, creating it if it doesn't exist.
+	}
+
+	// If the StorageCluster specifies a label selector, append it to the
+	// node affinity, creating it if it doesn't exist.
+	if sc.Spec.LabelSelector != nil {
 		reqs := convertLabelToNodeSelectorRequirements(*sc.Spec.LabelSelector)
 		if len(reqs) != 0 {
 			appendNodeRequirements(&placement, reqs...)

--- a/pkg/controller/storagecluster/placement_test.go
+++ b/pkg/controller/storagecluster/placement_test.go
@@ -79,7 +79,7 @@ func TestGetPlacement(t *testing.T) {
 	sc = &ocsv1.StorageCluster{}
 	mockStorageCluster.DeepCopyInto(sc)
 	sc.Spec.Placement = mockPlacements
-	assert.Equal(t, defaultLabelPlacement["all"], getPlacement(sc, "all"))
+	assert.Equal(t, mockPlacements["all"], getPlacement(sc, "all"))
 
 	// Case 3: LabelSelector to modify the default placements correctly
 	sc = &ocsv1.StorageCluster{}

--- a/pkg/controller/storagecluster/placement_test.go
+++ b/pkg/controller/storagecluster/placement_test.go
@@ -16,160 +16,135 @@ const (
 	MasterAffinityKey = "node-role.kubernetes.io/master"
 )
 
-var mockPlacements = map[rookv1.KeyType]rookv1.Placement{
-	"all": rookv1.Placement{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					corev1.NodeSelectorTerm{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							corev1.NodeSelectorRequirement{
-								Key:      WorkerAffinityKey,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-						},
-					},
-				},
-			},
+var masterLabelSelector = metav1.LabelSelector{
+	MatchExpressions: []metav1.LabelSelectorRequirement{
+		metav1.LabelSelectorRequirement{
+			Key:      MasterAffinityKey,
+			Operator: metav1.LabelSelectorOpExists,
 		},
-		Tolerations: []corev1.Toleration{
-			corev1.Toleration{
-				Key:      defaults.NodeTolerationKey,
-				Operator: corev1.TolerationOpEqual,
-				Value:    "true",
-				Effect:   corev1.TaintEffectNoSchedule,
+	},
+}
+var masterSelectorRequirement = corev1.NodeSelectorRequirement{
+	Key:      MasterAffinityKey,
+	Operator: corev1.NodeSelectorOpExists,
+}
+
+var workerLabelSelector = metav1.LabelSelector{
+	MatchExpressions: []metav1.LabelSelectorRequirement{
+		metav1.LabelSelectorRequirement{
+			Key:      WorkerAffinityKey,
+			Operator: metav1.LabelSelectorOpExists,
+		},
+	},
+}
+var workerSelectorRequirement = corev1.NodeSelectorRequirement{
+	Key:      WorkerAffinityKey,
+	Operator: corev1.NodeSelectorOpExists,
+}
+var workerNodeSelector = corev1.NodeSelector{
+	NodeSelectorTerms: []corev1.NodeSelectorTerm{
+		corev1.NodeSelectorTerm{
+			MatchExpressions: []corev1.NodeSelectorRequirement{
+				workerSelectorRequirement,
 			},
 		},
 	},
 }
-var defaultLabelPlacement = map[rookv1.KeyType]rookv1.Placement{
+var workerNodeAffinity = corev1.NodeAffinity{
+	RequiredDuringSchedulingIgnoredDuringExecution: &workerNodeSelector,
+}
+var workerPlacements = map[rookv1.KeyType]rookv1.Placement{
 	"all": rookv1.Placement{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					corev1.NodeSelectorTerm{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							corev1.NodeSelectorRequirement{
-								Key:      defaults.NodeAffinityKey,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-						},
-					},
-				},
-			},
-		},
-		Tolerations: []corev1.Toleration{
-			corev1.Toleration{
-				Key:      defaults.NodeTolerationKey,
-				Operator: corev1.TolerationOpEqual,
-				Value:    "true",
-				Effect:   corev1.TaintEffectNoSchedule,
-			},
-		},
+		NodeAffinity: &workerNodeAffinity,
 	},
+}
+
+var emptyLabelSelector = metav1.LabelSelector{
+	MatchExpressions: []metav1.LabelSelectorRequirement{},
+}
+var emptyPlacements = map[rookv1.KeyType]rookv1.Placement{
+	"all": rookv1.Placement{},
 }
 
 func TestGetPlacement(t *testing.T) {
-	// Case 1: Defaults are preserved i.e no placement and no label selector
-	sc := &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	assert.Equal(t, defaultLabelPlacement["all"], getPlacement(sc, "all"))
-
-	// Case 2: The configured Placements override the defaults
-	sc = &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	sc.Spec.Placement = mockPlacements
-	assert.Equal(t, mockPlacements["all"], getPlacement(sc, "all"))
-
-	// Case 3: LabelSelector to modify the default placements correctly
-	sc = &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	sc.Spec.LabelSelector = &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			metav1.LabelSelectorRequirement{
-				Key:      WorkerAffinityKey,
-				Operator: metav1.LabelSelectorOpExists,
+	cases := []struct {
+		label             string
+		placements        rookv1.PlacementSpec
+		labelSelector     *metav1.LabelSelector
+		expectedPlacement rookv1.Placement
+	}{
+		{
+			label:         "Test Case 1: Defaults are preserved i.e no placement and no label selector",
+			placements:    rookv1.PlacementSpec{},
+			labelSelector: nil,
+			expectedPlacement: rookv1.Placement{
+				NodeAffinity: defaults.DefaultNodeAffinity,
+				Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
 			},
 		},
-	}
-	assert.Equal(t, mockPlacements["all"], getPlacement(sc, "all"))
-
-	// Case 4: LabelSelector modifies an empty NodeAffinity
-	sc = &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	sc.Spec.Placement = map[rookv1.KeyType]rookv1.Placement{
-		"all": rookv1.Placement{
-			Tolerations: defaults.DaemonPlacements["all"].Tolerations,
-		},
-	}
-	sc.Spec.LabelSelector = &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			metav1.LabelSelectorRequirement{
-				Key:      MasterAffinityKey,
-				Operator: metav1.LabelSelectorOpExists,
+		{
+			label:         "Case 2: The configured Placements override the defaults",
+			placements:    emptyPlacements,
+			labelSelector: nil,
+			expectedPlacement: rookv1.Placement{
+				NodeAffinity: defaults.DefaultNodeAffinity,
 			},
 		},
-	}
-	expectedPlacement := rookv1.Placement{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					corev1.NodeSelectorTerm{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							corev1.NodeSelectorRequirement{
-								Key:      MasterAffinityKey,
-								Operator: corev1.NodeSelectorOpExists,
+		{
+			label:         "Case 3: LabelSelector to modify the default Placements correctly",
+			placements:    rookv1.PlacementSpec{},
+			labelSelector: &workerLabelSelector,
+			expectedPlacement: rookv1.Placement{
+				NodeAffinity: &workerNodeAffinity,
+				Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
+			},
+		},
+		{
+			label:         "Case 4: LabelSelector modifies an empty NodeAffinity",
+			placements:    emptyPlacements,
+			labelSelector: &workerLabelSelector,
+			expectedPlacement: rookv1.Placement{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &workerNodeSelector,
+				},
+			},
+		},
+		{
+			label:         "Case 5: LabelSelector modifies a configured NodeAffinity",
+			placements:    workerPlacements,
+			labelSelector: &masterLabelSelector,
+			expectedPlacement: rookv1.Placement{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							corev1.NodeSelectorTerm{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									workerSelectorRequirement,
+									masterSelectorRequirement,
+								},
 							},
 						},
 					},
 				},
 			},
 		},
-		Tolerations: defaults.DaemonPlacements["all"].Tolerations,
-	}
-	assert.Equal(t, expectedPlacement, getPlacement(sc, "all"))
-
-	// Case 5: LabelSelector modifies a configured NodeAffinity
-	sc = &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	sc.Spec.Placement = mockPlacements
-	sc.Spec.LabelSelector = &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			metav1.LabelSelectorRequirement{
-				Key:      MasterAffinityKey,
-				Operator: metav1.LabelSelectorOpExists,
+		{
+			label:         "Case 6: Empty LabelSelector sets no NodeAffinity",
+			placements:    rookv1.PlacementSpec{},
+			labelSelector: &emptyLabelSelector,
+			expectedPlacement: rookv1.Placement{
+				Tolerations: defaults.DaemonPlacements["all"].Tolerations,
 			},
 		},
 	}
-	expectedPlacement = rookv1.Placement{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					corev1.NodeSelectorTerm{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							corev1.NodeSelectorRequirement{
-								Key:      WorkerAffinityKey,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-							corev1.NodeSelectorRequirement{
-								Key:      MasterAffinityKey,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-						},
-					},
-				},
-			},
-		},
-		Tolerations: defaults.DaemonPlacements["all"].Tolerations,
-	}
 
-	assert.Equal(t, expectedPlacement, getPlacement(sc, "all"))
-
-	// Case 6: Empty LabelSelector sets no Node Affinity
-	sc = &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	sc.Spec.LabelSelector = &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{},
+	for _, c := range cases {
+		sc := &ocsv1.StorageCluster{}
+		mockStorageCluster.DeepCopyInto(sc)
+		sc.Spec.Placement = c.placements
+		sc.Spec.LabelSelector = c.labelSelector
+		expectedPlacement := c.expectedPlacement
+		actualPlacement := getPlacement(sc, "all")
+		assert.Equal(t, expectedPlacement, actualPlacement, c.label)
 	}
-	assert.Equal(t, defaults.DaemonPlacements["all"], getPlacement(sc, "all"))
 }


### PR DESCRIPTION
The value of StorageCluster.Spec.LabelSelector was not being properly
appended to the generated Placements of the OCS components.
Specifically, adding a new NodeSelectorTerm results in a selector term that
is ORed with any other terms, whereas adding a new
NodeSelectorRequirement to an existing NodeSelectorTerm would result in
an AND of all requirements in that term. This commit makes it so the
LabelSelector field is ANDed with any other existing node selectors in
the Placement, properly omitting a selector if an empty LabelSelector is
specified.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>