### PR TITLE
Bug 1840539: [release 4.5] Added the pattern to the end of the command

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -911,7 +911,7 @@ else
   ceph osd out osd.${FAILED_OSD_ID} 
   ceph osd purge osd.${FAILED_OSD_ID} --force --yes-i-really-mean-it
   echo "Attempting to remove the parent host. Errors can be ignored if there are other OSDs on the same host"
-  ceph osd crush rm $HOST_TO_REMOVE
+  ceph osd crush rm $HOST_TO_REMOVE || true
 fi`
 
 	job := &batchv1.Job{


### PR DESCRIPTION
Added || true to the end of the command. If the command ceph osd crush rm
gives output with error message, the script will abort
and the job would fail. This change ensures that the script doesn't
abort and the job runs without a failure.

Signed-off-by: Servesha Dudhgaonkar <sdudhgao@redhat.com>