### PR TITLE
StorageCluster: set uninstall defaults

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -49,8 +49,8 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	monCountOverrideEnvVar = "MON_COUNT_OVERRIDE"
 	// EBS represents AWS EBS provisioner for StorageClass
 	EBS StorageClassProvisionerType = "kubernetes.io/aws-ebs"
-	// CleanupPolicyAnnotation defines the cleanup policy
-	CleanupPolicyAnnotation = "cleanup.ocs.openshift.io"
+	// CleanupPolicyAnnotation defines the cleanup policy for data and metadata during uninstall
+	CleanupPolicyAnnotation = "uninstall.ocs.openshift.io/cleanup-policy"
 	// CleanupPolicyDelete when set, modifies the cleanup policy for Rook to delete the DataDirHostPath on uninstall
 	CleanupPolicyDelete CleanupPolicyType = "delete"
 	// CleanupPolicyRetain when set, modifies the cleanup policy for Rook to not cleanup the DataDirHostPath and the disks on uninstall

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -49,8 +49,8 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	monCountOverrideEnvVar = "MON_COUNT_OVERRIDE"
 	// EBS represents AWS EBS provisioner for StorageClass
 	EBS StorageClassProvisionerType = "kubernetes.io/aws-ebs"
-	// CleanupPolicyLabel defines the cleanup policy
-	CleanupPolicyLabel = "cleanup.ocs.openshift.io"
+	// CleanupPolicyAnnotation defines the cleanup policy
+	CleanupPolicyAnnotation = "cleanup.ocs.openshift.io"
 	// CleanupPolicyDelete when set, modifies the cleanup policy for Rook to delete the DataDirHostPath on uninstall
 	CleanupPolicyDelete CleanupPolicyType = "yes-really-destroy-data"
 	//Name of MetadataPVCTemplate
@@ -482,7 +482,7 @@ func (r *ReconcileStorageCluster) isActiveStorageCluster(instance *ocsv1.Storage
 }
 
 func (r *ReconcileStorageCluster) setRookCleanupPolicy(instance *ocsv1.StorageCluster, reqLogger logr.Logger) (err error) {
-	if v, found := instance.ObjectMeta.Labels[CleanupPolicyLabel]; found {
+	if v, found := instance.ObjectMeta.Annotations[CleanupPolicyAnnotation]; found {
 		if v == string(CleanupPolicyDelete) {
 			cephCluster := &cephv1.CephCluster{}
 			err = r.client.Get(context.TODO(), types.NamespacedName{Name: generateNameForCephCluster(instance), Namespace: instance.Namespace}, cephCluster)

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -33,6 +33,9 @@ type StorageClassProvisionerType string
 // CleanupPolicyType is a string representing cleanup policy
 type CleanupPolicyType string
 
+// UninstallModeType is a string representing cleanup mode, it decides whether the deletion is graceful or forced
+type UninstallModeType string
+
 // ensureFunc which encapsulate all the 'ensure*' type functions
 type ensureFunc func(*ocsv1.StorageCluster, logr.Logger) error
 
@@ -55,6 +58,12 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	CleanupPolicyDelete CleanupPolicyType = "delete"
 	// CleanupPolicyRetain when set, modifies the cleanup policy for Rook to not cleanup the DataDirHostPath and the disks on uninstall
 	CleanupPolicyRetain CleanupPolicyType = "retain"
+	// UninstallModeAnnotation defines the uninstall mode
+	UninstallModeAnnotation = "uninstall.ocs.openshift.io/mode"
+	// UninstallModeForced when set, sets the uninstall mode for Rook and Noobaa to forced.
+	UninstallModeForced UninstallModeType = "forced"
+	// UninstallModeGraceful when set, sets the uninstall mode for Rook and Noobaa to graceful.
+	UninstallModeGraceful UninstallModeType = "graceful"
 	//Name of MetadataPVCTemplate
 	metadataPVCName = "metadata"
 )

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -175,6 +175,9 @@ func (r *ReconcileStorageCluster) Reconcile(request reconcile.Request) (reconcil
 				return reconcile.Result{}, err
 			}
 		}
+
+		r.reconcileUninstallAnnotations(instance, reqLogger)
+
 	} else {
 		// The object is marked for deletion
 		instance.Status.Phase = statusutil.PhaseDeleting
@@ -587,6 +590,19 @@ func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqL
 	}
 
 	return nil
+}
+
+// reconcileUninstallAnnotations looks at the current uninstall annotations on the StorageCluster and sets defaults if none are set.
+func (r *ReconcileStorageCluster) reconcileUninstallAnnotations(sc *ocsv1.StorageCluster, reqLogger logr.Logger) {
+	if _, found := sc.ObjectMeta.Annotations[UninstallModeAnnotation]; !found {
+		metav1.SetMetaDataAnnotation(&sc.ObjectMeta, string(UninstallModeAnnotation), string(UninstallModeGraceful))
+		reqLogger.Info("setting uninstall mode annotation to default", UninstallModeGraceful)
+	}
+
+	if _, found := sc.ObjectMeta.Annotations[CleanupPolicyAnnotation]; !found {
+		metav1.SetMetaDataAnnotation(&sc.ObjectMeta, string(CleanupPolicyAnnotation), string(CleanupPolicyDelete))
+		reqLogger.Info("setting uninstall cleanup policy annotation to default", CleanupPolicyDelete)
+	}
 }
 
 // Checks whether a string is contained within a slice

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -52,7 +52,9 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	// CleanupPolicyAnnotation defines the cleanup policy
 	CleanupPolicyAnnotation = "cleanup.ocs.openshift.io"
 	// CleanupPolicyDelete when set, modifies the cleanup policy for Rook to delete the DataDirHostPath on uninstall
-	CleanupPolicyDelete CleanupPolicyType = "yes-really-destroy-data"
+	CleanupPolicyDelete CleanupPolicyType = "delete"
+	// CleanupPolicyRetain when set, modifies the cleanup policy for Rook to not cleanup the DataDirHostPath and the disks on uninstall
+	CleanupPolicyRetain CleanupPolicyType = "retain"
 	//Name of MetadataPVCTemplate
 	metadataPVCName = "metadata"
 )


### PR DESCRIPTION
The default policy for uninstall mode is set to graceful and the default for the cleanup policy is set to delete.

These annotations are set only if the annotations are not already set on the StorageCluster. If set, even as an empty string, we don't make any changes.

