### PR TITLE
Reconcile external resources

### DIFF
--- a/deploy/crds/ocs.openshift.io_storageclusters_crd.yaml
+++ b/deploy/crds/ocs.openshift.io_storageclusters_crd.yaml
@@ -2446,10 +2446,10 @@ spec:
                     description: ConditionType is the state of the operator's reconciliation
                       functionality.
                     type: string
-            externalSecretFound:
-              description: ExternalSecretFound indicates whether a Secret containing
-                information about an external CephCluster was found or not
-              type: boolean
+            externalSecretHash:
+              description: ExternalSecretHash holds the checksum value of external
+                secret data.
+              type: string
             failureDomain:
               description: FailureDomain is the base CRUSH element Ceph will use to
                 distribute its data replicas for the default CephBlockPool

--- a/pkg/apis/ocs/v1/storagecluster_types.go
+++ b/pkg/apis/ocs/v1/storagecluster_types.go
@@ -35,8 +35,8 @@ type StorageClusterSpec struct {
 	MultiCloudGateway  *MultiCloudGatewaySpec                 `json:"multiCloudGateway,omitempty"`
 	// Version specifies the version of StorageCluster
 	Version string `json:"version,omitempty"`
-   // Network represents cluster network settings
-	Network  *rook.NetworkSpec `json:"network,omitempty"`
+	// Network represents cluster network settings
+	Network *rook.NetworkSpec `json:"network,omitempty"`
 }
 
 // ExternalStorageClusterSpec defines the spec of the external Storage Cluster

--- a/pkg/apis/ocs/v1/storagecluster_types.go
+++ b/pkg/apis/ocs/v1/storagecluster_types.go
@@ -129,9 +129,8 @@ type StorageClusterStatus struct {
 	// +optional
 	FailureDomain string `json:"failureDomain,omitempty"`
 
-	// ExternalSecretFound indicates whether a Secret containing information
-	// about an external CephCluster was found or not
-	ExternalSecretFound bool `json:"externalSecretFound,omitempty"`
+	// ExternalSecretHash holds the checksum value of external secret data.
+	ExternalSecretHash string `json:"externalSecretHash,omitempty"`
 
 	StorageClassesCreated       bool `json:"storageClassesCreated,omitempty"`
 	CephObjectStoresCreated     bool `json:"cephObjectStoresCreated,omitempty"`


### PR DESCRIPTION
Reconciling external cluster resources by adding a checksum on external secret data.

Whenever external secret data is changed a new checksum is generated, which is then compared with the previously generated checksum. Since they don't match, `ensure` function proceeds forward, thus updating the resources.