### PR TITLE
StorageCluster: add uninstall mode

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -49,8 +49,8 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	monCountOverrideEnvVar = "MON_COUNT_OVERRIDE"
 	// EBS represents AWS EBS provisioner for StorageClass
 	EBS StorageClassProvisionerType = "kubernetes.io/aws-ebs"
-	// CleanupPolicyAnnotation defines the cleanup policy
-	CleanupPolicyAnnotation = "cleanup.ocs.openshift.io"
+	// CleanupPolicyAnnotation defines the cleanup policy for data and metadata during uninstall
+	CleanupPolicyAnnotation = "uninstall.ocs.openshift.io/cleanup-policy"
 	// CleanupPolicyDelete when set, modifies the cleanup policy for Rook to delete the DataDirHostPath on uninstall
 	CleanupPolicyDelete CleanupPolicyType = "delete"
 	// CleanupPolicyRetain when set, modifies the cleanup policy for Rook to not cleanup the DataDirHostPath and the disks on uninstall

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -49,8 +49,8 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	monCountOverrideEnvVar = "MON_COUNT_OVERRIDE"
 	// EBS represents AWS EBS provisioner for StorageClass
 	EBS StorageClassProvisionerType = "kubernetes.io/aws-ebs"
-	// CleanupPolicyLabel defines the cleanup policy
-	CleanupPolicyLabel = "cleanup.ocs.openshift.io"
+	// CleanupPolicyAnnotation defines the cleanup policy
+	CleanupPolicyAnnotation = "cleanup.ocs.openshift.io"
 	// CleanupPolicyDelete when set, modifies the cleanup policy for Rook to delete the DataDirHostPath on uninstall
 	CleanupPolicyDelete CleanupPolicyType = "yes-really-destroy-data"
 	//Name of MetadataPVCTemplate
@@ -482,7 +482,7 @@ func (r *ReconcileStorageCluster) isActiveStorageCluster(instance *ocsv1.Storage
 }
 
 func (r *ReconcileStorageCluster) setRookCleanupPolicy(instance *ocsv1.StorageCluster, reqLogger logr.Logger) (err error) {
-	if v, found := instance.ObjectMeta.Labels[CleanupPolicyLabel]; found {
+	if v, found := instance.ObjectMeta.Annotations[CleanupPolicyAnnotation]; found {
 		if v == string(CleanupPolicyDelete) {
 			cephCluster := &cephv1.CephCluster{}
 			err = r.client.Get(context.TODO(), types.NamespacedName{Name: generateNameForCephCluster(instance), Namespace: instance.Namespace}, cephCluster)

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -33,6 +33,9 @@ type StorageClassProvisionerType string
 // CleanupPolicyType is a string representing cleanup policy
 type CleanupPolicyType string
 
+// UninstallModeType is a string representing cleanup mode, it decides whether the deletion is graceful or forced
+type UninstallModeType string
+
 // ensureFunc which encapsulate all the 'ensure*' type functions
 type ensureFunc func(*ocsv1.StorageCluster, logr.Logger) error
 
@@ -55,6 +58,12 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	CleanupPolicyDelete CleanupPolicyType = "delete"
 	// CleanupPolicyRetain when set, modifies the cleanup policy for Rook to not cleanup the DataDirHostPath and the disks on uninstall
 	CleanupPolicyRetain CleanupPolicyType = "retain"
+	// UninstallModeAnnotation defines the uninstall mode
+	UninstallModeAnnotation = "uninstall.ocs.openshift.io/mode"
+	// UninstallModeForced when set, sets the uninstall mode for Rook and Noobaa to forced.
+	UninstallModeForced UninstallModeType = "forced"
+	// UninstallModeGraceful when set, sets the uninstall mode for Rook and Noobaa to graceful.
+	UninstallModeGraceful UninstallModeType = "graceful"
 	//Name of MetadataPVCTemplate
 	metadataPVCName = "metadata"
 )

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -52,7 +52,9 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	// CleanupPolicyAnnotation defines the cleanup policy
 	CleanupPolicyAnnotation = "cleanup.ocs.openshift.io"
 	// CleanupPolicyDelete when set, modifies the cleanup policy for Rook to delete the DataDirHostPath on uninstall
-	CleanupPolicyDelete CleanupPolicyType = "yes-really-destroy-data"
+	CleanupPolicyDelete CleanupPolicyType = "delete"
+	// CleanupPolicyRetain when set, modifies the cleanup policy for Rook to not cleanup the DataDirHostPath and the disks on uninstall
+	CleanupPolicyRetain CleanupPolicyType = "retain"
 	//Name of MetadataPVCTemplate
 	metadataPVCName = "metadata"
 )


### PR DESCRIPTION
Rook and Noobaa are now both defaulting to wait for removal of existing
PVCs and OBCs before deleting their operands. In cases where the admin
wants to enforce a forced cleanup, this label on the StorageCluster
should be set.

uninstall-mode.ocs.openshift.io="yes-really-uninstall-even-if-in-use"

Co-authored-by: Nitin Goyal <nigoyal@redhat.com>
Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>