### PR TITLE
Bug 1881071:Made monitoring optional during external cluster initilization

### DIFF
--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -272,6 +272,17 @@ func newExternalCephCluster(sc *ocsv1.StorageCluster, cephImage string, monitori
 	labels := map[string]string{
 		"app": sc.Name,
 	}
+
+	var monitoringSpec = cephv1.MonitoringSpec{Enabled: false}
+
+	if monitoringIP != "" {
+		monitoringSpec = cephv1.MonitoringSpec{
+			Enabled:              true,
+			RulesNamespace:       sc.Namespace,
+			ExternalMgrEndpoints: []corev1.EndpointAddress{{IP: monitoringIP}},
+		}
+	}
+
 	externalCephCluster := &cephv1.CephCluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateNameForCephCluster(sc),
@@ -289,11 +300,7 @@ func newExternalCephCluster(sc *ocsv1.StorageCluster, cephImage string, monitori
 				ManagePodBudgets:               false,
 				ManageMachineDisruptionBudgets: false,
 			},
-			Monitoring: cephv1.MonitoringSpec{
-				Enabled:              true,
-				RulesNamespace:       sc.Namespace,
-				ExternalMgrEndpoints: []corev1.EndpointAddress{{IP: monitoringIP}},
-			},
+			Monitoring: monitoringSpec,
 		},
 	}
 


### PR DESCRIPTION
This PR is required to enable upgrades in external mode from 4.5 to 4.6 without any failure due to the requirement of monitoring info.

Signed-off-by: Anmol Sachan <anmol13694@gmail.com>