### PR TITLE
enable pruning and add CRD verification for Pruning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,8 @@ update-generated: operator-sdk
 verify-generated: update-generated
 	@echo "Verifying generated code"
 	hack/verify-generated.sh
+	@echo "Verifying CRDs"
+	hack/verify-crds.sh
 
 ocs-operator-ci: shellcheck-test gofmt golint govet unit-test build verify-generated verify-latest-deploy-yaml
 

--- a/hack/verify-crds.sh
+++ b/hack/verify-crds.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+FILES="./deploy/crds/*crd.yaml"
+FAILS=false
+for f in $FILES
+do
+    if [[ $(./_output/tools/bin/yq r $f apiVersion) == "apiextensions.k8s.io/v1beta1" ]]; then
+        if [[ $(./_output/tools/bin/yq r $f spec.validation.openAPIV3Schema.properties.metadata.description) != "null" ]]; then
+            echo "Error: cannot have a metadata description in $f"
+            FAILS=true
+        fi
+
+        if [[ $(./_output/tools/bin/yq r $f spec.preserveUnknownFields) != "false" ]]; then
+            echo "Error: pruning not enabled (spec.preserveUnknownFields != false) in $f"
+            FAILS=true
+        fi
+    fi
+done
+
+if [ "$FAILS" = true ] ; then
+    exit 1
+fi
+


### PR DESCRIPTION
+ adding verify-crds.sh that will check if pruning is enabled
for CRDs and if it has metadata description (which is not
allowed in Structural Schema).

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>