### PR TITLE
Shellcheck cleanup - make shellcheck actually run and fail

### DIFF
--- a/hack/build-must-gather.sh
+++ b/hack/build-must-gather.sh
@@ -4,4 +4,4 @@ set -e
 
 source hack/common.sh
 
-${IMAGE_BUILD_CMD} build -f must-gather/Dockerfile -t ${MUST_GATHER_FULL_IMAGE_NAME} must-gather/
+${IMAGE_BUILD_CMD} build -f must-gather/Dockerfile -t "${MUST_GATHER_FULL_IMAGE_NAME}" must-gather/

--- a/hack/build-operator-index.sh
+++ b/hack/build-operator-index.sh
@@ -9,7 +9,7 @@ echo
 echo "Did you push the bundle image? It must be pullable from '$IMAGE_REGISTRY'."
 echo "Run '${IMAGE_BUILD_CMD} push ${BUNDLE_FULL_IMAGE_NAME}'"
 echo
-${OPM} index add --bundles ${BUNDLE_FULL_IMAGE_NAME} --tag ${INDEX_FULL_IMAGE_NAME}
+${OPM} index add --bundles "${BUNDLE_FULL_IMAGE_NAME}" --tag "${INDEX_FULL_IMAGE_NAME}"
 
 echo
 echo "Run '${IMAGE_BUILD_CMD} push ${INDEX_FULL_IMAGE_NAME}' to push operator index to image registry."

--- a/hack/build-operator.sh
+++ b/hack/build-operator.sh
@@ -4,4 +4,4 @@ set -e
 
 source hack/common.sh
 
-${IMAGE_BUILD_CMD} build -f build/Dockerfile -t ${OPERATOR_FULL_IMAGE_NAME} build/
+${IMAGE_BUILD_CMD} build -f build/Dockerfile -t "${OPERATOR_FULL_IMAGE_NAME}" build/

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# OCS-OPERATOR-SKIP-SHELLCHECK
-# skipping file as changes from shellcheck effect working of script
+# shellcheck disable=SC2034
+# disable unused variable warnings
 
 GO111MODULE="on"
 GOPROXY="https://proxy.golang.org"

--- a/hack/ensure-operator-sdk.sh
+++ b/hack/ensure-operator-sdk.sh
@@ -8,8 +8,8 @@ source hack/operator-sdk-common.sh
 if [ ! -x "${OPERATOR_SDK}" ]; then
 	echo "Downloading operator-sdk ${OPERATOR_SDK_VERSION}-${OPERATOR_SDK_PLATFORM}"
 	mkdir -p ${OUTDIR_TOOLS}
-	curl -JL ${OPERATOR_SDK_URL}/${OPERATOR_SDK_VERSION}/${OPERATOR_SDK_BIN} -o ${OPERATOR_SDK}
-	chmod +x ${OPERATOR_SDK}
+	curl -JL "${OPERATOR_SDK_URL}/${OPERATOR_SDK_VERSION}/${OPERATOR_SDK_BIN}" -o "${OPERATOR_SDK}"
+	chmod +x "${OPERATOR_SDK}"
 else
 	echo "Using operator-sdk cached at ${OPERATOR_SDK}"
 fi

--- a/hack/generate-appregistry.sh
+++ b/hack/generate-appregistry.sh
@@ -7,8 +7,8 @@ source hack/common.sh
 APPREGISRTY_DIR="build/_output/appregistry/olm-catalog/ocs-operator"
 rm -rf ${APPREGISRTY_DIR}
 mkdir -p "${APPREGISRTY_DIR}/${CSV_VERSION}"
-cp -r ${OCS_FINAL_DIR}/* ${APPREGISRTY_DIR}/${CSV_VERSION}/
-mv ${APPREGISRTY_DIR}/${CSV_VERSION}/ocs-operator.clusterserviceversion.yaml ${APPREGISRTY_DIR}/${CSV_VERSION}/ocs-operator.v${CSV_VERSION}.clusterserviceversion.yaml
+cp -r ${OCS_FINAL_DIR}/* "${APPREGISRTY_DIR}/${CSV_VERSION}/"
+mv "${APPREGISRTY_DIR}/${CSV_VERSION}/ocs-operator.clusterserviceversion.yaml" "${APPREGISRTY_DIR}/${CSV_VERSION}/ocs-operator.v${CSV_VERSION}.clusterserviceversion.yaml"
 cat > ${APPREGISRTY_DIR}/ocs-operator.package.yaml <<EOF
 channels:
 - name: alpha

--- a/hack/generate-k8s-openapi.sh
+++ b/hack/generate-k8s-openapi.sh
@@ -5,5 +5,5 @@ set -e
 source hack/common.sh
 source hack/operator-sdk-common.sh
 
-./${OPERATOR_SDK} generate k8s
-./${OPERATOR_SDK} generate crds
+./"${OPERATOR_SDK}" generate k8s
+./"${OPERATOR_SDK}" generate crds

--- a/hack/generate-latest-csv.sh
+++ b/hack/generate-latest-csv.sh
@@ -36,7 +36,7 @@ fi
 
 echo "Generating MD5 Checksum for CSV with version $CSV_VERSION"
 $CSV_CHECKSUM \
-	--csv-version=$CSV_VERSION \
+	--csv-version="$CSV_VERSION" \
 	--replaces-csv-version="$REPLACES_CSV_VERSION" \
 	--rook-image="$ROOK_IMAGE" \
 	--ceph-image="$CEPH_IMAGE" \

--- a/hack/operator-sdk-common.sh
+++ b/hack/operator-sdk-common.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# shellcheck disable=SC2034
+# don't fail on unused variables - this is for sourcing
+
 OPERATOR_SDK_URL="${OPERATOR_SDK_URL:-https://github.com/operator-framework/operator-sdk/releases/download}"
 OPERATOR_SDK_VERSION="${OPERATOR_SDK_VERSION:-v0.17.0}"
 OPERATOR_SDK_PLATFORM="x86_64-linux-gnu"

--- a/hack/red-hat-storage-ocs-ci-tests.sh
+++ b/hack/red-hat-storage-ocs-ci-tests.sh
@@ -59,6 +59,7 @@ fi
 # Create a Python virtual environment for the tests to execute with.
 echo "Using $REDHAT_OCS_CI_PYTHON_BINARY"
 $REDHAT_OCS_CI_PYTHON_BINARY -m venv .venv
+# shellcheck disable=SC1091
 source .venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt

--- a/hack/shellcheck-test.sh
+++ b/hack/shellcheck-test.sh
@@ -2,6 +2,8 @@
   
 # Check for shell syntax & style.
 
+source hack/common.sh
+
 test_syntax() {
         bash -n "${1}"
 }
@@ -27,9 +29,9 @@ BASE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 if [[ -z "${SHELLCHECK}" ]]; then
         echo "warning: could not find shellcheck ... installing shellcheck" >&2
         scversion="stable"
+        FILE="${OUTDIR_TOOLS}/shellcheck"
         wget -qO- "https://storage.googleapis.com/shellcheck/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
-        cp "shellcheck-${scversion}/shellcheck" "$GOPATH"/src/github.com/openshift/ocs-operator/tools/
-        FILE="$GOPATH"/src/github.com/openshift/ocs-operator/tools/shellcheck
+        cp -f "shellcheck-${scversion}/shellcheck" "${FILE}"
         if [ -f "$FILE" ]; then
                 SHELLCHECK="${FILE}"
         fi

--- a/hack/shellcheck-test.sh
+++ b/hack/shellcheck-test.sh
@@ -59,5 +59,8 @@ for script in ${SCRIPTS}; do
                 echo "${script}: ok" >&2
         fi
 done
+
+echo "${failed} scripts with errors were found"
+
 exit ${failed}
 

--- a/hack/shellcheck-test.sh
+++ b/hack/shellcheck-test.sh
@@ -14,7 +14,8 @@ test_shellcheck() {
                 if grep -q '^#.*OCS-OPERATOR-SKIP-SHELLCHECK' "${1}"; then
                         return 0
                 fi
-                shellcheck -x -e SC2181,SC2029,SC1091,SC1090,SC2012 "${1}"
+                #shell check -x -e SC2181,SC2029,SC1091,SC1090,SC2012 "${1}"
+                shellcheck -x -e SC2181 "${1}"
         else
                 return 0
         fi

--- a/hack/shellcheck-test.sh
+++ b/hack/shellcheck-test.sh
@@ -38,7 +38,7 @@ if [[ -z "${SHELLCHECK}" ]]; then
 fi
 
 cd "${BASE_DIR}" || exit 2
-SCRIPTS=$(find "$GOPATH"/src/github.com/openshift/ocs-operator \( -path "*/vendor/*" -o -path "*/build/*" -o -path "*/_cache/*" \) -prune -o -name "*~" -prune -o -type f -exec grep -l -e '^#!/bin/bash$' {} \;)
+SCRIPTS=$(find . \( -path "*/vendor/*" -o -path "*/build/*" -o -path "*/_cache/*" \) -prune -o -name "*~" -prune -o -type f -exec grep -l -e '^#!/bin/bash$' {} \;)
 
 failed=0
 for script in ${SCRIPTS}; do

--- a/hack/shellcheck-test.sh
+++ b/hack/shellcheck-test.sh
@@ -38,7 +38,7 @@ if [[ -z "${SHELLCHECK}" ]]; then
 fi
 
 cd "${BASE_DIR}" || exit 2
-SCRIPTS=$(find . \( -path "*/vendor/*" -o -path "*/build/*" -o -path "*/_cache/*" \) -prune -o -name "*~" -prune -o -type f -exec grep -l -e '^#!/bin/bash$' {} \;)
+SCRIPTS=$(find . \( -path "*/vendor/*" -o -path "*/build/*" -o -path "*/_cache/*" \) -prune -o -name "*~" -prune -o -name "*.swp" -prune -o -type f -exec grep -l -e '^#!/bin/bash$' {} \;)
 
 failed=0
 for script in ${SCRIPTS}; do

--- a/hack/shellcheck-test.sh
+++ b/hack/shellcheck-test.sh
@@ -44,12 +44,12 @@ failed=0
 for script in ${SCRIPTS}; do
         err=0
         test_syntax "${script}"
-        if [[ ${err} -ne 0 ]]; then
+        if [[ $? -ne 0 ]]; then
                 err=1
                 echo "detected syntax issues in ${script}}" >&2
         fi
         test_shellcheck "${script}"
-        if [[ ${err} -ne 0 ]]; then
+        if [[ $? -ne 0 ]]; then
                 err=1
                 echo "detected shellcheck issues in ${script}" >&2
         fi

--- a/hack/shellcheck-test.sh
+++ b/hack/shellcheck-test.sh
@@ -54,7 +54,7 @@ for script in ${SCRIPTS}; do
                 echo "detected shellcheck issues in ${script}" >&2
         fi
         if [[ $err -ne 0 ]]; then
-                ((failed=err))
+                ((failed+=err))
         else
                 echo "${script}: ok" >&2
         fi

--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -71,7 +71,7 @@ gen_args="generate csv --csv-version=$TMP_CSV_VERSION --output-dir=$OUTDIR_TEMPL
 if [ -n "$CSV_REPLACES_VERSION" ]; then
 	gen_args="$gen_args --from-version=$CSV_REPLACES_VERSION"
 fi
-$OPERATOR_SDK $gen_args
+$OPERATOR_SDK "$gen_args"
 mv $OUTDIR_TEMPLATES/manifests/ocs-operator.clusterserviceversion.yaml $OCS_CSV
 # Make variables templated for csv-merger tool
 if [ "$OS_TYPE" == "Darwin" ]; then

--- a/hack/verify-operator-bundle.sh
+++ b/hack/verify-operator-bundle.sh
@@ -5,4 +5,4 @@ set -e
 source hack/common.sh
 source hack/operator-sdk-common.sh
 
-./${OPERATOR_SDK} bundle validate $(dirname $OCS_FINAL_DIR) -b $IMAGE_BUILD_CMD --verbose
+./"${OPERATOR_SDK}" bundle validate "$(dirname $OCS_FINAL_DIR)" -b "$IMAGE_BUILD_CMD" --verbose

--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -48,7 +48,7 @@ commands+=("get csv -n openshift-storage")
 for command in "${commands[@]}"; do
      echo "collecting oc command ${command}" | tee -a ${BASE_COLLECTION_PATH}/gather-debug.log
      COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/oc_output/${command// /_}
-     timeout 120 oc ${command} >> "${COMMAND_OUTPUT_FILE}"
+     timeout 120 oc "${command}" >> "${COMMAND_OUTPUT_FILE}"
 done
 
 # Call other gather scripts

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -101,7 +101,7 @@ namespaces=$(oc get deploy --all-namespaces -o go-template --template='{{range .
 # Inspecting the namespace where ocs-cluster is installed
 for ns in $namespaces; do
     operatorImage=$(oc get pods -l app=rook-ceph-operator -n openshift-storage -o jsonpath="{range .items[*]}{@.spec.containers[0].image}+{end}" | tr "+" "\n" | head -n1)
-    cephClusterCount=$(oc get cephcluster -n ${ns} -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}" | wc -l)
+    cephClusterCount=$(oc get cephcluster -n "${ns}" -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}" | wc -l)
     if [ "${operatorImage}" = "" ]; then
         echo "not able to find the rook's operator image. Skipping collection of ceph command output" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
     elif [[ $cephClusterCount -gt 0 ]]; then
@@ -138,8 +138,8 @@ for ns in $namespaces; do
                 { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15" >> "${COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
                 { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "${ceph_commands[$i]} --connect-timeout=15 --format json-pretty" >> "${JSON_COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
             done
-            for i in `timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph osd lspools --connect-timeout=15"|awk '{print $2}'`; do
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $i" >> ${COMMAND_OUTPUT_DIR}/pools_rbd_$i; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1;
+            for i in $(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph osd lspools --connect-timeout=15"|awk '{print $2}'); do
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $i" >> "${COMMAND_OUTPUT_DIR}/pools_rbd_$i"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1;
             done
         fi
 


### PR DESCRIPTION
I was recently wondering why I am spotting obvious shellcheck errors in scripts but didn't see CI / test failures. Now looking into the shellcheck-test script, I realized that the return code from shellcheck was not properly interpreted, and all errors went without notice.

This PR fixes this and allows the shellcheck-test to fail. In order to be able to push this, the PR first fixes all shellcheck errors in scripts that have accumulated (12 scripts are fixed). Additionally, the hack/common.sh script is not skipped any more, but just disables the unused variable test.

Finally, a few additional aspects of the shellcheck-test script are improved: the dependency on GOPATH is removed (which is not required to be set for our module based code), so that one can run this without GOPATH set. And an informative output about the number of scripts with errors is added.