### PR TITLE
enhances containerized build

### DIFF
--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -1,10 +1,9 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal as builder
+FROM registry.access.redhat.com/ubi8/go-toolset AS builder
 
-RUN microdnf install -y make golang; microdnf -y clean all
-
-FROM builder
-
-RUN mkdir -p /output
 COPY . /ocs-operator
 WORKDIR /ocs-operator
-RUN make build-go OUTDIR_BIN=/output
+RUN make build-go
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal
+
+COPY --from=builder /ocs-operator/build/_output/bin/ocs-operator /usr/local/bin/ocs-operator

--- a/hack/build-container.sh
+++ b/hack/build-container.sh
@@ -4,5 +4,4 @@ set -e
 
 source hack/common.sh
 
-mkdir -p ${OUTDIR_BIN}
-${IMAGE_BUILD_CMD} build -v "$(pwd)/${OUTDIR_BIN}":/output -f build/Dockerfile.build .
+${IMAGE_BUILD_CMD} build -f build/Dockerfile.build -t "${OPERATOR_FULL_IMAGE_NAME}" .


### PR DESCRIPTION
Uses multi-stage build to minimize image size.
ubi8/go-toolset is used as builder image to build ocs-operator
and copy it into final image with ubi8/ubi-minimal as base.
Final image will be around 170MB in comparison to previous 2GB+.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>