### PR TITLE
Fix and refactor failing e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ build-functest:
 
 functest: build-functest
 	@echo "Running ocs developer functional test suite"
-	hack/functest.sh
+	hack/functest.sh $(ARGS)
 gofmt:
 	@echo "Running gofmt"
 	gofmt -s -l `find . -path ./vendor -prune -o -type f -name '*.go' -print`

--- a/functests/common.go
+++ b/functests/common.go
@@ -1,6 +1,9 @@
 package functests
 
 import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
 	k8sbatchv1 "k8s.io/api/batch/v1"
@@ -9,6 +12,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
+
+func debug(msg string, args ...interface{}) {
+	ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf(msg, args...)))
+}
 
 // GetRandomPVC returns a pvc with a randomized name
 func GetRandomPVC(storageClass string, quantity string) *k8sv1.PersistentVolumeClaim {

--- a/functests/data_validation_test.go
+++ b/functests/data_validation_test.go
@@ -6,6 +6,7 @@ import (
 
 	tests "github.com/openshift/ocs-operator/functests"
 	deploymanager "github.com/openshift/ocs-operator/pkg/deploy-manager"
+
 	k8sbatchv1 "k8s.io/api/batch/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/functests/data_validation_test.go
+++ b/functests/data_validation_test.go
@@ -11,22 +11,16 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 var _ = Describe("job creation", DataValidationTest)
 
 func DataValidationTest() {
-	var k8sClient *kubernetes.Clientset
-	var deployManager *deploymanager.DeployManager
-
-	BeforeEach(func() {
-		RegisterFailHandler(Fail)
-		deployManager, err := deploymanager.NewDeployManager()
-		Expect(err).To(BeNil())
-
-		k8sClient = deployManager.GetK8sClient()
-	})
+	deployManager, err := deploymanager.NewDeployManager()
+	if err != nil {
+		panic("failed to initialize DeployManager")
+	}
+	k8sClient := deployManager.GetK8sClient()
 
 	Describe("rbd", func() {
 		var namespace string

--- a/functests/data_validation_test.go
+++ b/functests/data_validation_test.go
@@ -46,18 +46,12 @@ func DataValidationTest() {
 		Context("Create job with pvc", func() {
 			It("and verify the data integrity", func() {
 				By("Creating PVC")
-				_, err := k8sClient.CoreV1().PersistentVolumeClaims(namespace).Create(pvc)
+				err := deployManager.WaitForPVCBound(pvc, namespace)
 				Expect(err).To(BeNil())
 
-				By("Verifying PVC reaches BOUND phase")
-				deployManager.WaitForPVCBound(pvc.Name, namespace)
-
-				By("Creating job")
-				_, err = k8sClient.BatchV1().Jobs(namespace).Create(job)
+				By("Running Job")
+				err = deployManager.WaitForJobSucceeded(job, namespace)
 				Expect(err).To(BeNil())
-
-				By("Verifying job succeeds in data validation")
-				deployManager.WaitForJobSucceeded(job.GetName(), namespace)
 
 				finalJob, err := k8sClient.BatchV1().Jobs(namespace).Get(job.GetName(), metav1.GetOptions{})
 				Expect(err).To(BeNil())

--- a/functests/pvc_creation_test.go
+++ b/functests/pvc_creation_test.go
@@ -10,22 +10,16 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
 
 var _ = Describe("PVC Creation", PVCCreationTest)
 
 func PVCCreationTest() {
-	var k8sClient *kubernetes.Clientset
-	var deployManager *deploymanager.DeployManager
-
-	BeforeEach(func() {
-		RegisterFailHandler(Fail)
-
-		deployManager, err := deploymanager.NewDeployManager()
-		Expect(err).To(BeNil())
-		k8sClient = deployManager.GetK8sClient()
-	})
+	deployManager, err := deploymanager.NewDeployManager()
+	if err != nil {
+		panic("failed to initialize DeployManager")
+	}
+	k8sClient := deployManager.GetK8sClient()
 
 	Describe("rbd", func() {
 		var pvc *k8sv1.PersistentVolumeClaim

--- a/functests/pvc_creation_test.go
+++ b/functests/pvc_creation_test.go
@@ -40,11 +40,8 @@ func PVCCreationTest() {
 		Context("create pvc", func() {
 			It("and verify bound status", func() {
 				By("Creating PVC")
-				_, err := k8sClient.CoreV1().PersistentVolumeClaims(namespace).Create(pvc)
+				err := deployManager.WaitForPVCBound(pvc, namespace)
 				Expect(err).To(BeNil())
-
-				By("Verifying PVC reaches BOUND phase")
-				deployManager.WaitForPVCBound(pvc.Name, namespace)
 
 				By("Deleting PVC")
 				err = k8sClient.CoreV1().PersistentVolumeClaims(namespace).Delete(pvc.Name, &metav1.DeleteOptions{})

--- a/functests/pvc_creation_test.go
+++ b/functests/pvc_creation_test.go
@@ -5,8 +5,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	tests "github.com/openshift/ocs-operator/functests"
-
 	deploymanager "github.com/openshift/ocs-operator/pkg/deploy-manager"
+
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,7 +34,6 @@ func PVCCreationTest() {
 		BeforeEach(func() {
 			namespace = tests.TestNamespace
 			pvc = tests.GetRandomPVC(tests.StorageClassRBD, "1Gi")
-
 		})
 
 		AfterEach(func() {

--- a/functests/setup_teardown.go
+++ b/functests/setup_teardown.go
@@ -29,6 +29,7 @@ func BeforeTestSuiteSetup() {
 // AfterTestSuiteCleanup is the function called to tear down the test environment
 func AfterTestSuiteCleanup() {
 	flag.Parse()
+
 	t, err := deploymanager.NewDeployManager()
 	gomega.Expect(err).To(gomega.BeNil())
 
@@ -57,7 +58,7 @@ func AfterUpgradeTestSuiteCleanup() {
 	err = t.DeleteNamespaceAndWait(TestNamespace)
 	gomega.Expect(err).To(gomega.BeNil())
 
-	// Only called after upgrade failures, so the cluster has to be unnstalled.
+	// Only called after upgrade failures, so the cluster has to be uninstalled.
 	err = t.UninstallOCS(OcsRegistryImage, OcsSubscriptionChannel)
 	gomega.Expect(err).To(gomega.BeNil())
 }

--- a/functests/setup_teardown.go
+++ b/functests/setup_teardown.go
@@ -16,13 +16,13 @@ func BeforeTestSuiteSetup() {
 	t, err := deploymanager.NewDeployManager()
 	gomega.Expect(err).To(gomega.BeNil())
 
-	err = t.CreateNamespace(TestNamespace)
-	gomega.Expect(err).To(gomega.BeNil())
-
 	err = t.DeployOCSWithOLM(OcsRegistryImage, OcsSubscriptionChannel)
 	gomega.Expect(err).To(gomega.BeNil())
 
 	err = t.StartDefaultStorageCluster()
+	gomega.Expect(err).To(gomega.BeNil())
+
+	err = t.CreateNamespace(TestNamespace)
 	gomega.Expect(err).To(gomega.BeNil())
 }
 

--- a/functests/setup_teardown.go
+++ b/functests/setup_teardown.go
@@ -35,8 +35,9 @@ func AfterTestSuiteCleanup() {
 	// collect debug log before deleting namespace & cluster
 	gopath := os.Getenv("GOPATH")
 	cmd := exec.Command("/bin/bash", gopath+"/src/github.com/openshift/ocs-operator/hack/dump-debug-info.sh")
-	_, err = cmd.CombinedOutput()
-	gomega.Expect(err).To(gomega.BeNil())
+	cmd.Env = os.Environ()
+	output, err := cmd.CombinedOutput()
+	gomega.Expect(err).To(gomega.BeNil(), "Error dumping debug info: %v", output)
 
 	err = t.DeleteNamespaceAndWait(TestNamespace)
 	gomega.Expect(err).To(gomega.BeNil())

--- a/hack/cluster-clean.sh
+++ b/hack/cluster-clean.sh
@@ -9,15 +9,6 @@ set +e
 echo "Deleting noobaa objects"
 $OCS_OC_PATH -n openshift-storage delete noobaa --all
 
-# Remove finalizers from all cephclusters, to not block the cleanup
-echo "Removing cephcluster finalizers"
-$OCS_OC_PATH get cephcluster -n openshift-storage -o=custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace,FINALIZERS:.metadata.finalizers --no-headers | grep cephcluster.ceph.rook.io | while read -r p; do
-    arr=("$p")
-    name="${arr[0]}"
-    namespace="${arr[1]}"
-    $OCS_OC_PATH patch cephcluster "$name" -n "$namespace" --type=json -p '[{ "op": "remove", "path": "/metadata/finalizers" }]'
-done
-
 # delete storage clusters.
 # StorageClusterInitialization and CephClusters are automatically deleted as a result
 # deleting the StorageCluster due to owner references.

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -87,6 +87,9 @@ OCS_SUBSCRIPTION_CHANNEL=${OCS_SUBSCRIPTION_CHANNEL:-alpha}
 UPGRADE_FROM_OCS_REGISTRY_IMAGE="${UPGRADE_FROM_OCS_REGISTRY_IMAGE:-quay.io/ocs-dev/ocs-registry:4.2.0}"
 UPGRADE_FROM_OCS_SUBSCRIPTION_CHANNEL="${UPGRADE_FROM_OCS_SUBSCRIPTION_CHANNEL:-$OCS_SUBSCRIPTION_CHANNEL}"
 
+OCS_MUST_GATHER_DIR="${OCS_MUST_GATHER_DIR:-ocs-must-gather}"
+OCP_MUST_GATHER_DIR="${OCP_MUST_GATHER_DIR:-ocp-must-gather}"
+
 OS_TYPE=$(uname)
 
 # Override the image name when this is invoked from openshift ci
@@ -97,4 +100,6 @@ if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
 	# ocs-must-gather image name to the csv-merger tool
 	export OCS_MUST_GATHER_IMAGE="${MUST_GATHER_FULL_IMAGE_NAME}"
 	MUST_GATHER_FULL_IMAGE_NAME="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:ocs-must-gather-quay"
+	OCS_MUST_GATHER_DIR="${ARTIFACT_DIR}/ocs-must-gather"
+	OCP_MUST_GATHER_DIR="${ARTIFACT_DIR}/ocp-must-gather"
 fi

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -94,12 +94,12 @@ OS_TYPE=$(uname)
 
 # Override the image name when this is invoked from openshift ci
 if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
-	CATALOG_FULL_IMAGE_NAME="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:${CATALOG_IMAGE_NAME}"
+	CATALOG_FULL_IMAGE_NAME="${IMAGE_FORMAT%:*}:ocs-registry"
 	echo "Openshift CI detected, deploying using image $CATALOG_FULL_IMAGE_NAME"
 	# When run by the openshift ci, we must pass the original
 	# ocs-must-gather image name to the csv-merger tool
 	export OCS_MUST_GATHER_IMAGE="${MUST_GATHER_FULL_IMAGE_NAME}"
-	MUST_GATHER_FULL_IMAGE_NAME="registry.svc.ci.openshift.org/${OPENSHIFT_BUILD_NAMESPACE}/stable:ocs-must-gather-quay"
+	MUST_GATHER_FULL_IMAGE_NAME="${IMAGE_FORMAT%:*}:ocs-must-gather-quay"
 	OCS_MUST_GATHER_DIR="${ARTIFACT_DIR}/ocs-must-gather"
 	OCP_MUST_GATHER_DIR="${ARTIFACT_DIR}/ocp-must-gather"
 fi

--- a/hack/dump-debug-info.sh
+++ b/hack/dump-debug-info.sh
@@ -2,12 +2,14 @@
 
 source hack/common.sh
 
+set -e
+
 echo "dumping debug information"
 
 echo "Running ocs-must-gather to ${OCS_MUST_GATHER_DIR}"
-mkdir -p $OCS_MUST_GATHER_DIR
+mkdir -p "$OCS_MUST_GATHER_DIR"
 ${OCS_OC_PATH} adm must-gather --image "$MUST_GATHER_FULL_IMAGE_NAME" --dest-dir "$OCS_MUST_GATHER_DIR"
 
 echo "Running ocp-must-gather to ${OCP_MUST_GATHER_DIR}"
-mkdir -p $OCP_MUST_GATHER_DIR
+mkdir -p "$OCP_MUST_GATHER_DIR"
 ${OCS_OC_PATH} --insecure-skip-tls-verify adm must-gather --dest-dir "$OCP_MUST_GATHER_DIR"

--- a/hack/dump-debug-info.sh
+++ b/hack/dump-debug-info.sh
@@ -4,18 +4,10 @@ source hack/common.sh
 
 echo "dumping debug information"
 
-echo "Running ocs-must-gather"
-OCS_MUST_GATHER_DIR="ocs-must-gather"
-if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
-  OCS_MUST_GATHER_DIR="/tmp/artifacts/ocs-must-gather"
-fi
+echo "Running ocs-must-gather to ${OCS_MUST_GATHER_DIR}"
 mkdir -p $OCS_MUST_GATHER_DIR
 ${OCS_OC_PATH} adm must-gather --image "$MUST_GATHER_FULL_IMAGE_NAME" --dest-dir "$OCS_MUST_GATHER_DIR"
 
-echo "Running ocp-must-gather"
-OCP_MUST_GATHER_DIR="ocp-must-gather"
-if [ -n "$OPENSHIFT_BUILD_NAMESPACE" ]; then
-  OCP_MUST_GATHER_DIR="/tmp/artifacts/ocp-must-gather"
-fi
+echo "Running ocp-must-gather to ${OCP_MUST_GATHER_DIR}"
 mkdir -p $OCP_MUST_GATHER_DIR
 ${OCS_OC_PATH} --insecure-skip-tls-verify adm must-gather --dest-dir "$OCP_MUST_GATHER_DIR"

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -2,7 +2,8 @@
 
 source hack/common.sh
 
-$OUTDIR_BIN/functests --ocs-registry-image="${CATALOG_FULL_IMAGE_NAME}" \
+$OUTDIR_BIN/functests -ginkgo.v \
+        --ocs-registry-image="${CATALOG_FULL_IMAGE_NAME}" \
 	--ocs-subscription-channel="${OCS_SUBSCRIPTION_CHANNEL}" \
 	--upgrade-from-ocs-registry-image="${UPGRADE_FROM_OCS_REGISTRY_IMAGE}" \
 	--upgrade-from-ocs-subscription-channel="${UPGRADE_FROM_OCS_SUBSCRIPTION_CHANNEL}" \

--- a/openshift-ci/Dockerfile.registry.build
+++ b/openshift-ci/Dockerfile.registry.build
@@ -12,7 +12,7 @@ FROM quay.io/openshift/origin-operator-registry:latest
 COPY --from=stage /ocs-operator/build/_output/appregistry/olm-catalog /registry/ocs-catalog
 
 # replaces ocs-operator image with the one built by openshift ci
-RUN find /registry/ocs-catalog/ -type f -exec sed -i "s|image\: .*/ocs-operator:.*$|image: default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com/${OPENSHIFT_BUILD_NAMESPACE}/stable:ocs-operator|g" {} \; || :
+RUN find /registry/ocs-catalog/ -type f -exec sed -i "s|image\: .*/ocs-operator:.*$|image: default-route-openshift-image-registry.apps.build02.ci.devcluster.openshift.com/${OPENSHIFT_BUILD_NAMESPACE}/stable:ocs-operator|g" {} \; || :
 
 # Initialize the database
 RUN initializer --manifests /registry/ocs-catalog --output bundles.db

--- a/pkg/deploy-manager/config.go
+++ b/pkg/deploy-manager/config.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 
+	nbv1 "github.com/noobaa/noobaa-operator/v2/pkg/apis/noobaa/v1alpha1"
 	ocsv1 "github.com/openshift/ocs-operator/pkg/apis/ocs/v1"
 	olmclient "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
-	rookv1 "github.com/rook/rook/pkg/client/clientset/versioned"
+	rookcephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	rookclient "github.com/rook/rook/pkg/client/clientset/versioned"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
@@ -30,13 +32,15 @@ const MinOSDsCount = 3
 
 func init() {
 	ocsv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	rookcephv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	nbv1.SchemeBuilder.AddToScheme(scheme.Scheme)
 }
 
 // DeployManager is a util tool used by the functional tests
 type DeployManager struct {
 	olmClient      *olmclient.Clientset
 	k8sClient      *kubernetes.Clientset
-	rookClient     *rookv1.Clientset
+	rookClient     *rookclient.Clientset
 	ocsClient      *rest.RESTClient
 	crClient       crclient.Client
 	parameterCodec runtime.ParameterCodec
@@ -58,7 +62,7 @@ func (t *DeployManager) GetOcsClient() *rest.RESTClient {
 }
 
 // GetRookClient is the function used to retrieve the rook client
-func (t *DeployManager) GetRookClient() *rookv1.Clientset {
+func (t *DeployManager) GetRookClient() *rookclient.Clientset {
 	return t.rookClient
 }
 
@@ -112,7 +116,7 @@ func NewDeployManager() (*DeployManager, error) {
 	if err != nil {
 		return nil, err
 	}
-	rookClient, err := rookv1.NewForConfig(rookConfig)
+	rookClient, err := rookclient.NewForConfig(rookConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/deploy-manager/subscription.go
+++ b/pkg/deploy-manager/subscription.go
@@ -483,7 +483,6 @@ func (t *DeployManager) VerifyComponentOperators() error {
 		return err
 	}
 
-	//resolver := install.StrategyResolver{}
 	var resolver *install.StrategyResolver
 	strategy, err := resolver.UnmarshalStrategy(csv.Spec.InstallStrategy)
 	if err != nil {


### PR DESCRIPTION
There are several problems with the e2e-aws tests that have been preventing them from successfully running on PRs. This PR fixes all currently known problems. It includes some refactoring of the OCS uninstallation to deal with intermittent errors in the AfterSuite.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>