### PR TITLE
[WIP] Fix empty label selector crash

### DIFF
--- a/pkg/controller/storagecluster/placement.go
+++ b/pkg/controller/storagecluster/placement.go
@@ -23,13 +23,14 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookv1.Placement {
 	if sc.Spec.LabelSelector == nil {
 		placement.NodeAffinity = defaults.DefaultNodeAffinity
 	} else {
+		placement.NodeAffinity = &corev1.NodeAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{},
+		}
+
 		term := convertLabelToNodeSelector(*sc.Spec.LabelSelector)
 		if len(term.MatchExpressions) != 0 {
-			placement.NodeAffinity = &corev1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-					NodeSelectorTerms: []corev1.NodeSelectorTerm{term},
-				},
-			}
+			placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms =
+				[]corev1.NodeSelectorTerm{term}
 		}
 	}
 

--- a/pkg/controller/storagecluster/placement_test.go
+++ b/pkg/controller/storagecluster/placement_test.go
@@ -116,5 +116,9 @@ func TestGetPlacement(t *testing.T) {
 	sc.Spec.LabelSelector = &metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{},
 	}
-	assert.Equal(t, defaults.DaemonPlacements["all"], getPlacement(sc, "all"))
+	expectedPlacement := defaults.DaemonPlacements["all"]
+	expectedPlacement.NodeAffinity = &corev1.NodeAffinity{
+		RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{},
+	}
+	assert.Equal(t, expectedPlacement, getPlacement(sc, "all"))
 }


### PR DESCRIPTION
This is a more minimal attempt at #618 to fix the segfault in `newStorageClassDeviceSets` when an empty labelselector is provided.

This is more minimal for easier backporting.
It also provides a test case as a separate patch that demonstrates the segfault without this patch.

The refactoring and enhancement of #618 could follow on top.