### PR TITLE
Add a check to verify RGW endpoint is reachable or not

### DIFF
--- a/pkg/controller/storagecluster/external_resources.go
+++ b/pkg/controller/storagecluster/external_resources.go
@@ -242,8 +242,7 @@ func (r *ReconcileStorageCluster) createExternalStorageClusterResources(instance
 				delete(d.Data, externalCephRgwEndpointKey)
 				// Set the external rgw endpoint variable for later use on the Noobaa CR (as a label)
 				// Replace the colon with an underscore, otherwise the label will be invalid
-				externalRgwEndpointReplaceColon := strings.Replace(rgwEndpoint, ":", "_", -1)
-				externalRgwEndpoint = externalRgwEndpointReplaceColon
+				externalRgwEndpoint = strings.Replace(rgwEndpoint, ":", "_", -1)
 
 				// 'sc' points to OBC StorageClass
 				sc = scs[2]

--- a/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -267,7 +267,7 @@ func assertNoobaaResource(t *testing.T, reconciler ReconcileStorageCluster) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, fNoobaa.Labels[externalRgwEndpointLabelName])
 	// The endpoint has its colon replaced by an underscore so that the label is valid
-	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], "10.20.30.40_50")
+	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], externalRgwEndpoint)
 }
 
 func getReconciler(t *testing.T, objs ...runtime.Object) ReconcileStorageCluster {


### PR DESCRIPTION
Added an extra check to verify RGW endpoint passed,
in External cluster mode, is reachable or not.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>