### PR TITLE
restores YAML manifests for Prometheus rules

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,3 +4,4 @@ USER nobody
 
 ADD _output/bin/ocs-operator /usr/local/bin/ocs-operator
 ADD _output/bin/metrics-exporter /usr/local/bin/metrics-exporter
+ADD _output/*rules*.yaml /ocs-prometheus-rules/

--- a/build/Dockerfile.build
+++ b/build/Dockerfile.build
@@ -8,3 +8,4 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal
 
 COPY --from=builder /ocs-operator/build/_output/bin/ocs-operator /usr/local/bin/ocs-operator
 COPY --from=builder /ocs-operator/build/_output/bin/metrics-exporter /usr/local/bin/metrics-exporter
+COPY --from=builder /ocs-operator/build/_output/*rules*.yaml /ocs-prometheus-rules/

--- a/hack/build-operator.sh
+++ b/hack/build-operator.sh
@@ -4,4 +4,5 @@ set -e
 
 source hack/common.sh
 
+cp $PROMETHEUS_RULES_PATH/*rules*.yaml $OUTDIR
 ${IMAGE_BUILD_CMD} build -f build/Dockerfile -t "${OPERATOR_FULL_IMAGE_NAME}" build/

--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -1,1 +1,25 @@
-# this is just a temporary empty stub to satisfy the CI
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: prometheus-ocs-rules
+  namespace: openshift-storage
+spec:
+  groups:
+  - name: cluster-services-alert.rules
+    rules:
+    - alert: ClusterObjectStoreState
+      annotations:
+        description: Cluster Object Store is in unhealthy state for more than 15s.
+          Please check Ceph cluster health or RGW connection.
+        message: Cluster Object Store is in unhealthy state. Please check Ceph cluster
+          health or RGW connection.
+        severity_level: error
+        storage_type: RGW
+      expr: |
+        ocs_rgw_health_status{job="ocs-metrics-exporter"} > 1
+      for: 15s
+      labels:
+        severity: critical

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -1,1 +1,27 @@
-# this is just a temporary empty stub to satisfy the CI
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: k8s
+    role: alert-rules
+  name: prometheus-ocs-rules
+  namespace: openshift-storage
+spec:
+  groups:
+  - name: ocs.rules
+    rules: []
+  - name: cluster-services-alert.rules
+    rules:
+    - alert: ClusterObjectStoreState
+      annotations:
+        description: Cluster Object Store is in unhealthy state for more than 15s.
+          Please check Ceph cluster health.
+        message: Cluster Object Store is in unhealthy state. Please check Ceph cluster
+          health.
+        severity_level: error
+        storage_type: RGW
+      expr: |
+        ocs_rgw_health_status{job="ocs-metrics-exporter"} > 1
+      for: 15s
+      labels:
+        severity: critical

--- a/openshift-ci/Dockerfile.deploy
+++ b/openshift-ci/Dockerfile.deploy
@@ -4,6 +4,7 @@ ENV LANG=en_US.utf8
 
 COPY ocs-operator /usr/local/bin/ocs-operator
 COPY metrics-exporter /usr/local/bin/metrics-exporter
+COPY *rules*.yaml /ocs-prometheus-rules/
 USER 1001
 
 ENTRYPOINT [ "/usr/local/bin/ocs-operator" ]

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -333,7 +333,7 @@ func (r *ReconcileStorageCluster) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
-	err = r.enablePrometheusRules(instance)
+	err = r.enablePrometheusRules(instance.Spec.ExternalStorage.Enable)
 	if err != nil {
 		reqLogger.Error(err, "failed to reconcile prometheus rules")
 		return reconcile.Result{}, err


### PR DESCRIPTION
This restores prometheus rules YAML deleted by  commit
5a4b96929585cd7ed9dd217dbe864884859c79f7 and uses it for deployment
instead of Go Structs. This helps in decoupling monitoring resources
from operator resources. Also, at later stage these files will be
generated dynamically and will be scalable.

**CI fix :** https://github.com/openshift/release/pull/11528

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>