### PR TITLE
must-gather: fix newly uncovered shellcheck error

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -111,6 +111,7 @@ for ns in $namespaces; do
     echo "collecting dump of namespace" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
     timeout 300 oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect ns/"${ns}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     echo "collecting dump of clusterresourceversion" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    # shellcheck disable=SC2129
     timeout 120 oc adm --dest-dir="${CEPH_COLLECTION_PATH}/pvc_all_namespaces" inspect pvc --all-namespaces >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     timeout 120 oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect csv -n "${ns}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     timeout 120 oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect sc -n "${ns}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1


### PR DESCRIPTION
SC2129: Consider using { cmd1; cmd2; } >> file instead of individual
redirects.

Just disable this for this instance.
This must have been uncovered by using a newer shellcheck version.

Signed-off-by: Michael Adam <obnox@redhat.com>