### PR TITLE
README.md fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ here.](https://github.com/operator-framework/operator-sdk#quick-start)
 Once the SDK is installed, the operator can be built via:
 
 ```console
-$ dep ensure --vendor-only
-
 $ make ocs-operator
 ```
 
@@ -137,6 +135,9 @@ kind: OperatorGroup
 metadata:
   name: openshift-storage-operatorgroup
   namespace: openshift-storage
+spec:
+  targetNamespaces:
+    - openshift-storage
 EOF
 ```
 


### PR DESCRIPTION
I followed the instructions on the README.md to deploy a custom ocs-operator and noted two parts that weren't consistent with the documentation. Specifying the target namespace for the catalogSource is important because the deployment will fail otherwise.  