### PR TITLE
external cluster: Fix propagation of connected status

### DIFF
--- a/pkg/controller/util/status.go
+++ b/pkg/controller/util/status.go
@@ -199,14 +199,6 @@ func MapExternalCephClusterNegativeConditions(conditions *[]conditionsv1.Conditi
 			Reason:  ExternalClusterErrorReason,
 			Message: fmt.Sprintf("External CephCluster error: %v", string(found.Status.Message)),
 		})
-	default:
-
-		conditionsv1.SetStatusCondition(conditions, conditionsv1.Condition{
-			Type:    conditionsv1.ConditionDegraded,
-			Status:  corev1.ConditionTrue,
-			Reason:  ExternalClusterUnknownReason,
-			Message: fmt.Sprintf("External CephCluster Unknown Condition: %v", string(found.Status.Message)),
-		})
 	}
 }
 


### PR DESCRIPTION
The MapExternalCephClusterNegativeConditions erroneously interpreted the
CephClusterConnected state as bad and set Degraded state because of the
default case. Removing the default case to let all not explicitly
mentioned status fall through.

Signed-off-by: Michael Adam <obnox@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=1848387