### PR TITLE
storagecluster: Fix order of func calls in deleteResources

### DIFF
--- a/pkg/controller/storagecluster/uninstall_reconciler.go
+++ b/pkg/controller/storagecluster/uninstall_reconciler.go
@@ -377,17 +377,17 @@ func (r *ReconcileStorageCluster) deleteResources(sc *ocsv1.StorageCluster, reqL
 		return err
 	}
 
+	err = r.deleteNodeTaint(sc, reqLogger)
+	if err != nil {
+		return err
+	}
+
 	// TODO: skip the deletion of these labels till we figure out a way to wait
 	// for the cleanup jobs
 	//err = r.deleteNodeAffinityKeyFromNodes(sc, reqLogger)
 	//if err != nil {
 	//	return err
 	//}
-
-	err = r.deleteNodeTaint(sc, reqLogger)
-	if err != nil {
-		return err
-	}
 
 	return nil
 }


### PR DESCRIPTION
deleteNodeTaint was getting called after deleteNodeAffinityKeyFromNodes
because of which deleteNodeTaint wont be able to find eligible nodes to
delete taint. Fix the same via changing the order of both calls

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>
cc: @raghavendra-talur 