### PR TITLE
Fixed cluster failure when Netwok is not specified.

### DIFF
--- a/pkg/apis/ocs/v1/storagecluster_types.go
+++ b/pkg/apis/ocs/v1/storagecluster_types.go
@@ -36,7 +36,7 @@ type StorageClusterSpec struct {
 	// Version specifies the version of StorageCluster
 	Version string `json:"version,omitempty"`
    // Network represents cluster network settings
-	Network  rook.NetworkSpec `json:"network,omitempty"`
+	Network  *rook.NetworkSpec `json:"network,omitempty"`
 }
 
 // ExternalStorageClusterSpec defines the spec of the external Storage Cluster

--- a/pkg/apis/ocs/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ocs/v1/zz_generated.deepcopy.go
@@ -397,7 +397,11 @@ func (in *StorageClusterSpec) DeepCopyInto(out *StorageClusterSpec) {
 		*out = new(MultiCloudGatewaySpec)
 		(*in).DeepCopyInto(*out)
 	}
-	in.Network.DeepCopyInto(&out.Network)
+	if in.Network != nil {
+		in, out := &in.Network, &out.Network
+		*out = new(rookiov1.NetworkSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -51,7 +51,7 @@ func (r *ReconcileStorageCluster) ensureCephCluster(sc *ocsv1.StorageCluster, re
 		}
 	}
 
-	if sc.Spec.Network.IsMultus() {
+	if isMultus(sc.Spec.Network) {
 		err := validateMultusSelectors(sc.Spec.Network.Selectors)
 		if err != nil {
 			return err
@@ -240,10 +240,17 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, r
 	} else {
 		reqLogger.Info(fmt.Sprintf("No monDataDirHostPath, monPVCTemplate or storageDeviceSets configured for storageCluster %s", sc.GetName()))
 	}
-	if sc.Spec.Network.IsMultus() {
-		cephCluster.Spec.Network.NetworkSpec = sc.Spec.Network
+	if isMultus(sc.Spec.Network) {
+		cephCluster.Spec.Network.NetworkSpec = *sc.Spec.Network
 	}
 	return cephCluster
+}
+
+func isMultus(nwSpec *rook.NetworkSpec) bool {
+	if nwSpec != nil {
+		return nwSpec.IsMultus()
+	}
+	return false
 }
 
 func validateMultusSelectors(selectors map[string]string) error {

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -595,33 +595,33 @@ func TestStorageClusterOnMultus(t *testing.T) {
 	}
 	platform := &CloudPlatform{platform: PlatformUnknown}
 	cases := []struct {
-		testCase string
-		publicNW string
+		testCase  string
+		publicNW  string
 		clusterNW string
-		cr *api.StorageCluster
+		cr        *api.StorageCluster
 	}{
 		{
 			// When only public network is specified.
-			testCase: "public",
-			publicNW: "public-network",
+			testCase:  "public",
+			publicNW:  "public-network",
 			clusterNW: "",
 		},
 		{
 			// When only cluster network is specified, this will be an error case .
-			testCase: "cluster",
-			publicNW: "",
+			testCase:  "cluster",
+			publicNW:  "",
 			clusterNW: "cluster-network",
 		},
 		{
 			// When both public and cluster network are specified.
-			testCase: "both",
-			publicNW: "public-network",
+			testCase:  "both",
+			publicNW:  "public-network",
 			clusterNW: "cluster-network",
 		},
 		{
 			// When public network and cluster network is empty, this will be an error case.
-			testCase: "none",
-			publicNW: "",
+			testCase:  "none",
+			publicNW:  "",
 			clusterNW: "",
 		},
 		{

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -613,7 +613,7 @@ func TestStorageClusterOnMultus(t *testing.T) {
 			clusterNW: "cluster-network",
 		},
 		{
-	   		// When both public and cluster network are specified.
+			// When both public and cluster network are specified.
 			testCase: "both",
 			publicNW: "public-network",
 			clusterNW: "cluster-network",
@@ -624,29 +624,36 @@ func TestStorageClusterOnMultus(t *testing.T) {
 			publicNW: "",
 			clusterNW: "",
 		},
+		{
+			// When Network is not specified
+			testCase: "default",
+		},
 	}
 
 	for _, c := range cases {
 		c.cr = createDefaultStorageCluster()
-		c.cr.Spec.Network = v1.NetworkSpec{
-			Provider: networkProvider,
-			Selectors: map[string]string{
-				"public": c.publicNW,
-				"cluster": c.clusterNW,
-			},
+		if c.testCase != "default" {
+			c.cr.Spec.Network = &v1.NetworkSpec{
+				Provider: networkProvider,
+				Selectors: map[string]string{
+					"public":  c.publicNW,
+					"cluster": c.clusterNW,
+				},
+			}
 		}
 		reconciler := createFakeInitializationStorageClusterReconcilerWithPlatform(t, platform)
 		_ = reconciler.client.Create(nil, c.cr)
 		result, err := reconciler.Reconcile(request)
-		validMultus := validateMultusSelectors(c.cr.Spec.Network.Selectors)
-		if validMultus != nil {
-			assert.Error(t, err)
-		} else {
-			assert.NoError(t, err)
-			assert.Equal(t, reconcile.Result{}, result)
-			assertCephClusterNetwork(t, reconciler, c.cr, request)
+		if c.testCase != "default" {
+			validMultus := validateMultusSelectors(c.cr.Spec.Network.Selectors)
+			if validMultus != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, reconcile.Result{}, result)
+				assertCephClusterNetwork(t, reconciler, c.cr, request)
+			}
 		}
-
 	}
 }
 
@@ -655,5 +662,10 @@ func assertCephClusterNetwork(t assert.TestingT, reconciler ReconcileStorageClus
 	cephCluster := newCephCluster(cr, "", 3, log)
 	err := reconciler.client.Get(nil, request.NamespacedName, cephCluster)
 	assert.NoError(t, err)
-	assert.Equal(t, cr.Spec.Network, cephCluster.Spec.Network.NetworkSpec)
+	if cr.Spec.Network == nil {
+		assert.Equal(t, "", cephCluster.Spec.Network.NetworkSpec.Provider)
+		assert.Nil(t, cephCluster.Spec.Network.NetworkSpec.Selectors)
+	} else {
+		assert.Equal(t, *cr.Spec.Network, cephCluster.Spec.Network.NetworkSpec)
+	}
 }


### PR DESCRIPTION
When Network was not specified in the storagecluster CR, the cluster
creation failed as it was checking for some value that was not defined.

Signed-off-by: rohan47 <rohgupta@redhat.com>