### PR TITLE
Whitelist instead of Blacklist to hide internal objects

### DIFF
--- a/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -702,10 +702,7 @@ metadata:
     olm.skipRange: '>=0.0.1 <4.6.0'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/suggested-namespace: openshift-storage
-    operators.operatorframework.io/internal-objects: '["cephclusters.ceph.rook.io",
-      "cephblockpools.ceph.rook.io", "cephobjectstores.ceph.rook.io", "cephobjectstoreusers.ceph.rook.io",
-      "cephnfses.ceph.rook.io","cephclients.ceph.rook.io", "noobaas.noobaa.io", "objectbuckets.objectbucket.io","objectbucketclaims.objectbucket.io","ocsinitializations.ocs.openshift.io",
-      "storageclusterinitializations.ocs.openshift.io", "cephfilesystems.ceph.rook.io"]'
+    operators.operatorframework.io/internal-objects: '["ocsinitializations.ocs.openshift.io","storageclusterinitializations.ocs.openshift.io","cephclusters.ceph.rook.io","cephblockpools.ceph.rook.io","cephobjectstores.ceph.rook.io","cephobjectstoreusers.ceph.rook.io","cephnfses.ceph.rook.io","cephclients.ceph.rook.io","cephfilesystems.ceph.rook.io","cephrbdmirrors.ceph.rook.io","cephobjectrealms.ceph.rook.io","cephobjectzonegroups.ceph.rook.io","cephobjectzones.ceph.rook.io","noobaas.noobaa.io","objectbucketclaims.objectbucket.io","objectbuckets.objectbucket.io"]'
     repository: https://github.com/openshift/ocs-operator
     support: Red Hat
   name: ocs-operator.v4.6.0


### PR DESCRIPTION
adding API whitelist to populate internal-objects.
This allows us to hide any API that we do not want to expose
to user without having to append individual APIs to the
internal objects list. Instead we add APIs that we want to
expose and the rest is automatically hidden.