### PR TITLE
Update to newer rook/ceph:v1.4 tag to pick up csv fix

### DIFF
--- a/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1892,7 +1892,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: ocs-operator
                 - name: ROOK_CEPH_IMAGE
-                  value: rook/ceph:v1.4.0
+                  value: rook/ceph:v1.4.0-28.g3c00330
                 - name: CEPH_IMAGE
                   value: ceph/ceph:v14.2
                 - name: NOOBAA_CORE_IMAGE
@@ -1997,7 +1997,7 @@ spec:
                   value: "false"
                 - name: ROOK_OBC_WATCH_OPERATOR_NAMESPACE
                   value: "true"
-                image: rook/ceph:v1.4.0
+                image: rook/ceph:v1.4.0-28.g3c00330
                 name: rook-ceph-operator
                 resources: {}
                 volumeMounts:
@@ -2367,7 +2367,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: rook/ceph:v1.4.0
+  - image: rook/ceph:v1.4.0-28.g3c00330
     name: rook-container
   - image: ceph/ceph:v14.2
     name: ceph-container

--- a/hack/generate-latest-csv.sh
+++ b/hack/generate-latest-csv.sh
@@ -13,7 +13,7 @@ export SKIP_MINIMUM="0.0.1"
 export SKIP_RANGE=">=${SKIP_MINIMUM} <${CSV_VERSION}"
 
 # Current dependency images our DEV CSV are pinned to
-export ROOK_IMAGE=${ROOK_IMAGE:-"rook/ceph:v1.4.0"}
+export ROOK_IMAGE=${ROOK_IMAGE:-"rook/ceph:v1.4.0-28.g3c00330"}
 export NOOBAA_IMAGE=${NOOBAA_IMAGE:-"noobaa/noobaa-operator:2.3.0"}
 export NOOBAA_CORE_IMAGE=${NOOBAA_CORE_IMAGE:-"noobaa/noobaa-core:5.5.0"}
 export NOOBAA_DB_IMAGE=${NOOBAA_DB_IMAGE:-"centos/mongodb-36-centos7"}


### PR DESCRIPTION
The service account names were being generated incorrectly in v1.4.0. Now the service account names are generated correctly in the latest tag.
