### PR TITLE
Bug 1854651: [release 4.5] backport pr 618 - fix segfault

### DIFF
--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -335,8 +335,7 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster) []rook.StorageClassDevi
 						Operator: corev1.NodeSelectorOpIn,
 						Values:   []string{topologyKeyValues[topologyIndex]},
 					}
-					nodeSelectorTerms := placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-					nodeSelectorTerms[0].MatchExpressions = append(nodeSelectorTerms[0].MatchExpressions, nodeZoneSelector)
+					appendNodeRequirements(&placement, nodeZoneSelector)
 				}
 			} else {
 				placement = ds.Placement

--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -1,0 +1,375 @@
+package storagecluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+	"strconv"
+
+	"github.com/go-logr/logr"
+	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
+	ocsv1 "github.com/openshift/ocs-operator/pkg/apis/ocs/v1"
+	"github.com/openshift/ocs-operator/pkg/controller/defaults"
+	statusutil "github.com/openshift/ocs-operator/pkg/controller/util"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rook "github.com/rook/rook/pkg/apis/rook.io/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/reference"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// ensureCephCluster ensures that a CephCluster resource exists with its Spec in
+// the desired state.
+func (r *ReconcileStorageCluster) ensureCephCluster(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
+	if sc.Spec.ExternalStorage.Enable && len(sc.Spec.StorageDeviceSets) != 0 {
+		return fmt.Errorf("'StorageDeviceSets' should not be initialized in an external CephCluster")
+	}
+	// if StorageClass is "gp2" or "io1" based, set tuneSlowDeviceClass to true
+	// this is for performance optimization of slow device class
+	//TODO: If for a StorageDeviceSet there is a separate metadata pvc template, check for StorageClass of data pvc template only
+	for i, ds := range sc.Spec.StorageDeviceSets {
+		throttle, err := r.throttleStorageDevices(*ds.DataPVCTemplate.Spec.StorageClassName)
+		if err != nil {
+			return fmt.Errorf("Failed to verify StorageClass provisioner. %+v", err)
+		}
+		if throttle {
+			sc.Spec.StorageDeviceSets[i].Config.TuneSlowDeviceClass = true
+		} else {
+			sc.Spec.StorageDeviceSets[i].Config.TuneSlowDeviceClass = false
+		}
+	}
+
+	var cephCluster *cephv1.CephCluster
+	// Define a new CephCluster object
+	if sc.Spec.ExternalStorage.Enable {
+		cephCluster = newExternalCephCluster(sc, r.cephImage)
+	} else {
+		cephCluster = newCephCluster(sc, r.cephImage, r.nodeCount, reqLogger)
+	}
+
+	// Set StorageCluster instance as the owner and controller
+	if err := controllerutil.SetControllerReference(sc, cephCluster, r.scheme); err != nil {
+		return err
+	}
+
+	// Check if this CephCluster already exists
+	found := &cephv1.CephCluster{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: cephCluster.Name, Namespace: cephCluster.Namespace}, found)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if sc.Spec.ExternalStorage.Enable {
+				reqLogger.Info("Creating external CephCluster")
+			} else {
+				reqLogger.Info("Creating CephCluster")
+			}
+			return r.client.Create(context.TODO(), cephCluster)
+		}
+		return err
+	}
+
+	// Update the CephCluster if it is not in the desired state
+	if !reflect.DeepEqual(cephCluster.Spec, found.Spec) {
+		reqLogger.Info("Updating spec for CephCluster")
+		if !sc.Spec.ExternalStorage.Enable {
+			// Check if Cluster is Expanding
+			if len(found.Spec.Storage.StorageClassDeviceSets) < len(cephCluster.Spec.Storage.StorageClassDeviceSets) {
+				r.phase = statusutil.PhaseClusterExpanding
+			} else if len(found.Spec.Storage.StorageClassDeviceSets) == len(cephCluster.Spec.Storage.StorageClassDeviceSets) {
+				for _, countInFoundSpec := range found.Spec.Storage.StorageClassDeviceSets {
+					for _, countInCephClusterSpec := range cephCluster.Spec.Storage.StorageClassDeviceSets {
+						if countInFoundSpec.Name == countInCephClusterSpec.Name && countInCephClusterSpec.Count > countInFoundSpec.Count {
+							r.phase = statusutil.PhaseClusterExpanding
+							break
+						}
+					}
+					if r.phase == statusutil.PhaseClusterExpanding {
+						break
+					}
+				}
+			}
+		}
+		found.Spec = cephCluster.Spec
+		return r.client.Update(context.TODO(), found)
+	}
+
+	// Add it to the list of RelatedObjects if found
+	objectRef, err := reference.GetReference(r.scheme, found)
+	if err != nil {
+		return err
+	}
+	objectreferencesv1.SetObjectReference(&sc.Status.RelatedObjects, *objectRef)
+
+	// Handle CephCluster resource status
+	if found.Status.State == "" {
+		reqLogger.Info("CephCluster resource is not reporting status.")
+		// What does this mean to OCS status? Assuming progress.
+		reason := "CephClusterStatus"
+		message := "CephCluster resource is not reporting status"
+		statusutil.MapCephClusterNoConditions(&r.conditions, reason, message)
+	} else {
+		// Interpret CephCluster status and set any negative conditions
+		if sc.Spec.ExternalStorage.Enable {
+			statusutil.MapExternalCephClusterNegativeConditions(&r.conditions, found)
+		} else {
+			statusutil.MapCephClusterNegativeConditions(&r.conditions, found)
+		}
+	}
+
+	// When phase is expanding, wait for CephCluster state to be updating
+	// this means expansion is in progress and overall system is progressing
+	// else expansion is not yet triggered
+	if sc.Status.Phase == statusutil.PhaseClusterExpanding &&
+		found.Status.State != cephv1.ClusterStateUpdating {
+		r.phase = statusutil.PhaseClusterExpanding
+	}
+
+	if sc.Spec.ExternalStorage.Enable {
+		if found.Status.State == cephv1.ClusterStateConnecting {
+			sc.Status.Phase = statusutil.PhaseConnecting
+		} else if found.Status.State == cephv1.ClusterStateConnected {
+			sc.Status.Phase = statusutil.PhaseReady
+		} else {
+			sc.Status.Phase = statusutil.PhaseNotReady
+		}
+
+		if err = r.client.Status().Update(context.TODO(), sc); err != nil {
+			reqLogger.Error(err, "Failed to update external cluster status")
+			return err
+		}
+	}
+
+	return nil
+}
+
+// newCephCluster returns a CephCluster object.
+func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, reqLogger logr.Logger) *cephv1.CephCluster {
+	labels := map[string]string{
+		"app": sc.Name,
+	}
+
+	cephCluster := &cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateNameForCephCluster(sc),
+			Namespace: sc.Namespace,
+			Labels:    labels,
+		},
+		Spec: cephv1.ClusterSpec{
+			CephVersion: cephv1.CephVersionSpec{
+				Image:            cephImage,
+				AllowUnsupported: false,
+			},
+			Mon: cephv1.MonSpec{
+				Count:                getMonCount(nodeCount),
+				AllowMultiplePerNode: false,
+			},
+			Mgr: cephv1.MgrSpec{
+				Modules: []cephv1.Module{
+					cephv1.Module{Name: "pg_autoscaler", Enabled: true},
+					cephv1.Module{Name: "balancer", Enabled: true},
+				},
+			},
+			DataDirHostPath: "/var/lib/rook",
+			DisruptionManagement: cephv1.DisruptionManagementSpec{
+				ManagePodBudgets:                 true,
+				ManageMachineDisruptionBudgets:   false,
+				MachineDisruptionBudgetNamespace: "openshift-machine-api",
+			},
+			RBDMirroring: cephv1.RBDMirroringSpec{
+				Workers: 0,
+			},
+			Network: cephv1.NetworkSpec{
+				HostNetwork: sc.Spec.HostNetwork,
+			},
+			Monitoring: cephv1.MonitoringSpec{
+				Enabled:        true,
+				RulesNamespace: "openshift-storage",
+			},
+			Storage: rook.StorageScopeSpec{
+				StorageClassDeviceSets: newStorageClassDeviceSets(sc),
+			},
+			Placement: rook.PlacementSpec{
+				"all": getPlacement(sc, "all"),
+				"mon": getPlacement(sc, "mon"),
+				"rgw": getPlacement(sc, "rgw"),
+				"mds": getPlacement(sc, "mds"),
+			},
+			Resources: newCephDaemonResources(sc.Spec.Resources),
+			ContinueUpgradeAfterChecksEvenIfNotHealthy: true,
+		},
+	}
+	monPVCTemplate := sc.Spec.MonPVCTemplate
+	monDataDirHostPath := sc.Spec.MonDataDirHostPath
+	// If the `monPVCTemplate` is provided, the mons will provisioned on the
+	// provided `monPVCTemplate`.
+	if monPVCTemplate != nil {
+		cephCluster.Spec.Mon.VolumeClaimTemplate = monPVCTemplate
+		// If the `monDataDirHostPath` is provided without the `monPVCTemplate`,
+		// the mons will be provisioned on the provided `monDataDirHostPath`.
+	} else if len(monDataDirHostPath) > 0 {
+		cephCluster.Spec.DataDirHostPath = monDataDirHostPath
+		// If no `monPVCTemplate` and `monDataDirHostPath` is provided, the mons will
+		// be provisioned using the PVC template of first StorageDeviceSets if present.
+	} else if len(sc.Spec.StorageDeviceSets) > 0 {
+		ds := sc.Spec.StorageDeviceSets[0]
+		cephCluster.Spec.Mon.VolumeClaimTemplate = &corev1.PersistentVolumeClaim{
+			Spec: corev1.PersistentVolumeClaimSpec{
+				StorageClassName: ds.DataPVCTemplate.Spec.StorageClassName,
+				Resources: corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("10Gi"),
+					},
+				},
+			},
+		}
+	} else {
+		reqLogger.Info(fmt.Sprintf("No monDataDirHostPath, monPVCTemplate or storageDeviceSets configured for storageCluster %s", sc.GetName()))
+	}
+	return cephCluster
+}
+
+func newExternalCephCluster(sc *ocsv1.StorageCluster, cephImage string) *cephv1.CephCluster {
+	labels := map[string]string{
+		"app": sc.Name,
+	}
+	externalCephCluster := &cephv1.CephCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      generateNameForCephCluster(sc),
+			Namespace: sc.Namespace,
+			Labels:    labels,
+		},
+		Spec: cephv1.ClusterSpec{
+			External: cephv1.ExternalSpec{
+				Enable: true,
+			},
+			CrashCollector: cephv1.CrashCollectorSpec{
+				Disable: true,
+			},
+		},
+	}
+	return externalCephCluster
+}
+
+func getMonCount(nodeCount int) int {
+	count := defaults.MonCountMin
+
+	// return static value if overriden
+	override := os.Getenv(monCountOverrideEnvVar)
+	if override != "" {
+		count, err := strconv.Atoi(override)
+		if err != nil {
+			log.Error(err, "could not decode env var %s", monCountOverrideEnvVar)
+		} else {
+			return count
+		}
+	}
+
+	if nodeCount >= defaults.MonCountMax {
+		count = defaults.MonCountMax
+	}
+
+	return count
+}
+
+// newStorageClassDeviceSets converts a list of StorageDeviceSets into a list of Rook StorageClassDeviceSets
+func newStorageClassDeviceSets(sc *ocsv1.StorageCluster) []rook.StorageClassDeviceSet {
+	storageDeviceSets := sc.Spec.StorageDeviceSets
+	topologyMap := sc.Status.NodeTopologies
+
+	var storageClassDeviceSets []rook.StorageClassDeviceSet
+
+	for _, ds := range storageDeviceSets {
+		resources := ds.Resources
+		if resources.Requests == nil && resources.Limits == nil {
+			resources = defaults.DaemonResources["osd"]
+		}
+
+		topologyKey := ds.TopologyKey
+		topologyKeyValues := []string{}
+		noPlacement := ds.Placement.NodeAffinity == nil && ds.Placement.PodAffinity == nil && ds.Placement.PodAntiAffinity == nil
+
+		if noPlacement {
+			if topologyKey == "" {
+				topologyKey = determineFailureDomain(sc)
+			}
+			if topologyMap != nil {
+				topologyKey, topologyKeyValues = topologyMap.GetKeyValues(topologyKey)
+			}
+		}
+
+		count := ds.Count
+		replica := ds.Replica
+		if replica == 0 {
+			replica = defaults.DeviceSetReplica
+
+			// This is a temporary hack in place due to limitations
+			// in the current implementation of the OCP console.
+			// The console is hardcoded to create a StorageCluster
+			// with a Count of 3, as made sense for the previous
+			// behavior, but it cannot be updated until the next
+			// z-stream release of OCP 4.2. This workaround is to
+			// enable the new behavior while the console is waiting
+			// to be updated.
+			// TODO: Remove this behavior when OCP console is updated
+			count = count / 3
+		}
+
+		for i := 0; i < replica; i++ {
+			placement := rook.Placement{}
+
+			if noPlacement {
+				in := getPlacement(sc, "osd")
+				(&in).DeepCopyInto(&placement)
+
+				if len(topologyKeyValues) >= replica {
+					podAffinityTerms := placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+					podAffinityTerms[0].PodAffinityTerm.TopologyKey = topologyKey
+
+					topologyIndex := i % len(topologyKeyValues)
+					nodeZoneSelector := corev1.NodeSelectorRequirement{
+						Key:      topologyKey,
+						Operator: corev1.NodeSelectorOpIn,
+						Values:   []string{topologyKeyValues[topologyIndex]},
+					}
+					nodeSelectorTerms := placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+					nodeSelectorTerms[0].MatchExpressions = append(nodeSelectorTerms[0].MatchExpressions, nodeZoneSelector)
+				}
+			} else {
+				placement = ds.Placement
+			}
+
+			set := rook.StorageClassDeviceSet{
+				Name:                 fmt.Sprintf("%s-%d", ds.Name, i),
+				Count:                count,
+				Resources:            resources,
+				Placement:            placement,
+				Config:               ds.Config.ToMap(),
+				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{ds.DataPVCTemplate},
+				Portable:             ds.Portable,
+				TuneSlowDeviceClass:  ds.Config.TuneSlowDeviceClass,
+			}
+			storageClassDeviceSets = append(storageClassDeviceSets, set)
+		}
+	}
+
+	return storageClassDeviceSets
+}
+
+func newCephDaemonResources(custom map[string]corev1.ResourceRequirements) map[string]corev1.ResourceRequirements {
+	resources := map[string]corev1.ResourceRequirements{
+		"mon": defaults.GetDaemonResources("mon", custom),
+		"mgr": defaults.GetDaemonResources("mgr", custom),
+	}
+
+	for k := range resources {
+		if r, ok := custom[k]; ok {
+			resources[k] = r
+		}
+	}
+
+	return resources
+}

--- a/pkg/controller/storagecluster/placement.go
+++ b/pkg/controller/storagecluster/placement.go
@@ -20,11 +20,17 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookv1.Placement {
 		in := defaults.DaemonPlacements[component]
 		(&in).DeepCopyInto(&placement)
 	}
-	if sc.Spec.LabelSelector == nil {
+
+	// If no placement is specified for the given component and the
+	// StorageCluster has no label selector, set the default node
+	// affinity.
+	if placement.NodeAffinity == nil && sc.Spec.LabelSelector == nil {
 		placement.NodeAffinity = defaults.DefaultNodeAffinity
-	} else {
-		// If the StorageCluster specifies a label selector, append it to the
-		// node affinity, creating it if it doesn't exist.
+	}
+
+	// If the StorageCluster specifies a label selector, append it to the
+	// node affinity, creating it if it doesn't exist.
+	if sc.Spec.LabelSelector != nil {
 		reqs := convertLabelToNodeSelectorRequirements(*sc.Spec.LabelSelector)
 		if len(reqs) != 0 {
 			appendNodeRequirements(&placement, reqs...)

--- a/pkg/controller/storagecluster/placement_test.go
+++ b/pkg/controller/storagecluster/placement_test.go
@@ -79,7 +79,7 @@ func TestGetPlacement(t *testing.T) {
 	sc = &ocsv1.StorageCluster{}
 	mockStorageCluster.DeepCopyInto(sc)
 	sc.Spec.Placement = mockPlacements
-	assert.Equal(t, defaultLabelPlacement["all"], getPlacement(sc, "all"))
+	assert.Equal(t, mockPlacements["all"], getPlacement(sc, "all"))
 
 	// Case 3: LabelSelector to modify the default placements correctly
 	sc = &ocsv1.StorageCluster{}

--- a/pkg/controller/storagecluster/placement_test.go
+++ b/pkg/controller/storagecluster/placement_test.go
@@ -16,160 +16,135 @@ const (
 	MasterAffinityKey = "node-role.kubernetes.io/master"
 )
 
-var mockPlacements = map[rookv1.KeyType]rookv1.Placement{
-	"all": rookv1.Placement{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					corev1.NodeSelectorTerm{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							corev1.NodeSelectorRequirement{
-								Key:      WorkerAffinityKey,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-						},
-					},
-				},
-			},
+var masterLabelSelector = metav1.LabelSelector{
+	MatchExpressions: []metav1.LabelSelectorRequirement{
+		metav1.LabelSelectorRequirement{
+			Key:      MasterAffinityKey,
+			Operator: metav1.LabelSelectorOpExists,
 		},
-		Tolerations: []corev1.Toleration{
-			corev1.Toleration{
-				Key:      defaults.NodeTolerationKey,
-				Operator: corev1.TolerationOpEqual,
-				Value:    "true",
-				Effect:   corev1.TaintEffectNoSchedule,
+	},
+}
+var masterSelectorRequirement = corev1.NodeSelectorRequirement{
+	Key:      MasterAffinityKey,
+	Operator: corev1.NodeSelectorOpExists,
+}
+
+var workerLabelSelector = metav1.LabelSelector{
+	MatchExpressions: []metav1.LabelSelectorRequirement{
+		metav1.LabelSelectorRequirement{
+			Key:      WorkerAffinityKey,
+			Operator: metav1.LabelSelectorOpExists,
+		},
+	},
+}
+var workerSelectorRequirement = corev1.NodeSelectorRequirement{
+	Key:      WorkerAffinityKey,
+	Operator: corev1.NodeSelectorOpExists,
+}
+var workerNodeSelector = corev1.NodeSelector{
+	NodeSelectorTerms: []corev1.NodeSelectorTerm{
+		corev1.NodeSelectorTerm{
+			MatchExpressions: []corev1.NodeSelectorRequirement{
+				workerSelectorRequirement,
 			},
 		},
 	},
 }
-var defaultLabelPlacement = map[rookv1.KeyType]rookv1.Placement{
+var workerNodeAffinity = corev1.NodeAffinity{
+	RequiredDuringSchedulingIgnoredDuringExecution: &workerNodeSelector,
+}
+var workerPlacements = map[rookv1.KeyType]rookv1.Placement{
 	"all": rookv1.Placement{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					corev1.NodeSelectorTerm{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							corev1.NodeSelectorRequirement{
-								Key:      defaults.NodeAffinityKey,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-						},
-					},
-				},
-			},
-		},
-		Tolerations: []corev1.Toleration{
-			corev1.Toleration{
-				Key:      defaults.NodeTolerationKey,
-				Operator: corev1.TolerationOpEqual,
-				Value:    "true",
-				Effect:   corev1.TaintEffectNoSchedule,
-			},
-		},
+		NodeAffinity: &workerNodeAffinity,
 	},
+}
+
+var emptyLabelSelector = metav1.LabelSelector{
+	MatchExpressions: []metav1.LabelSelectorRequirement{},
+}
+var emptyPlacements = map[rookv1.KeyType]rookv1.Placement{
+	"all": rookv1.Placement{},
 }
 
 func TestGetPlacement(t *testing.T) {
-	// Case 1: Defaults are preserved i.e no placement and no label selector
-	sc := &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	assert.Equal(t, defaultLabelPlacement["all"], getPlacement(sc, "all"))
-
-	// Case 2: The configured Placements override the defaults
-	sc = &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	sc.Spec.Placement = mockPlacements
-	assert.Equal(t, mockPlacements["all"], getPlacement(sc, "all"))
-
-	// Case 3: LabelSelector to modify the default placements correctly
-	sc = &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	sc.Spec.LabelSelector = &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			metav1.LabelSelectorRequirement{
-				Key:      WorkerAffinityKey,
-				Operator: metav1.LabelSelectorOpExists,
+	cases := []struct {
+		label             string
+		placements        rookv1.PlacementSpec
+		labelSelector     *metav1.LabelSelector
+		expectedPlacement rookv1.Placement
+	}{
+		{
+			label:         "Test Case 1: Defaults are preserved i.e no placement and no label selector",
+			placements:    rookv1.PlacementSpec{},
+			labelSelector: nil,
+			expectedPlacement: rookv1.Placement{
+				NodeAffinity: defaults.DefaultNodeAffinity,
+				Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
 			},
 		},
-	}
-	assert.Equal(t, mockPlacements["all"], getPlacement(sc, "all"))
-
-	// Case 4: LabelSelector modifies an empty NodeAffinity
-	sc = &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	sc.Spec.Placement = map[rookv1.KeyType]rookv1.Placement{
-		"all": rookv1.Placement{
-			Tolerations: defaults.DaemonPlacements["all"].Tolerations,
-		},
-	}
-	sc.Spec.LabelSelector = &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			metav1.LabelSelectorRequirement{
-				Key:      MasterAffinityKey,
-				Operator: metav1.LabelSelectorOpExists,
+		{
+			label:         "Case 2: The configured Placements override the defaults",
+			placements:    emptyPlacements,
+			labelSelector: nil,
+			expectedPlacement: rookv1.Placement{
+				NodeAffinity: defaults.DefaultNodeAffinity,
 			},
 		},
-	}
-	expectedPlacement := rookv1.Placement{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					corev1.NodeSelectorTerm{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							corev1.NodeSelectorRequirement{
-								Key:      MasterAffinityKey,
-								Operator: corev1.NodeSelectorOpExists,
+		{
+			label:         "Case 3: LabelSelector to modify the default Placements correctly",
+			placements:    rookv1.PlacementSpec{},
+			labelSelector: &workerLabelSelector,
+			expectedPlacement: rookv1.Placement{
+				NodeAffinity: &workerNodeAffinity,
+				Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
+			},
+		},
+		{
+			label:         "Case 4: LabelSelector modifies an empty NodeAffinity",
+			placements:    emptyPlacements,
+			labelSelector: &workerLabelSelector,
+			expectedPlacement: rookv1.Placement{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &workerNodeSelector,
+				},
+			},
+		},
+		{
+			label:         "Case 5: LabelSelector modifies a configured NodeAffinity",
+			placements:    workerPlacements,
+			labelSelector: &masterLabelSelector,
+			expectedPlacement: rookv1.Placement{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							corev1.NodeSelectorTerm{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									workerSelectorRequirement,
+									masterSelectorRequirement,
+								},
 							},
 						},
 					},
 				},
 			},
 		},
-		Tolerations: defaults.DaemonPlacements["all"].Tolerations,
-	}
-	assert.Equal(t, expectedPlacement, getPlacement(sc, "all"))
-
-	// Case 5: LabelSelector modifies a configured NodeAffinity
-	sc = &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	sc.Spec.Placement = mockPlacements
-	sc.Spec.LabelSelector = &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			metav1.LabelSelectorRequirement{
-				Key:      MasterAffinityKey,
-				Operator: metav1.LabelSelectorOpExists,
+		{
+			label:         "Case 6: Empty LabelSelector sets no NodeAffinity",
+			placements:    rookv1.PlacementSpec{},
+			labelSelector: &emptyLabelSelector,
+			expectedPlacement: rookv1.Placement{
+				Tolerations: defaults.DaemonPlacements["all"].Tolerations,
 			},
 		},
 	}
-	expectedPlacement = rookv1.Placement{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					corev1.NodeSelectorTerm{
-						MatchExpressions: []corev1.NodeSelectorRequirement{
-							corev1.NodeSelectorRequirement{
-								Key:      WorkerAffinityKey,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-							corev1.NodeSelectorRequirement{
-								Key:      MasterAffinityKey,
-								Operator: corev1.NodeSelectorOpExists,
-							},
-						},
-					},
-				},
-			},
-		},
-		Tolerations: defaults.DaemonPlacements["all"].Tolerations,
-	}
 
-	assert.Equal(t, expectedPlacement, getPlacement(sc, "all"))
-
-	// Case 6: Empty LabelSelector sets no Node Affinity
-	sc = &ocsv1.StorageCluster{}
-	mockStorageCluster.DeepCopyInto(sc)
-	sc.Spec.LabelSelector = &metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{},
+	for _, c := range cases {
+		sc := &ocsv1.StorageCluster{}
+		mockStorageCluster.DeepCopyInto(sc)
+		sc.Spec.Placement = c.placements
+		sc.Spec.LabelSelector = c.labelSelector
+		expectedPlacement := c.expectedPlacement
+		actualPlacement := getPlacement(sc, "all")
+		assert.Equal(t, expectedPlacement, actualPlacement, c.label)
 	}
-	assert.Equal(t, defaults.DaemonPlacements["all"], getPlacement(sc, "all"))
 }

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -5,34 +5,28 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/blang/semver"
 	"github.com/go-logr/logr"
 	openshiftv1 "github.com/openshift/api/template/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
-	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
 	ocsv1 "github.com/openshift/ocs-operator/pkg/apis/ocs/v1"
 	"github.com/openshift/ocs-operator/pkg/controller/defaults"
 	statusutil "github.com/openshift/ocs-operator/pkg/controller/util"
 	"github.com/openshift/ocs-operator/version"
 	"github.com/operator-framework/operator-sdk/pkg/ready"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	rook "github.com/rook/rook/pkg/apis/rook.io/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
-	"k8s.io/client-go/tools/reference"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -713,129 +707,6 @@ func (r *ReconcileStorageCluster) ensureCephConfig(sc *ocsv1.StorageCluster, req
 	return nil
 }
 
-// ensureCephCluster ensures that a CephCluster resource exists with its Spec in
-// the desired state.
-func (r *ReconcileStorageCluster) ensureCephCluster(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
-	if sc.Spec.ExternalStorage.Enable && len(sc.Spec.StorageDeviceSets) != 0 {
-		return fmt.Errorf("'StorageDeviceSets' should not be initialized in an external CephCluster")
-	}
-	// if StorageClass is "gp2" or "io1" based, set tuneSlowDeviceClass to true
-	// this is for performance optimization of slow device class
-	//TODO: If for a StorageDeviceSet there is a separate metadata pvc template, check for StorageClass of data pvc template only
-	for i, ds := range sc.Spec.StorageDeviceSets {
-		throttle, err := r.throttleStorageDevices(*ds.DataPVCTemplate.Spec.StorageClassName)
-		if err != nil {
-			return fmt.Errorf("Failed to verify StorageClass provisioner. %+v", err)
-		}
-		if throttle {
-			sc.Spec.StorageDeviceSets[i].Config.TuneSlowDeviceClass = true
-		} else {
-			sc.Spec.StorageDeviceSets[i].Config.TuneSlowDeviceClass = false
-		}
-	}
-
-	var cephCluster *cephv1.CephCluster
-	// Define a new CephCluster object
-	if sc.Spec.ExternalStorage.Enable {
-		cephCluster = newExternalCephCluster(sc, r.cephImage)
-	} else {
-		cephCluster = newCephCluster(sc, r.cephImage, r.nodeCount, reqLogger)
-	}
-
-	// Set StorageCluster instance as the owner and controller
-	if err := controllerutil.SetControllerReference(sc, cephCluster, r.scheme); err != nil {
-		return err
-	}
-
-	// Check if this CephCluster already exists
-	found := &cephv1.CephCluster{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: cephCluster.Name, Namespace: cephCluster.Namespace}, found)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			if sc.Spec.ExternalStorage.Enable {
-				reqLogger.Info("Creating external CephCluster")
-			} else {
-				reqLogger.Info("Creating CephCluster")
-			}
-			return r.client.Create(context.TODO(), cephCluster)
-		}
-		return err
-	}
-
-	// Update the CephCluster if it is not in the desired state
-	if !reflect.DeepEqual(cephCluster.Spec, found.Spec) {
-		reqLogger.Info("Updating spec for CephCluster")
-		if !sc.Spec.ExternalStorage.Enable {
-			// Check if Cluster is Expanding
-			if len(found.Spec.Storage.StorageClassDeviceSets) < len(cephCluster.Spec.Storage.StorageClassDeviceSets) {
-				r.phase = statusutil.PhaseClusterExpanding
-			} else if len(found.Spec.Storage.StorageClassDeviceSets) == len(cephCluster.Spec.Storage.StorageClassDeviceSets) {
-				for _, countInFoundSpec := range found.Spec.Storage.StorageClassDeviceSets {
-					for _, countInCephClusterSpec := range cephCluster.Spec.Storage.StorageClassDeviceSets {
-						if countInFoundSpec.Name == countInCephClusterSpec.Name && countInCephClusterSpec.Count > countInFoundSpec.Count {
-							r.phase = statusutil.PhaseClusterExpanding
-							break
-						}
-					}
-					if r.phase == statusutil.PhaseClusterExpanding {
-						break
-					}
-				}
-			}
-		}
-		found.Spec = cephCluster.Spec
-		return r.client.Update(context.TODO(), found)
-	}
-
-	// Add it to the list of RelatedObjects if found
-	objectRef, err := reference.GetReference(r.scheme, found)
-	if err != nil {
-		return err
-	}
-	objectreferencesv1.SetObjectReference(&sc.Status.RelatedObjects, *objectRef)
-
-	// Handle CephCluster resource status
-	if found.Status.State == "" {
-		reqLogger.Info("CephCluster resource is not reporting status.")
-		// What does this mean to OCS status? Assuming progress.
-		reason := "CephClusterStatus"
-		message := "CephCluster resource is not reporting status"
-		statusutil.MapCephClusterNoConditions(&r.conditions, reason, message)
-	} else {
-		// Interpret CephCluster status and set any negative conditions
-		if sc.Spec.ExternalStorage.Enable {
-			statusutil.MapExternalCephClusterNegativeConditions(&r.conditions, found)
-		} else {
-			statusutil.MapCephClusterNegativeConditions(&r.conditions, found)
-		}
-	}
-
-	// When phase is expanding, wait for CephCluster state to be updating
-	// this means expansion is in progress and overall system is progressing
-	// else expansion is not yet triggered
-	if sc.Status.Phase == statusutil.PhaseClusterExpanding &&
-		found.Status.State != cephv1.ClusterStateUpdating {
-		r.phase = statusutil.PhaseClusterExpanding
-	}
-
-	if sc.Spec.ExternalStorage.Enable {
-		if found.Status.State == cephv1.ClusterStateConnecting {
-			sc.Status.Phase = statusutil.PhaseConnecting
-		} else if found.Status.State == cephv1.ClusterStateConnected {
-			sc.Status.Phase = statusutil.PhaseReady
-		} else {
-			sc.Status.Phase = statusutil.PhaseNotReady
-		}
-
-		if err = r.client.Status().Update(context.TODO(), sc); err != nil {
-			reqLogger.Error(err, "Failed to update external cluster status")
-			return err
-		}
-	}
-
-	return nil
-}
-
 // determineFailureDomain determines the appropriate Ceph failure domain based
 // on the storage cluster's topology map
 func determineFailureDomain(sc *ocsv1.StorageCluster) string {
@@ -852,213 +723,6 @@ func determineFailureDomain(sc *ocsv1.StorageCluster) string {
 		}
 	}
 	return failureDomain
-}
-
-// newCephCluster returns a CephCluster object.
-func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, reqLogger logr.Logger) *cephv1.CephCluster {
-	labels := map[string]string{
-		"app": sc.Name,
-	}
-
-	cephCluster := &cephv1.CephCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      generateNameForCephCluster(sc),
-			Namespace: sc.Namespace,
-			Labels:    labels,
-		},
-		Spec: cephv1.ClusterSpec{
-			CephVersion: cephv1.CephVersionSpec{
-				Image:            cephImage,
-				AllowUnsupported: false,
-			},
-			Mon: cephv1.MonSpec{
-				Count:                getMonCount(nodeCount),
-				AllowMultiplePerNode: false,
-			},
-			Mgr: cephv1.MgrSpec{
-				Modules: []cephv1.Module{
-					cephv1.Module{Name: "pg_autoscaler", Enabled: true},
-					cephv1.Module{Name: "balancer", Enabled: true},
-				},
-			},
-			DataDirHostPath: "/var/lib/rook",
-			DisruptionManagement: cephv1.DisruptionManagementSpec{
-				ManagePodBudgets:                 true,
-				ManageMachineDisruptionBudgets:   false,
-				MachineDisruptionBudgetNamespace: "openshift-machine-api",
-			},
-			RBDMirroring: cephv1.RBDMirroringSpec{
-				Workers: 0,
-			},
-			Network: cephv1.NetworkSpec{
-				HostNetwork: sc.Spec.HostNetwork,
-			},
-			Monitoring: cephv1.MonitoringSpec{
-				Enabled:        true,
-				RulesNamespace: "openshift-storage",
-			},
-			Storage: rook.StorageScopeSpec{
-				StorageClassDeviceSets: newStorageClassDeviceSets(sc),
-			},
-			Placement: rook.PlacementSpec{
-				"all": getPlacement(sc, "all"),
-				"mon": getPlacement(sc, "mon"),
-				"rgw": getPlacement(sc, "rgw"),
-				"mds": getPlacement(sc, "mds"),
-			},
-			Resources: newCephDaemonResources(sc.Spec.Resources),
-			ContinueUpgradeAfterChecksEvenIfNotHealthy: true,
-		},
-	}
-	monPVCTemplate := sc.Spec.MonPVCTemplate
-	monDataDirHostPath := sc.Spec.MonDataDirHostPath
-	// If the `monPVCTemplate` is provided, the mons will provisioned on the
-	// provided `monPVCTemplate`.
-	if monPVCTemplate != nil {
-		cephCluster.Spec.Mon.VolumeClaimTemplate = monPVCTemplate
-		// If the `monDataDirHostPath` is provided without the `monPVCTemplate`,
-		// the mons will be provisioned on the provided `monDataDirHostPath`.
-	} else if len(monDataDirHostPath) > 0 {
-		cephCluster.Spec.DataDirHostPath = monDataDirHostPath
-		// If no `monPVCTemplate` and `monDataDirHostPath` is provided, the mons will
-		// be provisioned using the PVC template of first StorageDeviceSets if present.
-	} else if len(sc.Spec.StorageDeviceSets) > 0 {
-		ds := sc.Spec.StorageDeviceSets[0]
-		cephCluster.Spec.Mon.VolumeClaimTemplate = &corev1.PersistentVolumeClaim{
-			Spec: corev1.PersistentVolumeClaimSpec{
-				StorageClassName: ds.DataPVCTemplate.Spec.StorageClassName,
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("10Gi"),
-					},
-				},
-			},
-		}
-	} else {
-		reqLogger.Info(fmt.Sprintf("No monDataDirHostPath, monPVCTemplate or storageDeviceSets configured for storageCluster %s", sc.GetName()))
-	}
-	return cephCluster
-}
-
-func newExternalCephCluster(sc *ocsv1.StorageCluster, cephImage string) *cephv1.CephCluster {
-	labels := map[string]string{
-		"app": sc.Name,
-	}
-	externalCephCluster := &cephv1.CephCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      generateNameForCephCluster(sc),
-			Namespace: sc.Namespace,
-			Labels:    labels,
-		},
-		Spec: cephv1.ClusterSpec{
-			External: cephv1.ExternalSpec{
-				Enable: true,
-			},
-			CrashCollector: cephv1.CrashCollectorSpec{
-				Disable: true,
-			},
-		},
-	}
-	return externalCephCluster
-}
-
-func newCephDaemonResources(custom map[string]corev1.ResourceRequirements) map[string]corev1.ResourceRequirements {
-	resources := map[string]corev1.ResourceRequirements{
-		"mon": defaults.GetDaemonResources("mon", custom),
-		"mgr": defaults.GetDaemonResources("mgr", custom),
-	}
-
-	for k := range resources {
-		if r, ok := custom[k]; ok {
-			resources[k] = r
-		}
-	}
-
-	return resources
-}
-
-// newStorageClassDeviceSets converts a list of StorageDeviceSets into a list of Rook StorageClassDeviceSets
-func newStorageClassDeviceSets(sc *ocsv1.StorageCluster) []rook.StorageClassDeviceSet {
-	storageDeviceSets := sc.Spec.StorageDeviceSets
-	topologyMap := sc.Status.NodeTopologies
-
-	var storageClassDeviceSets []rook.StorageClassDeviceSet
-
-	for _, ds := range storageDeviceSets {
-		resources := ds.Resources
-		if resources.Requests == nil && resources.Limits == nil {
-			resources = defaults.DaemonResources["osd"]
-		}
-
-		topologyKey := ds.TopologyKey
-		topologyKeyValues := []string{}
-		noPlacement := ds.Placement.NodeAffinity == nil && ds.Placement.PodAffinity == nil && ds.Placement.PodAntiAffinity == nil
-
-		if noPlacement {
-			if topologyKey == "" {
-				topologyKey = determineFailureDomain(sc)
-			}
-			if topologyMap != nil {
-				topologyKey, topologyKeyValues = topologyMap.GetKeyValues(topologyKey)
-			}
-		}
-
-		count := ds.Count
-		replica := ds.Replica
-		if replica == 0 {
-			replica = defaults.DeviceSetReplica
-
-			// This is a temporary hack in place due to limitations
-			// in the current implementation of the OCP console.
-			// The console is hardcoded to create a StorageCluster
-			// with a Count of 3, as made sense for the previous
-			// behavior, but it cannot be updated until the next
-			// z-stream release of OCP 4.2. This workaround is to
-			// enable the new behavior while the console is waiting
-			// to be updated.
-			// TODO: Remove this behavior when OCP console is updated
-			count = count / 3
-		}
-
-		for i := 0; i < replica; i++ {
-			placement := rook.Placement{}
-
-			if noPlacement {
-				in := getPlacement(sc, "osd")
-				(&in).DeepCopyInto(&placement)
-
-				if len(topologyKeyValues) >= replica {
-					podAffinityTerms := placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-					podAffinityTerms[0].PodAffinityTerm.TopologyKey = topologyKey
-
-					topologyIndex := i % len(topologyKeyValues)
-					nodeZoneSelector := corev1.NodeSelectorRequirement{
-						Key:      topologyKey,
-						Operator: corev1.NodeSelectorOpIn,
-						Values:   []string{topologyKeyValues[topologyIndex]},
-					}
-					nodeSelectorTerms := placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-					nodeSelectorTerms[0].MatchExpressions = append(nodeSelectorTerms[0].MatchExpressions, nodeZoneSelector)
-				}
-			} else {
-				placement = ds.Placement
-			}
-
-			set := rook.StorageClassDeviceSet{
-				Name:                 fmt.Sprintf("%s-%d", ds.Name, i),
-				Count:                count,
-				Resources:            resources,
-				Placement:            placement,
-				Config:               ds.Config.ToMap(),
-				VolumeClaimTemplates: []corev1.PersistentVolumeClaim{ds.DataPVCTemplate},
-				Portable:             ds.Portable,
-				TuneSlowDeviceClass:  ds.Config.TuneSlowDeviceClass,
-			}
-			storageClassDeviceSets = append(storageClassDeviceSets, set)
-		}
-	}
-
-	return storageClassDeviceSets
 }
 
 func (r *ReconcileStorageCluster) throttleStorageDevices(storageClassName string) (bool, error) {
@@ -1197,27 +861,6 @@ func remove(slice []string, s string) (result []string) {
 		result = append(result, item)
 	}
 	return
-}
-
-func getMonCount(nodeCount int) int {
-	count := defaults.MonCountMin
-
-	// return static value if overriden
-	override := os.Getenv(monCountOverrideEnvVar)
-	if override != "" {
-		count, err := strconv.Atoi(override)
-		if err != nil {
-			log.Error(err, "could not decode env var %s", monCountOverrideEnvVar)
-		} else {
-			return count
-		}
-	}
-
-	if nodeCount >= defaults.MonCountMax {
-		count = defaults.MonCountMax
-	}
-
-	return count
 }
 
 // ensureJobTemplates ensures if the osd removal job template exists

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -492,6 +492,33 @@ func TestStorageClassDeviceSetCreation(t *testing.T) {
 		assert.Equal(t, deviceSet.DataPVCTemplate, scds.VolumeClaimTemplates[0])
 		assert.Equal(t, true, scds.Portable)
 	}
+
+	// Test with an empty label selector present in the StorageCluster.
+	// This used to trigger a segfault (nil pointer dereference) in
+	// newStorageClassDeviceSets. Make sure we don't regress.
+	var emptyLabelSelector = metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{},
+	}
+	sc.Spec.LabelSelector = &emptyLabelSelector
+
+	actual = newStorageClassDeviceSets(sc)
+	assert.Equal(t, defaults.DeviceSetReplica, len(actual))
+
+	for i, scds := range actual {
+		assert.Equal(t, fmt.Sprintf("%s-%d", deviceSet.Name, i), scds.Name)
+		// TODO: Change this when OCP console is updated
+		assert.Equal(t, deviceSet.Count/3, scds.Count)
+		assert.Equal(t, defaults.DaemonResources["osd"], scds.Resources)
+		topologyKey := scds.Placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.TopologyKey
+		assert.Equal(t, zoneTopologyLabel, topologyKey)
+		matchExpressions := scds.Placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
+		assert.Equal(t, 1, len(matchExpressions))
+		nodeSelector := matchExpressions[0]
+		assert.Equal(t, zoneTopologyLabel, nodeSelector.Key)
+		assert.Equal(t, nodeTopologyMap.Labels[zoneTopologyLabel][i], nodeSelector.Values[0])
+		assert.Equal(t, deviceSet.DataPVCTemplate, scds.VolumeClaimTemplates[0])
+		assert.Equal(t, true, scds.Portable)
+	}
 }
 
 func TestStorageDeviceSets(t *testing.T) {


### PR DESCRIPTION
This backports PR #618 (and as prerequisite also the innocuous pr #567).
This is needed to fix a nil pointer dereference segfault in `newStorageClassDeviceSets` when an empty LabelSelector was provided in the StorageCluster CR.

See https://bugzilla.redhat.com/show_bug.cgi?id=1854651