### PR TITLE
 must-gather: add noobaa cli to must-gather

### DIFF
--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -22,6 +22,7 @@ noobaa_resources+=(bucketclass)
 
 noobaa_cli=()
 noobaa_cli+=("obc list")
+noobaa_cli+=("status")
 
 /templates/noobaa.template
 
@@ -33,6 +34,8 @@ for cli in "${noobaa_cli[@]}"; do
     COMMAND_OUTPUT_FILE="${NOOBAA_COLLLECTION_PATH}"/raw_output/${cli// /_}
     { timeout 180 noobaa "${cli}" --namespace openshift-storage >> "${COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
+
+noobaa diagnose --dir "${NOOBAA_COLLLECTION_PATH}"/raw_output/ --namespace openshift-storage ;  >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 
 # Run the Collection of NooBaa Resources using must-gather
 for resource in "${noobaa_resources[@]}"; do

--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -21,13 +21,17 @@ noobaa_resources+=(backingstore)
 noobaa_resources+=(bucketclass)
 
 noobaa_cli=()
-noobaa_cli+=(noobaa obc list)
+noobaa_cli+=("obc list")
+
+/templates/noobaa.template
+
+mkdir -p ${NOOBAA_COLLLECTION_PATH}/raw_output/}
 
 # Run the Collection of Noobaa cli using must-gather
 for cli in "${noobaa_cli[@]}"; do
     echo "collecting dump of ${cli}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
     COMMAND_OUTPUT_FILE="${NOOBAA_COLLLECTION_PATH}"/raw_output/${cli// /_}
-    { timeout 180 "${cli}" >> "${COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    { timeout 180 noobaa "${cli}" --namespace openshift-storage >> "${COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
 
 # Run the Collection of NooBaa Resources using must-gather

--- a/must-gather/templates/noobaa.template
+++ b/must-gather/templates/noobaa.template
@@ -1,0 +1,7 @@
+pod=$(oc get pods -n openshift-storage| grep noobaa-operator|  awk '{print $1}')
+if [ -z  $pod ]; then
+   echo "noobaa operator pod does not exist"
+else
+   oc rsync -n  openshift-storage $pod:/usr/local/bin/noobaa-operator /usr/bin
+   mv /usr/bin/noobaa-operator /usr/bin/noobaa
+fi


### PR DESCRIPTION
Add noobaa cli to must-gather. gathering binary from noobaa operator pod. Running the noobaa commands by executing binary.