### PR TITLE
StorageCluster: perform delete of cephCluster

### DIFF
--- a/pkg/controller/storagecluster/noobaa_system_reconciler.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler.go
@@ -2,6 +2,7 @@ package storagecluster
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	nbv1 "github.com/noobaa/noobaa-operator/v2/pkg/apis/noobaa/v1alpha1"
@@ -140,7 +141,7 @@ func (r *ReconcileStorageCluster) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *ocs
 }
 
 // Delete noobaa system in the namespace
-func (r *ReconcileStorageCluster) deleteNoobaaSystems(sc *ocsv1.StorageCluster, reqLogger logr.Logger) (bool, error) {
+func (r *ReconcileStorageCluster) deleteNoobaaSystems(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
 	noobaa := &nbv1.NooBaa{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: "noobaa", Namespace: sc.Namespace}, noobaa)
 	if err != nil {
@@ -152,17 +153,15 @@ func (r *ReconcileStorageCluster) deleteNoobaaSystems(sc *ocsv1.StorageCluster, 
 			}
 			err = r.client.List(context.TODO(), pvcs, opts...)
 			if err != nil {
-				return false, err
+				return err
 			}
 			if len(pvcs.Items) > 0 {
-				reqLogger.Info("Waiting on NooBaa system and PVCs to be deleted")
-				return false, nil
+				return fmt.Errorf("Waiting on NooBaa system and PVCs to be deleted")
 			}
 			reqLogger.Info("NooBaa and noobaa-core PVC not found.")
-			return true, nil
+			return nil
 		}
-		reqLogger.Error(err, "Failed to retrieve NooBaa system")
-		return false, err
+		return fmt.Errorf("Failed to retrieve NooBaa system: %v", err)
 	}
 
 	isOwned := false
@@ -175,7 +174,7 @@ func (r *ReconcileStorageCluster) deleteNoobaaSystems(sc *ocsv1.StorageCluster, 
 	if !isOwned {
 		// if the noobaa found is not owned by our storagecluster, we skip it from deletion.
 		reqLogger.Info("NooBaa object found, but ownerReference not set to storagecluster. Skipping")
-		return true, nil
+		return nil
 	}
 
 	if noobaa.GetDeletionTimestamp().IsZero() {
@@ -183,9 +182,8 @@ func (r *ReconcileStorageCluster) deleteNoobaaSystems(sc *ocsv1.StorageCluster, 
 		err = r.client.Delete(context.TODO(), noobaa)
 		if err != nil {
 			reqLogger.Error(err, "Failed to delete NooBaa system")
-			return false, err
+			return fmt.Errorf("Failed to delete NooBaa system: %v", err)
 		}
 	}
-	reqLogger.Info("Waiting on NooBaa system to be deleted")
-	return false, nil
+	return fmt.Errorf("Waiting on NooBaa system to be deleted")
 }

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -180,7 +180,6 @@ func (r *ReconcileStorageCluster) Reconcile(request reconcile.Request) (reconcil
 		if contains(instance.GetFinalizers(), storageClusterFinalizer) {
 			err = r.deleteResources(instance, reqLogger)
 			if err != nil {
-				reqLogger.Error(err, "Could not delete one or more resources from the StorageCluster")
 				return reconcile.Result{}, err
 			}
 			reqLogger.Info("Removing finalizer")

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -773,6 +773,11 @@ func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqL
 		return err
 	}
 
+	err = r.deleteCephCluster(sc, reqLogger)
+	if err != nil {
+		return err
+	}
+
 	err = r.deleteStorageClasses(sc, reqLogger)
 	if err != nil {
 		return err

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -770,9 +770,8 @@ func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqL
 	if err != nil {
 		finalerr = fmt.Errorf("%w, %v", finalerr, err)
 	}
-	// NoobaaSystem is dependent upon ceph for volume provisioning.
-	// We want to make sure we delete noobaasystem before we delete cephcluster, to get a clean uninstall.
-	_, err = r.deleteNoobaaSystems(sc, reqLogger)
+
+	err = r.deleteNoobaaSystems(sc, reqLogger)
 	if err != nil {
 		finalerr = fmt.Errorf("%w, %v", finalerr, err)
 	}

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -782,10 +782,12 @@ func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqL
 		return err
 	}
 
-	err = r.deleteNodeAffinityKeyFromNodes(sc, reqLogger)
-	if err != nil {
-		return err
-	}
+	// TODO: skip the deletion of these labels till we figure out a way to wait
+	// for the cleanup jobs
+	//err = r.deleteNodeAffinityKeyFromNodes(sc, reqLogger)
+	//if err != nil {
+	//	return err
+	//}
 
 	err = r.deleteNodeTaint(sc, reqLogger)
 	if err != nil {

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -760,39 +760,35 @@ func (r *ReconcileStorageCluster) setRookCleanupPolicy(instance *ocsv1.StorageCl
 }
 
 // deleteResources is the function where the storageClusterFinalizer is handled
-// Every function that is called within this function
-// 1. should be idempotent
-// 2. should wrap the finalerr with its own err
-// 3. optionally set a state variable for other calls which might depend on it
-// If this function returns a nil finalerr, the finalizer is removed.
-func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqLogger logr.Logger) (finalerr error) {
+// Every function that is called within this function should be idempotent
+func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
 
 	err := r.setRookCleanupPolicy(sc, reqLogger)
 	if err != nil {
-		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+		return err
 	}
 
 	err = r.deleteNoobaaSystems(sc, reqLogger)
 	if err != nil {
-		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+		return err
 	}
 
 	err = r.deleteStorageClasses(sc, reqLogger)
 	if err != nil {
-		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+		return err
 	}
 
 	err = r.deleteNodeAffinityKeyFromNodes(sc, reqLogger)
 	if err != nil {
-		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+		return err
 	}
 
 	err = r.deleteNodeTaint(sc, reqLogger)
 	if err != nil {
-		finalerr = fmt.Errorf("%w, %v", finalerr, err)
+		return err
 	}
 
-	return finalerr
+	return nil
 }
 
 // Checks whether a string is contained within a slice

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -180,6 +180,7 @@ func (r *ReconcileStorageCluster) Reconcile(request reconcile.Request) (reconcil
 		if contains(instance.GetFinalizers(), storageClusterFinalizer) {
 			err = r.deleteResources(instance, reqLogger)
 			if err != nil {
+				reqLogger.Error(err, "Could not delete one or more resources from the StorageCluster")
 				return reconcile.Result{}, err
 			}
 			reqLogger.Info("Removing finalizer")


### PR DESCRIPTION
Until now, the cephCluster was being deleted simultaneously with the
storageCluster as the storageCluster has the owner refernce for the
cephCluster.

With this commit, we perform the deletion of the cephCluster in order.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>