### PR TITLE
Add csi log level to rook-ceph-operator-config configmap

### DIFF
--- a/pkg/controller/ocsinitialization/ocsinitialization_controller.go
+++ b/pkg/controller/ocsinitialization/ocsinitialization_controller.go
@@ -359,6 +359,7 @@ func newRookCephOperatorConfig(namespace string) *corev1.ConfigMap {
 	data := make(map[string]string)
 	data["CSI_PROVISIONER_TOLERATIONS"] = defaultCSIToleration
 	data["CSI_PLUGIN_TOLERATIONS"] = defaultCSIToleration
+	data["CSI_LOG_LEVEL"] = "5"
 	config.Data = data
 
 	return config


### PR DESCRIPTION
as the CSI log level is set to `0` by default no debug and info logs will be printed it will be
hard to debug csi. This commit sets the csi log level as "5".

Signed-off-by: Madhu Rajanna <madhupr007@gmail.com>