### PR TITLE
updates BackingStore and NooBaa CRDs

### DIFF
--- a/deploy/olm-catalog/ocs-operator/manifests/backingstore.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/backingstore.crd.yaml
@@ -206,7 +206,6 @@ spec:
                   type: string
               required:
               - numVolumes
-              - secret
               type: object
             s3Compatible:
               description: S3Compatible specifies a backing store of type s3-compatible

--- a/deploy/olm-catalog/ocs-operator/manifests/noobaa.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/noobaa.crd.yaml
@@ -626,6 +626,14 @@ spec:
                       type: array
                   type: object
               type: object
+            cleanupPolicy:
+              description: CleanupPolicy (optional) Indicates user's policy for deletion
+              properties:
+                confirmation:
+                  description: CleanupConfirmationProperty is a string that specifies
+                    cleanup confirmation
+                  type: string
+              type: object
             coreResources:
               description: CoreResources (optional) overrides the default resource
                 requirements for the server container


### PR DESCRIPTION
runs `make gen-latest-csv` to updated BackingStore and NooBaa CRDs
with the latest v2.3.0 api spec of NooBaa Operator.

+ removes `secret` from required (as seen in https://github.com/noobaa/noobaa-operator/blob/2.3/deploy/crds/noobaa.io_backingstores_crd.yaml#L206-L209)
+ adds `CleanupPolicy` (as seen in https://github.com/noobaa/noobaa-operator/blob/2.3/deploy/crds/noobaa.io_noobaas_crd.yaml#L628-L635)

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>