### PR TITLE
Set storagecluster.status.failuredomain

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -205,6 +205,14 @@ func (r *ReconcileStorageCluster) Reconcile(request reconcile.Request) (reconcil
 			reqLogger.Error(err, "Failed to set node topology map")
 			return reconcile.Result{}, err
 		}
+
+		if instance.Status.FailureDomain == "" {
+			instance.Status.FailureDomain = determineFailureDomain(instance)
+			if err := r.client.Update(context.TODO(), instance); err != nil {
+				reqLogger.Info("Status Update Error", "StatusUpdateErr", "Failed to set failure domain")
+				return reconcile.Result{}, err
+			}
+		}
 	}
 
 	// in-memory conditions should start off empty. It will only ever hold


### PR DESCRIPTION
The storageCluster.status.failuredomain was empty causing
the cephblockpool.spec.failuredomain to be empty as well.

Signed-off-by: N Balachandran <nibalach@redhat.com>