### PR TITLE
Add TargetSizeRatio of .49 to RGW data pool

### DIFF
--- a/pkg/controller/storagecluster/cephobjectstores.go
+++ b/pkg/controller/storagecluster/cephobjectstores.go
@@ -92,6 +92,7 @@ func (r *ReconcileStorageCluster) newCephObjectStoreInstances(initData *ocsv1.St
 					FailureDomain: initData.Status.FailureDomain,
 					Replicated: cephv1.ReplicatedSpec{
 						Size: 3,
+						TargetSizeRatio: .49,
 					},
 				},
 				MetadataPool: cephv1.PoolSpec{


### PR DESCRIPTION
The purpose of the `target_size_ratio` is to configure the pool for some pre-optimization of pg placement when the autoscaler is active. If the `target-size-ratio` is set, then up to that threshold of capacity, the pre-optimization will be active. Above the threshold, it is changing the normal non-optimized mode.

This change sets the `target_size_ratio` for the RGW pool to `.49` like for the rbd pools and the cephfs data pool as recommended by ceph experts (starting with RHCS 4.1).

Signed-off-by: Michael Adam <obnox@redhat.com>