### PR TITLE
must-gather: make Dockerfile compatible with docker and buildah

### DIFF
--- a/must-gather/Dockerfile
+++ b/must-gather/Dockerfile
@@ -1,9 +1,9 @@
 FROM quay.io/openshift/origin-cli:latest
 
 # copy all collection scripts to /usr/bin
-COPY collection-scripts/* /usr/bin/
+COPY collection-scripts /usr/bin/
 
-RUN mkdir /templates
+RUN mkdir -p  /templates
 COPY templates /templates
 
 ENTRYPOINT /usr/bin/gather


### PR DESCRIPTION
Problem: Docker has a longstanding bug using globs in COPY directives
(i.e. COPY foo/dir/* /tmp/dir/ ).If the source files matched by the glob
include subdirectories, these subdirectories are not present in the destination.
Buildah - which is used to run builds in OCP 4.x - appears to utilise similar
 logic when processing globs.
Solution: use of absolute path and use of simple dir structure.

Signed-off-by: crombus <pkundra@redhat.com>