### PR TITLE
Refactored cephcluster_tests.go

### DIFF
--- a/pkg/controller/storagecluster/cephcluster_test.go
+++ b/pkg/controller/storagecluster/cephcluster_test.go
@@ -163,10 +163,9 @@ func TestNewCephClusterMonData(t *testing.T) {
 }
 
 func TestStorageClassDeviceSetCreation(t *testing.T) {
-	sc := &api.StorageCluster{}
-	sc.Spec.StorageDeviceSets = mockDeviceSets
-
-	nodeTopologyMap := &api.NodeTopologyMap{
+	sc1 := &api.StorageCluster{}
+	sc1.Spec.StorageDeviceSets = mockDeviceSets
+	sc1.Status.NodeTopologies = &api.NodeTopologyMap{
 		Labels: map[string]api.TopologyLabelValues{
 			zoneTopologyLabel: []string{
 				"zone1",
@@ -174,67 +173,86 @@ func TestStorageClassDeviceSetCreation(t *testing.T) {
 			},
 		},
 	}
-	sc.Status.NodeTopologies = nodeTopologyMap
 
-	actual := newStorageClassDeviceSets(sc)
-	assert.Equal(t, defaults.DeviceSetReplica, len(actual))
-
-	deviceSet := sc.Spec.StorageDeviceSets[0]
-	for i, scds := range actual {
-		assert.Equal(t, fmt.Sprintf("%s-%d", deviceSet.Name, i), scds.Name)
-		// TODO: Change this when OCP console is updated
-		assert.Equal(t, deviceSet.Count/3, scds.Count)
-		assert.Equal(t, defaults.DaemonResources["osd"], scds.Resources)
-		assert.Equal(t, getPlacement(sc, "osd"), scds.Placement)
-		assert.Equal(t, deviceSet.DataPVCTemplate, scds.VolumeClaimTemplates[0])
-		assert.Equal(t, true, scds.Portable)
+	sc2 := &api.StorageCluster{}
+	sc2.Spec.StorageDeviceSets = mockDeviceSets
+	sc2.Status.NodeTopologies = &api.NodeTopologyMap{
+		Labels: map[string]api.TopologyLabelValues{
+			zoneTopologyLabel: []string{
+				"zone1",
+				"zone2",
+				"zone3",
+			},
+		},
 	}
 
-	nodeTopologyMap.Labels[zoneTopologyLabel] = append(nodeTopologyMap.Labels[zoneTopologyLabel], "zone3")
-
-	actual = newStorageClassDeviceSets(sc)
-	assert.Equal(t, defaults.DeviceSetReplica, len(actual))
-
-	for i, scds := range actual {
-		assert.Equal(t, fmt.Sprintf("%s-%d", deviceSet.Name, i), scds.Name)
-		// TODO: Change this when OCP console is updated
-		assert.Equal(t, deviceSet.Count/3, scds.Count)
-		assert.Equal(t, defaults.DaemonResources["osd"], scds.Resources)
-		topologyKey := scds.Placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.TopologyKey
-		assert.Equal(t, zoneTopologyLabel, topologyKey)
-		matchExpressions := scds.Placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
-		assert.Equal(t, 2, len(matchExpressions))
-		nodeSelector := matchExpressions[1]
-		assert.Equal(t, zoneTopologyLabel, nodeSelector.Key)
-		assert.Equal(t, nodeTopologyMap.Labels[zoneTopologyLabel][i], nodeSelector.Values[0])
-		assert.Equal(t, deviceSet.DataPVCTemplate, scds.VolumeClaimTemplates[0])
-		assert.Equal(t, true, scds.Portable)
+	sc3 := &api.StorageCluster{}
+	sc3.Spec.StorageDeviceSets = mockDeviceSets
+	sc3.Status.NodeTopologies = &api.NodeTopologyMap{
+		Labels: map[string]api.TopologyLabelValues{
+			zoneTopologyLabel: []string{
+				"zone1",
+				"zone2",
+				"zone3",
+			},
+		},
 	}
-
-	// Test with an empty label selector present in the StorageCluster.
-	// This used to trigger a segfault (nil pointer dereference) in
-	// newStorageClassDeviceSets. Make sure we don't regress.
 	var emptyLabelSelector = metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{},
 	}
-	sc.Spec.LabelSelector = &emptyLabelSelector
+	sc3.Spec.LabelSelector = &emptyLabelSelector
 
-	actual = newStorageClassDeviceSets(sc)
-	assert.Equal(t, defaults.DeviceSetReplica, len(actual))
-
-	for i, scds := range actual {
-		assert.Equal(t, fmt.Sprintf("%s-%d", deviceSet.Name, i), scds.Name)
-		// TODO: Change this when OCP console is updated
-		assert.Equal(t, deviceSet.Count/3, scds.Count)
-		assert.Equal(t, defaults.DaemonResources["osd"], scds.Resources)
-		topologyKey := scds.Placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.TopologyKey
-		assert.Equal(t, zoneTopologyLabel, topologyKey)
-		matchExpressions := scds.Placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
-		assert.Equal(t, 1, len(matchExpressions))
-		nodeSelector := matchExpressions[0]
-		assert.Equal(t, zoneTopologyLabel, nodeSelector.Key)
-		assert.Equal(t, nodeTopologyMap.Labels[zoneTopologyLabel][i], nodeSelector.Values[0])
-		assert.Equal(t, deviceSet.DataPVCTemplate, scds.VolumeClaimTemplates[0])
-		assert.Equal(t, true, scds.Portable)
+	cases := []struct {
+		label                string
+		sc                   *api.StorageCluster
+		topologyKey          string
+		lenOfMatchExpression int
+	}{
+		{
+			label:       "case 1",
+			sc:          sc1,
+			topologyKey: "rack",
+		},
+		{
+			label:                "case 2",
+			sc:                   sc2,
+			topologyKey:          "zone",
+			lenOfMatchExpression: 2,
+		},
+		{
+			label:                "case 3",
+			sc:                   sc3,
+			topologyKey:          "zone",
+			lenOfMatchExpression: 1,
+		},
 	}
+
+	for _, c := range cases {
+
+		actual := newStorageClassDeviceSets(c.sc)
+		assert.Equal(t, defaults.DeviceSetReplica, len(actual))
+		deviceSet := c.sc.Spec.StorageDeviceSets[0]
+
+		for i, scds := range actual {
+			assert.Equal(t, fmt.Sprintf("%s-%d", deviceSet.Name, i), scds.Name)
+			assert.Equal(t, deviceSet.Count/3, scds.Count)
+			assert.Equal(t, defaults.DaemonResources["osd"], scds.Resources)
+			assert.Equal(t, deviceSet.DataPVCTemplate, scds.VolumeClaimTemplates[0])
+			assert.Equal(t, true, scds.Portable)
+
+			if c.topologyKey == "rack" {
+				assert.Equal(t, getPlacement(c.sc, "osd"), scds.Placement)
+			} else {
+				topologyKey := scds.Placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.TopologyKey
+				assert.Equal(t, zoneTopologyLabel, topologyKey)
+				matchExpressions := scds.Placement.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
+				assert.Equal(t, c.lenOfMatchExpression, len(matchExpressions))
+				nodeSelector := matchExpressions[c.lenOfMatchExpression-1]
+				assert.Equal(t, zoneTopologyLabel, nodeSelector.Key)
+				assert.Equal(t, c.sc.Status.NodeTopologies.Labels[zoneTopologyLabel][i], nodeSelector.Values[0])
+			}
+		}
+
+	}
+
 }


### PR DESCRIPTION
Instead of explicitly writing each test case within a function, it is reorganized to follow a table driven approach. The refactoring is done for `cephClusterCreate, cephClusterUpdate,cephClusterWithNoConditions, cephClusterWithNegativeConditions`

Signed off by: Priyanka Jiandani <pjiandan@redhat.com>