### PR TITLE
must-gather: skip ceph collection in external mode OCS

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -9,8 +9,14 @@ SINCE_TIME=$1
 gather_namespaced_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
 gather_clusterscoped_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
 gather_noobaa_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
-gather_ceph_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
 
+
+
+if [ "$(oc get storagecluster -n openshift-storage -o go-template='{{range .items}}{{.spec.externalStorage.enable}}{{"\n"}}{{end}}')" == true ]; then
+    echo "Skipping the ceph collection as External Storage is enabled"
+else    
+    gather_ceph_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
+fi
 echo "deleting empty files" >> ${BASE_COLLECTION_PATH}/gather-debug.log
 find "${BASE_COLLECTION_PATH}" -empty -delete >> ${BASE_COLLECTION_PATH}/gather-debug.log 2>&1
 exit 0


### PR DESCRIPTION
Skipping ceph collection when ocs is installed in external mode.

Signed-off-by: crombus <pkundra@redhat.com>