### PR TITLE
Upgrade build tools to Fedora 33 and Golang 1.15.2

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,7 +1,6 @@
-FROM fedora:30 as build-tools
+FROM fedora:33 as build-tools
 ENV GOPATH /go
 ENV GOBIN /go/bin
-ENV GOROOT /usr/local/go
 ENV GOCACHE /go/.cache
 ARG GO_PACKAGE_PATH=github.com/openshift/ocs-operator
 
@@ -14,12 +13,10 @@ RUN dnf -y install \
     tar \
     findutils \
     python3 \
+    go \
     && dnf clean all
 
-# dnf install golang pulls go1.12, so manually pulling go1.13.3
-RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
-RUN tar -xzf go1.13.3.linux-amd64.tar.gz && mv go /usr/local
-ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+ENV PATH=$GOPATH:$GOBIN:$PATH
 ENV GO111MODULE=on
 
 # get required golang tools and OC client


### PR DESCRIPTION
Upgrading build tools to latest Fedora release.
Golang 1.15.2 has important security fixes.