### PR TITLE
Fix CephObjectStore name exceeding 64 char length

### DIFF
--- a/pkg/controller/storagecluster/external_resources_test.go
+++ b/pkg/controller/storagecluster/external_resources_test.go
@@ -323,7 +323,7 @@ func assertCephObjectStore(t *testing.T, reconciler ReconcileStorageCluster, rem
 	sc := &api.StorageCluster{}
 	err := reconciler.client.Get(nil, request.NamespacedName, sc)
 	assert.NoError(t, err)
-	expectedName := fmt.Sprintf("%s-external-cephobjectstore", sc.Name)
+	expectedName := fmt.Sprintf("%s-cephobjectstore", sc.Name)
 	request.Name = expectedName
 	cObjS := &cephv1.CephObjectStore{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/storagecluster/generate.go
+++ b/pkg/controller/storagecluster/generate.go
@@ -27,12 +27,7 @@ func generateNameForCephBlockPool(initData *ocsv1.StorageCluster) string {
 }
 
 func generateNameForCephObjectStore(initData *ocsv1.StorageCluster) string {
-	cosName := "cephobjectstore"
-	if initData.Spec.ExternalStorage.Enable {
-		cosName = fmt.Sprintf("external-%s", cosName)
-	}
-	cosName = fmt.Sprintf("%s-%s", initData.Name, cosName)
-	return cosName
+	return fmt.Sprintf("%s-%s", initData.Name, "cephobjectstore")
 }
 
 func generateNameForCephRgwSC(initData *ocsv1.StorageCluster) string {


### PR DESCRIPTION
In external mode we are already adding 'external' keyword with
storagecluster, so need to add it again with cephobjectstore name.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>