### PR TITLE
[RHSTOR-1428] Introduce new controller for updating PersistentVolumes

### DIFF
--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -114,6 +114,16 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
           - apps
           resources:
           - deployments

--- a/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1341,6 +1341,16 @@ spec:
           verbs:
           - get
         - apiGroups:
+          - ""
+          resources:
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - patch
+        - apiGroups:
           - apps
           resources:
           - deployments

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -35,6 +35,16 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/pkg/controller/add_persistentvolume.go
+++ b/pkg/controller/add_persistentvolume.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/openshift/ocs-operator/pkg/controller/persistentvolume"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, persistentvolume.Add)
+}

--- a/pkg/controller/persistentvolume/persistentvolume_controller.go
+++ b/pkg/controller/persistentvolume/persistentvolume_controller.go
@@ -1,0 +1,123 @@
+package persistentvolume
+
+import (
+	"strings"
+
+	"github.com/openshift/ocs-operator/pkg/controller/util"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	csiExpansionSecretName      = "csi.storage.k8s.io/controller-expand-secret-name"
+	csiExpansionSecretNamespace = "csi.storage.k8s.io/controller-expand-secret-namespace"
+	csiRBDDriverSuffix          = ".rbd.csi.ceph.com"
+	csiCephFSDriverSuffix       = ".cephfs.csi.ceph.com"
+)
+
+var log = logf.Log.WithName("controller_persistentvolume")
+
+// Add creates a new PersistentVolume Controller and adds it to the Manager.
+// The Manager will set fields on the Controller and Start it when the Manager
+// is Started.
+func Add(mgr manager.Manager) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	r := &ReconcilePersistentVolume{
+		client:    mgr.GetClient(),
+		scheme:    mgr.GetScheme(),
+		reqLogger: log,
+	}
+
+	return r
+}
+
+// reconcilePV determines whether we want to reconcile a given PV
+func reconcilePV(obj runtime.Object) bool {
+	pv, ok := obj.(*corev1.PersistentVolume)
+	if !ok {
+		return false
+	}
+
+	drivers := []string{
+		csiRBDDriverSuffix,
+		csiCephFSDriverSuffix,
+	}
+
+	for _, driver := range drivers {
+		if pv.Spec.CSI != nil && strings.HasSuffix(pv.Spec.CSI.Driver, driver) {
+			if pv.Spec.StorageClassName != "" {
+				secretRef := pv.Spec.CSI.ControllerExpandSecretRef
+				if secretRef == nil || secretRef.Name == "" {
+					return true
+				}
+			}
+			return false
+		}
+	}
+
+	return false
+}
+
+var pvPredicate = predicate.Funcs{
+	CreateFunc: func(e event.CreateEvent) bool {
+		return reconcilePV(e.Object)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		return false
+	},
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		return reconcilePV(e.ObjectNew)
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
+		return reconcilePV(e.Object)
+	},
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("persistentvolume-controller", mgr, controller.Options{MaxConcurrentReconciles: 1, Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Compose a predicate that is an OR of the specified predicates
+	predicate := util.ComposePredicates(
+		predicate.ResourceVersionChangedPredicate{},
+		util.MetadataChangedPredicate{},
+	)
+
+	// Watch for changes to PersistentVolumes
+	err = c.Watch(&source.Kind{Type: &corev1.PersistentVolume{}}, &handler.EnqueueRequestForObject{}, predicate, pvPredicate)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ReconcilePersistentVolume reconciles a PersistentVolume object
+type ReconcilePersistentVolume struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client    client.Client
+	scheme    *runtime.Scheme
+	reqLogger logr.Logger
+}
+
+var _ reconcile.Reconciler = &ReconcilePersistentVolume{}

--- a/pkg/controller/persistentvolume/persistentvolume_controller_test.go
+++ b/pkg/controller/persistentvolume/persistentvolume_controller_test.go
@@ -1,0 +1,92 @@
+package persistentvolume
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestReconcilePV(t *testing.T) {
+	cases := []struct {
+		label               string
+		csi                 *corev1.CSIPersistentVolumeSource
+		invalidStorageClass bool
+		reconcile           bool
+	}{
+		{
+			label:     "nil CSI",
+			csi:       nil,
+			reconcile: false,
+		},
+		{
+			label: "invalid driver",
+			csi: &corev1.CSIPersistentVolumeSource{
+				Driver: "",
+			},
+			reconcile: false,
+		},
+		{
+			label: "RBD driver, invalid StorageClass",
+			csi: &corev1.CSIPersistentVolumeSource{
+				Driver: csiRBDDriverSuffix,
+			},
+			invalidStorageClass: true,
+			reconcile:           false,
+		},
+		{
+			label: "RBD driver, valid StorageClass, invalid SecretRef",
+			csi: &corev1.CSIPersistentVolumeSource{
+				ControllerExpandSecretRef: &corev1.SecretReference{
+					Name: "foo",
+				},
+				Driver: csiRBDDriverSuffix,
+			},
+			reconcile: false,
+		},
+		{
+			label: "valid RBD driver, nil SecretRef",
+			csi: &corev1.CSIPersistentVolumeSource{
+				Driver: csiRBDDriverSuffix,
+			},
+			reconcile: true,
+		},
+		{
+			label: "valid RBD driver, empty SecretRef",
+			csi: &corev1.CSIPersistentVolumeSource{
+				Driver: csiRBDDriverSuffix,
+				ControllerExpandSecretRef: &corev1.SecretReference{
+					Name: "",
+				},
+			},
+			reconcile: true,
+		},
+		{
+			label: "valid CephFS driver",
+			csi: &corev1.CSIPersistentVolumeSource{
+				Driver: csiCephFSDriverSuffix,
+			},
+			reconcile: true,
+		},
+	}
+
+	for i, c := range cases {
+		t.Logf("Case %d: %s\n", i+1, c.label)
+
+		storageClassName := ""
+		if !c.invalidStorageClass {
+			storageClassName = "foo"
+		}
+
+		pv := &corev1.PersistentVolume{
+			Spec: corev1.PersistentVolumeSpec{
+				PersistentVolumeSource: corev1.PersistentVolumeSource{
+					CSI: c.csi,
+				},
+				StorageClassName: storageClassName,
+			},
+		}
+
+		assert.Equal(t, c.reconcile, reconcilePV(pv))
+	}
+}

--- a/pkg/controller/persistentvolume/reconcile.go
+++ b/pkg/controller/persistentvolume/reconcile.go
@@ -1,0 +1,90 @@
+package persistentvolume
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// ensureFunc which encapsulate all the 'ensure*' type functions
+type ensureFunc func(*corev1.PersistentVolume, logr.Logger) error
+
+// Reconcile ...
+func (r *ReconcilePersistentVolume) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := r.reqLogger.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+
+	pv := &corev1.PersistentVolume{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, pv)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			reqLogger.Info("PersistentVolume not found")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, err
+	}
+
+	// Check GetDeletionTimestamp to determine if the object is under deletion
+	if !pv.GetDeletionTimestamp().IsZero() {
+		reqLogger.Info("Object is terminated, skipping reconciliation")
+		return reconcile.Result{}, nil
+	}
+
+	reqLogger.Info("Reconciling PersistentVolume")
+
+	ensureFs := []ensureFunc{
+		r.ensureExpansionSecret,
+	}
+	for _, f := range ensureFs {
+		err = f(pv, reqLogger)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcilePersistentVolume) ensureExpansionSecret(pv *corev1.PersistentVolume, reqLogger logr.Logger) error {
+	scName := pv.Spec.StorageClassName
+	if scName == "" {
+		reqLogger.Info("PersistentVolume has no associated StorageClass")
+		return nil
+	}
+	sc := &storagev1.StorageClass{}
+
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: scName}, sc)
+	if err != nil {
+		reqLogger.Error(err, "Error getting StorageClass")
+		return err
+	}
+
+	patch := client.MergeFrom(pv)
+
+	secretRef := &corev1.SecretReference{}
+
+	if secretName, ok := sc.Parameters[csiExpansionSecretName]; ok {
+		secretRef.Name = secretName
+	}
+	if secretNamespace, ok := sc.Parameters[csiExpansionSecretNamespace]; ok {
+		secretRef.Namespace = secretNamespace
+	}
+
+	newPV := &corev1.PersistentVolume{}
+	pv.DeepCopyInto(newPV)
+
+	newPV.Spec.CSI.ControllerExpandSecretRef = secretRef
+	err = r.client.Patch(context.TODO(), newPV, patch)
+	if err != nil {
+		reqLogger.Error(err, "Error patching PersistentVolume")
+		return err
+	}
+
+	reqLogger.Info("PersistentVolume patched")
+	return nil
+}

--- a/pkg/controller/persistentvolume/reconcile_test.go
+++ b/pkg/controller/persistentvolume/reconcile_test.go
@@ -1,0 +1,119 @@
+package persistentvolume
+
+import (
+	"testing"
+
+	api "github.com/openshift/ocs-operator/pkg/apis/ocs/v1"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var mockStorageClass = &storagev1.StorageClass{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "test-sc",
+	},
+	Parameters: map[string]string{},
+}
+
+var mockPersistentVolume = &corev1.PersistentVolume{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "test-pv",
+	},
+	Spec: corev1.PersistentVolumeSpec{
+		PersistentVolumeSource: corev1.PersistentVolumeSource{
+			CSI: &corev1.CSIPersistentVolumeSource{
+				ControllerExpandSecretRef: &corev1.SecretReference{},
+			},
+		},
+	},
+}
+
+func TestEnsureExpansionSecret(t *testing.T) {
+	cases := []struct {
+		label            string
+		storageClassName string
+		secretName       string
+		secretNamespace  string
+	}{
+		{
+			label: "no StorageClass",
+		},
+		{
+			label:            "valid StorageClass, no secret",
+			storageClassName: "test-sc",
+		},
+		{
+			label:            "valid StorageClass, valid secret",
+			storageClassName: "test-sc",
+			secretName:       "expand-secret",
+			secretNamespace:  "test-namespace",
+		},
+	}
+
+	for i, c := range cases {
+		t.Logf("Case %d: %s\n", i+1, c.label)
+
+		testPV := &corev1.PersistentVolume{}
+		mockPersistentVolume.DeepCopyInto(testPV)
+		testPV.Spec.StorageClassName = c.storageClassName
+
+		testSC := &storagev1.StorageClass{}
+		mockStorageClass.DeepCopyInto(testSC)
+		testSC.Parameters[csiExpansionSecretName] = c.secretName
+		testSC.Parameters[csiExpansionSecretNamespace] = c.secretName
+
+		request := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      testPV.GetName(),
+				Namespace: "",
+			},
+		}
+		reconciler := createFakePersistentVolumeReconciler(t, testPV, testSC)
+		result, err := reconciler.Reconcile(request)
+		assert.NoError(t, err)
+		assert.Equal(t, reconcile.Result{}, result)
+
+		actual := &corev1.PersistentVolume{}
+		err = reconciler.client.Get(nil, request.NamespacedName, actual)
+		assert.NoError(t, err)
+
+		actualSecretRef := actual.Spec.PersistentVolumeSource.CSI.ControllerExpandSecretRef
+		assert.Equal(t, testSC.Parameters[csiExpansionSecretName], actualSecretRef.Name)
+		assert.Equal(t, testSC.Parameters[csiExpansionSecretNamespace], actualSecretRef.Namespace)
+	}
+}
+
+func createFakeScheme(t *testing.T) *runtime.Scheme {
+	scheme, err := api.SchemeBuilder.Build()
+	if err != nil {
+		assert.Fail(t, "unable to build scheme")
+	}
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		assert.Fail(t, "failed to add corev1 scheme")
+	}
+	err = storagev1.AddToScheme(scheme)
+	if err != nil {
+		assert.Fail(t, "failed to add storagev1 scheme")
+	}
+	return scheme
+}
+
+func createFakePersistentVolumeReconciler(t *testing.T, obj ...runtime.Object) ReconcilePersistentVolume {
+	scheme := createFakeScheme(t)
+	client := fake.NewFakeClientWithScheme(scheme, obj...)
+
+	return ReconcilePersistentVolume{
+		client:    client,
+		scheme:    scheme,
+		reqLogger: logf.Log.WithName("controller_persistentvolume_test"),
+	}
+}

--- a/pkg/controller/storagecluster/storagecluster_controller.go
+++ b/pkg/controller/storagecluster/storagecluster_controller.go
@@ -135,7 +135,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
-	pred := predicate.Funcs{
+	pvcPredicate := predicate.Funcs{
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			// Evaluates to false if the object has been confirmed deleted.
 			return !e.DeleteStateUnknown
@@ -144,7 +144,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	err = c.Watch(&source.Kind{Type: &corev1.PersistentVolumeClaim{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &ocsv1.StorageCluster{},
-	}, pred)
+	}, pvcPredicate)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/storagecluster/storagecluster_controller.go
+++ b/pkg/controller/storagecluster/storagecluster_controller.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/openshift/ocs-operator/pkg/controller/util"
+
 	"github.com/go-logr/logr"
 	nbv1 "github.com/noobaa/noobaa-operator/v2/pkg/apis/noobaa/v1alpha1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
@@ -104,8 +106,14 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Compose a predicate that is an OR of the specified predicates
+	scPredicate := util.ComposePredicates(
+		predicate.GenerationChangedPredicate{},
+		util.MetadataChangedPredicate{},
+	)
+
 	// Watch for changes to primary resource StorageCluster
-	err = c.Watch(&source.Kind{Type: &ocsv1.StorageCluster{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &ocsv1.StorageCluster{}}, &handler.EnqueueRequestForObject{}, scPredicate)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/util/predicates.go
+++ b/pkg/controller/util/predicates.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"reflect"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ComposePredicates will compose a variable number of predicte and return a predicate that
+// will allow events that are allowed by any of the given predicates.
+func ComposePredicates(predicates ...predicate.Predicate) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Create(e) {
+					return true
+				}
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Delete(e) {
+					return true
+				}
+			}
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Update(e) {
+					return true
+				}
+			}
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			for _, p := range predicates {
+				if p != nil && p.Generic(e) {
+					return true
+				}
+			}
+			return false
+		},
+	}
+}
+
+// MetadataChangedPredicate will only allow events that changed labels,
+// annotations, or finalizers
+type MetadataChangedPredicate struct {
+	predicate.Funcs
+}
+
+// Update implements the update event trap for StorageClusterChangedPredicate
+func (p MetadataChangedPredicate) Update(e event.UpdateEvent) bool {
+	metaChanged := !reflect.DeepEqual(e.MetaOld.GetLabels(), e.MetaNew.GetLabels()) ||
+		!reflect.DeepEqual(e.MetaOld.GetAnnotations(), e.MetaNew.GetAnnotations()) ||
+		!reflect.DeepEqual(e.MetaOld.GetFinalizers(), e.MetaNew.GetFinalizers())
+
+	return e.MetaOld != nil &&
+		e.MetaNew != nil &&
+		metaChanged
+}

--- a/pkg/controller/util/predicates_test.go
+++ b/pkg/controller/util/predicates_test.go
@@ -1,0 +1,151 @@
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var one = int64(1)
+var now = metav1.NewTime(time.Now())
+
+func TestComposePredicatesUpdate(t *testing.T) {
+	cases := []struct {
+		label   string
+		metaNew *metav1.ObjectMeta
+		update  bool
+	}{
+		{
+			label:   "no update",
+			metaNew: &metav1.ObjectMeta{},
+			update:  false,
+		},
+		{
+			label: "labels update",
+			metaNew: &metav1.ObjectMeta{
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			update: true,
+		},
+		{
+			label: "resourceversion update",
+			metaNew: &metav1.ObjectMeta{
+				ResourceVersion: "foo",
+			},
+			update: true,
+		},
+		{
+			label: "any other field",
+			metaNew: &metav1.ObjectMeta{
+				Name:                       "foo",
+				GenerateName:               "foo",
+				Namespace:                  "foo",
+				SelfLink:                   "foo",
+				UID:                        types.UID("foo"),
+				Generation:                 one,
+				CreationTimestamp:          now,
+				DeletionTimestamp:          &now,
+				DeletionGracePeriodSeconds: &one,
+				OwnerReferences:            []metav1.OwnerReference{{}},
+				ClusterName:                "foo",
+				ManagedFields:              []metav1.ManagedFieldsEntry{{}},
+			},
+			update: false,
+		},
+	}
+
+	for i, c := range cases {
+		t.Logf("Case %d: %s\n", i+1, c.label)
+		pred := ComposePredicates(
+			predicate.ResourceVersionChangedPredicate{},
+			MetadataChangedPredicate{},
+		)
+		event := event.UpdateEvent{
+			MetaOld:   &metav1.ObjectMeta{},
+			MetaNew:   c.metaNew,
+			ObjectOld: &corev1.PersistentVolume{},
+			ObjectNew: &corev1.PersistentVolume{},
+		}
+
+		assert.Equal(t, c.update, pred.Update(event))
+	}
+}
+
+func TestMetadataChangedPredicateUpdate(t *testing.T) {
+	cases := []struct {
+		label   string
+		metaNew *metav1.ObjectMeta
+		update  bool
+	}{
+		{
+			label:   "no update",
+			metaNew: &metav1.ObjectMeta{},
+			update:  false,
+		},
+		{
+			label: "labels update",
+			metaNew: &metav1.ObjectMeta{
+				Labels: map[string]string{
+					"foo": "bar",
+				},
+			},
+			update: true,
+		},
+		{
+			label: "annotations update",
+			metaNew: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					"foo": "bar",
+				},
+			},
+			update: true,
+		},
+		{
+			label: "finalizers update",
+			metaNew: &metav1.ObjectMeta{
+				Finalizers: []string{
+					"foo",
+				},
+			},
+			update: true,
+		},
+		{
+			label: "any other field",
+			metaNew: &metav1.ObjectMeta{
+				Name:                       "foo",
+				GenerateName:               "foo",
+				Namespace:                  "foo",
+				SelfLink:                   "foo",
+				UID:                        types.UID("foo"),
+				ResourceVersion:            "foo",
+				Generation:                 one,
+				CreationTimestamp:          now,
+				DeletionTimestamp:          &now,
+				DeletionGracePeriodSeconds: &one,
+				OwnerReferences:            []metav1.OwnerReference{{}},
+				ClusterName:                "foo",
+				ManagedFields:              []metav1.ManagedFieldsEntry{{}},
+			},
+			update: false,
+		},
+	}
+
+	for i, c := range cases {
+		t.Logf("Case %d: %s\n", i+1, c.label)
+		pred := MetadataChangedPredicate{}
+		event := event.UpdateEvent{
+			MetaOld: &metav1.ObjectMeta{},
+			MetaNew: c.metaNew,
+		}
+
+		assert.Equal(t, c.update, pred.Update(event))
+	}
+}


### PR DESCRIPTION
This PR introduces a new controller for managing the volume attributes of Ceph-CSI PersistentVolumes. As part of the implementation, is also introduces the use of Predicate from the Kubernetes controller-runtime. This allows the controller to filter resource events, only queuing those which match all predicate conditions.

Alongside this, this PR implements the use of Predicates with the StorageCluster controller as well, both as an enhancement and a means to verify the use of Predicates in the CI.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>