### PR TITLE
Fix incorrect quoting of must-gather commands

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -50,7 +50,8 @@ commands+=("get events -n openshift-storage")
 for command in "${commands[@]}"; do
      echo "collecting oc command ${command}" | tee -a ${BASE_COLLECTION_PATH}/gather-debug.log
      COMMAND_OUTPUT_FILE=${BASE_COLLECTION_PATH}/oc_output/${command// /_}
-     timeout 120 oc "${command}" >> "${COMMAND_OUTPUT_FILE}"
+     # shellcheck disable=SC2086
+     timeout 120 oc ${command} >> "${COMMAND_OUTPUT_FILE}"
 done
 
 # Call other gather scripts


### PR DESCRIPTION
Quoting the command was resulting in:
Error: unknown command "get csv -n openshift-storage" for "oc"

disabled this because we want word splitting here:
```
SC2086: Double quote to prevent globbing and word splitting.
```

Looks like rebase is not necessary (4.5 branch): https://github.com/openshift/ocs-operator/blob/release-4.5/must-gather/collection-scripts/gather#L53

Signed-off-by: Rohan CJ <rohantmp@redhat.com>