### PR TITLE
Added the framework for the OCS rules and alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ tools/csv-merger/csv-merger
 tools/csv-checksum/csv-checksum
 tools/cluster-deploy/cluster-deploy
 tools/shellcheck
+metrics/mixin/build/vendor

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ $(call add-crd-gen,ocsv1,./pkg/apis/ocs/v1,./deploy/crds,./deploy/crds)
 	gen-release-csv \
 	gen-latest-csv \
 	gen-latest-deploy-yaml \
+	gen-latest-prometheus-rules-yamls \
 	verify-latest-deploy-yaml \
 	verify-latest-csv \
 	source-manifests \
@@ -89,6 +90,10 @@ gen-latest-deploy-yaml:
 	@echo "Generating latest deployment yaml file"
 	hack/gen-deployment-yaml.sh
 
+gen-latest-prometheus-rules-yamls:
+	@echo "Generating latest Prometheus rules yamls"
+	hack/gen-promethues-rules.sh
+	
 verify-latest-deploy-yaml: gen-latest-deploy-yaml
 	@echo "Verifying deployment yaml changes"
 	hack/verify-latest-deploy-yaml.sh

--- a/hack/gen-promethues-rules.sh
+++ b/hack/gen-promethues-rules.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+MIXIN_PATH="metrics/mixin"
+BUILD_PATH="metrics/mixin/build"
+RULES_PATH="metrics/deploy"
+
+#Create intermediate yamls to test if alerts are compiling a
+echo "Creating Promethues Rules And Alerts"
+
+(cd $MIXIN_PATH && make prometheus_alert_rules.yaml prometheus_alert_rules_external.yaml)
+
+echo "Running lint on generated Rules and Alerts"
+
+(cd $MIXIN_PATH && make lint)
+
+#Clean intermediate yamls
+rm $MIXIN_PATH/prometheus_alert_rules.yaml $MIXIN_PATH/prometheus_alert_rules_external.yaml $MIXIN_PATH/prometheus_rules.yaml
+
+set -e
+set -x
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+
+#Create build yamls temporary directory
+# Make sure to start with a clean 'manifests' dir
+rm -rf $BUILD_PATH/manifests
+mkdir $BUILD_PATH/manifests
+
+#Generate final Prometheus Rule Yamls
+echo "Creating Deploy Manifest Prometheus Rules"
+
+jsonnet -J vendor -m $BUILD_PATH/manifests "$BUILD_PATH/internal.jsonnet" | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
+jsonnet -J vendor -m $BUILD_PATH/manifests "$BUILD_PATH/external.jsonnet" | xargs -I{} sh -c 'cat {} | gojsontoyaml > {}.yaml; rm -f {}' -- {}
+
+# Rename and move the output rule yaml files
+echo "Moving Deploy Manifest Prometheus Rules to $RULES_PATH"
+
+mv $BUILD_PATH/manifests/prometheus-rules.yaml $RULES_PATH/prometheus-ocs-rules.yaml
+mv $BUILD_PATH/manifests/prometheus-rules-external.yaml $RULES_PATH/prometheus-ocs-rules-external.yaml
+
+#Clean build yamls temporary directory
+rm -rf $BUILD_PATH/manifests

--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: openshift-storage
 spec:
   groups:
-  - name: cluster-services-alert.rules
+  - name: external-cluster-services-alert.rules
     rules:
     - alert: ClusterObjectStoreState
       annotations:

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -8,8 +8,6 @@ metadata:
   namespace: openshift-storage
 spec:
   groups:
-  - name: ocs.rules
-    rules: []
   - name: cluster-services-alert.rules
     rules:
     - alert: ClusterObjectStoreState

--- a/metrics/mixin/Makefile
+++ b/metrics/mixin/Makefile
@@ -1,0 +1,29 @@
+# This Makefile should be used by developers to test generation of new new rules and alerts
+JSONNET_FMT := jsonnetfmt -n 2 --max-blank-lines 2 --string-style s --comment-style s
+
+all: prometheus_alert_rules.yaml prometheus_alert_rules_external.yaml lint
+
+fmt:
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+prometheus_alert_rules.yaml: mixin.libsonnet lib/alerts.jsonnet alerts/*.libsonnet
+	jsonnet -S lib/alerts.jsonnet > $@
+
+prometheus_alert_rules_external.yaml: mixin-external.libsonnet lib/alerts-external.jsonnet alerts/*.libsonnet
+	jsonnet -S lib/alerts-external.jsonnet > $@
+
+prometheus_rules.yaml: mixin.libsonnet lib/rules.jsonnet rules/*.libsonnet
+	jsonnet -S lib/rules.jsonnet > $@
+
+lint: prometheus_alert_rules.yaml
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+
+	promtool check rules prometheus_alert_rules.yaml
+
+clean:
+	rm -rf prometheus_alert_rules.yaml
+

--- a/metrics/mixin/README.md
+++ b/metrics/mixin/README.md
@@ -1,0 +1,85 @@
+# Prometheus Monitoring Mixin for OCS
+
+A set of Prometheus Rules & Alerts for OCS.
+
+The scope of this directory is to provide OCS specific Prometheus rule files using Prometheus Mixin.
+
+## Prerequisites
+* Jsonnet [[Install Jsonnet]](https://github.com/google/jsonnet#building-jsonnet)
+
+   [Jsonnet](https://jsonnet.org/learning/getting_started.html) is a data templating language for app and tool developers.
+
+   The mixin directory uses Jsonnet to provide reusable and configurable configs for Prometheus Rules & Alerts.
+
+   * Learning Resources:
+      * https://jsonnet.org/learning/tutorial.html
+      * https://jsonnet.org/ref/language.html
+      * https://github.com/monitoring-mixins/docs
+   * Reference Projects:
+      * https://github.com/kubernetes-monitoring/kubernetes-mixin
+      * https://github.com/openshift/cluster-monitoring-operator/
+      * More: https://jsonnet.org/articles/kubernetes.html
+* Jsonnet-bundler [[Install Jsonnet-bundler]](https://github.com/jsonnet-bundler/jsonnet-bundler#install)
+
+   [Jsonnet-bundler](https://github.com/jsonnet-bundler/jsonnet-bundler) is a package manager for jsonnet.
+* Promtool
+  1. [Download](https://golang.org/dl/) Go (>=1.11) and [install](https://golang.org/doc/install) it on your system.
+  2. Setup the [GOPATH](http://www.g33knotes.org/2014/07/60-second-count-down-to-go.html) environment.
+  3. Run `$ go get -d github.com/prometheus/prometheus/cmd/promtool`  
+
+
+## How to use?
+
+**To get dependencies**
+
+`$ jb install` inside the directory **metrics/mixin/build**
+
+### To add new alerts/rules:
+
+* Add new alerts in 'metrics/mixin/alerts' directory in libsonnet format. Learn about Jsonnet and Libsonnet from https://jsonnet.org/.
+  * Example: 
+    * To create a new alert for notifying if OCS request are above 5 per second in last one minute
+      * Create the alert expression using the metric exposed by the ocs exporter
+        * Metric exposed : **ocs_exporter_requests_total**
+        * Alert expression : **rate(ocs_exporter_requests_total[1m]) > 5**
+    * Create a file under metrics/mixin/alerts directory called requests.libsonnet and add the alert in the libsonnet following format.
+      * 
+      ```
+      {
+         prometheusAlerts+:: {
+         groups+: [
+            {
+               name: 'cluster-request-alert.rules',
+               rules: [
+               {
+                  alert: 'ClusterRequests',
+                  expr: |||
+                     rate(ocs_exporter_requests_total[1m]) > 5
+                  ||| % $._config,
+                  'for': $._config.clusterRequestsAlertTime,
+                  labels: {
+                     severity: 'critical',
+                  },
+                  annotations: {
+                     message: '',
+                     description:'',
+                     clusterRequestsAlertTime,
+                     storage_type: $._config.storageType,
+                     severity_level: 'error',
+                  },
+               },
+               ],
+            },
+         ],
+         },
+      }
+
+      ```
+      * Define constants like clusterRequestsAlertTime, storageType in the metrics/mixin/config.libsonnet file.
+      * Add this file to **metrics/mixin/alerts/alerts.libsonnet** or **metrics/mixin/alerts/alerts-external.libsonnet** depending on the type(For internal or external cluster)
+    * Test the alert/rule generation by using targets in metrics/mixin/Makefile. Eg:  `make prometheus_alert_rules.yaml`. This is **optional** and can be used to isolate issues.
+
+* Generate deployment manifests by using the OCS-operator Makefile target **gen-latest-prometheus-rules-yamls** : ` make gen-latest-prometheus-rules-yamls `. The generated manifests will be written at metrics/deploy/**prometheus-ocs-rules.yaml**(Internal mode) and metrics/deploy/**prometheus-ocs-rules-external.yaml**(External mode)
+
+## Background
+* [Prometheus Monitoring Mixin design doc](https://docs.google.com/document/d/1A9xvzwqnFVSOZ5fD3blKODXfsat5fg6ZhnKu9LK3lB4/edit#)

--- a/metrics/mixin/alerts/alerts-external.libsonnet
+++ b/metrics/mixin/alerts/alerts-external.libsonnet
@@ -1,0 +1,1 @@
+(import 'services-external.libsonnet')

--- a/metrics/mixin/alerts/alerts.libsonnet
+++ b/metrics/mixin/alerts/alerts.libsonnet
@@ -1,0 +1,1 @@
+(import 'services.libsonnet')

--- a/metrics/mixin/alerts/services-external.libsonnet
+++ b/metrics/mixin/alerts/services-external.libsonnet
@@ -1,0 +1,27 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'external-cluster-services-alert.rules',
+        rules: [
+          {
+            alert: 'ClusterObjectStoreState',
+            expr: |||
+              ocs_rgw_health_status{%(ocsExporterSelector)s} > 1
+            ||| % $._config,
+            'for': $._config.clusterObjectStoreStateAlertTime,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'Cluster Object Store is in unhealthy state. Please check Ceph cluster health or RGW connection.',
+              description: 'Cluster Object Store is in unhealthy state for more than %s. Please check Ceph cluster health or RGW connection.' % $._config.clusterObjectStoreStateAlertTime,
+              storage_type: $._config.objectStorageType,
+              severity_level: 'error',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/metrics/mixin/alerts/services.libsonnet
+++ b/metrics/mixin/alerts/services.libsonnet
@@ -1,0 +1,27 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'cluster-services-alert.rules',
+        rules: [
+          {
+            alert: 'ClusterObjectStoreState',
+            expr: |||
+              ocs_rgw_health_status{%(ocsExporterSelector)s} > 1
+            ||| % $._config,
+            'for': $._config.clusterObjectStoreStateAlertTime,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'Cluster Object Store is in unhealthy state. Please check Ceph cluster health.',
+              description: 'Cluster Object Store is in unhealthy state for more than %s. Please check Ceph cluster health.' % $._config.clusterObjectStoreStateAlertTime,
+              storage_type: $._config.objectStorageType,
+              severity_level: 'error',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/metrics/mixin/build/external.jsonnet
+++ b/metrics/mixin/build/external.jsonnet
@@ -1,0 +1,7 @@
+local kp = (import 'jsonnet/kube-prometheus-external.libsonnet') + {
+  _config+:: {
+    namespace: 'openshift-storage',
+  },
+};
+
+{ ['prometheus-' + name + '-external']: kp.prometheus[name] for name in std.objectFields(kp.prometheus) }

--- a/metrics/mixin/build/internal.jsonnet
+++ b/metrics/mixin/build/internal.jsonnet
@@ -1,0 +1,7 @@
+local kp = (import 'jsonnet/kube-prometheus.libsonnet') + {
+  _config+:: {
+    namespace: 'openshift-storage',
+  },
+};
+
+{ ['prometheus-' + name]: kp.prometheus[name] for name in std.objectFields(kp.prometheus) }

--- a/metrics/mixin/build/jsonnet/kube-prometheus-external.libsonnet
+++ b/metrics/mixin/build/jsonnet/kube-prometheus-external.libsonnet
@@ -1,0 +1,17 @@
+local k = import '../vendor/ksonnet/ksonnet.beta.3/k.libsonnet';
+
+(import 'prometheus.libsonnet') +
+(import '../../mixin-external.libsonnet') + {
+  kubePrometheus+:: {
+    namespace: k.core.v1.namespace.new($._config.namespace),
+    name: 'prometheus-ocs-rules-external',
+  },
+} + {
+  _config+:: {
+    namespace: 'default',
+
+    prometheus+:: {
+      rules: $.prometheusRules + $.prometheusAlerts,
+    },
+  },
+}

--- a/metrics/mixin/build/jsonnet/kube-prometheus.libsonnet
+++ b/metrics/mixin/build/jsonnet/kube-prometheus.libsonnet
@@ -1,0 +1,17 @@
+local k = import '../vendor/ksonnet/ksonnet.beta.3/k.libsonnet';
+
+(import 'prometheus.libsonnet') +
+(import '../../mixin.libsonnet') + {
+  kubePrometheus+:: {
+    namespace: k.core.v1.namespace.new($._config.namespace),
+    name: 'prometheus-ocs-rules',
+  },
+} + {
+  _config+:: {
+    namespace: 'default',
+
+    prometheus+:: {
+      rules: $.prometheusRules + $.prometheusAlerts,
+    },
+  },
+}

--- a/metrics/mixin/build/jsonnet/prometheus.libsonnet
+++ b/metrics/mixin/build/jsonnet/prometheus.libsonnet
@@ -1,0 +1,32 @@
+local k = import '../vendor/ksonnet/ksonnet.beta.3/k.libsonnet';
+
+{
+  _config+:: {
+    namespace: 'default',
+
+    prometheus+:: {
+      name: 'k8s',
+      rules: {},
+      renderedRules: {},
+      namespaces: $._config.namespace,
+    },
+  },
+  prometheus+:: {
+    [if $._config.prometheus.rules != null && $._config.prometheus.rules != {} then 'rules']:
+      {
+        apiVersion: 'monitoring.coreos.com/v1',
+        kind: 'PrometheusRule',
+        metadata: {
+          labels: {
+            prometheus: $._config.prometheus.name,
+            role: 'alert-rules',
+          },
+          name: 'prometheus-ocs-rules',
+          namespace: $._config.namespace,
+        },
+        spec: {
+          groups: $._config.prometheus.rules.groups,
+        },
+      },
+  },
+}

--- a/metrics/mixin/build/jsonnetfile.json
+++ b/metrics/mixin/build/jsonnetfile.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        {
+            "name": "ksonnet",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/ksonnet/ksonnet-lib",
+                    "subdir": ""
+                }
+            },
+            "version": "master"
+        }
+    ]
+}

--- a/metrics/mixin/build/jsonnetfile.lock.json
+++ b/metrics/mixin/build/jsonnetfile.lock.json
@@ -1,0 +1,14 @@
+{
+    "dependencies": [
+        {
+            "name": "ksonnet",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/ksonnet/ksonnet-lib",
+                    "subdir": ""
+                }
+            },
+            "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f"
+        }
+    ]
+}

--- a/metrics/mixin/config.libsonnet
+++ b/metrics/mixin/config.libsonnet
@@ -1,0 +1,17 @@
+{
+  _config+:: {
+    // Selectors are inserted between {} in Prometheus queries.
+    ocsExporterSelector: 'job="ocs-metrics-exporter"',
+
+    // Duration to raise various Alerts
+    clusterObjectStoreStateAlertTime: '15s',
+
+    // Constants
+    objectStorageType: 'RGW',
+
+    // We build alerts for the presence of all these jobs.
+    jobs: {
+      ocsExporter: $._config.ExporterSelector,
+    },
+  },
+}

--- a/metrics/mixin/lib/alerts-external.jsonnet
+++ b/metrics/mixin/lib/alerts-external.jsonnet
@@ -1,0 +1,1 @@
+std.manifestYamlDoc((import '../mixin-external.libsonnet').prometheusAlerts)

--- a/metrics/mixin/lib/alerts.jsonnet
+++ b/metrics/mixin/lib/alerts.jsonnet
@@ -1,0 +1,1 @@
+std.manifestYamlDoc((import '../mixin.libsonnet').prometheusAlerts)

--- a/metrics/mixin/lib/rules.jsonnet
+++ b/metrics/mixin/lib/rules.jsonnet
@@ -1,0 +1,1 @@
+std.manifestYamlDoc((import '../mixin.libsonnet').prometheusRules)

--- a/metrics/mixin/mixin-external.libsonnet
+++ b/metrics/mixin/mixin-external.libsonnet
@@ -1,0 +1,3 @@
+(import 'config.libsonnet') +
+(import 'alerts/alerts-external.libsonnet') +
+(import 'rules/rules.libsonnet')

--- a/metrics/mixin/mixin.libsonnet
+++ b/metrics/mixin/mixin.libsonnet
@@ -1,0 +1,3 @@
+(import 'config.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'rules/rules.libsonnet')

--- a/metrics/mixin/rules/rules.libsonnet
+++ b/metrics/mixin/rules/rules.libsonnet
@@ -1,0 +1,4 @@
+{
+  prometheusRules+:: {
+  },
+}


### PR DESCRIPTION
This PR adds a framework for generating OCS rules and alerts. 

This is a follow-up PR on #733, #737 and #739. This PR should clear up how OCS rules yamls are created and how they will be maintained in future.

Doc to install dependencies and use : metrics/mixin/README.md

Signed-off-by: Anmol Sachan <anmol13694@gmail.com>