### PR TITLE
must-gather: add more info for ceph crash

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -192,4 +192,19 @@ for ns in $namespaces; do
         { timeout 120 oc debug nodes/"${node}" -- bash -c "test -f /host/var/lib/rook/log/${ns}/ceph-volume.log && cat /host/var/lib/rook/log/${ns}/ceph-volume.log" > "${NODE_OUTPUT_DIR}"/ceph-volume.log; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     done
     oc delete -f pod_helper.yaml
+
+    for i in $(timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph crash ls --connect-timeout=15"| awk '{print $1}'); do
+        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "ceph crash info $i --connect-timeout=15" >> "${COMMAND_OUTPUT_DIR}"/crash_"${i}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1;
+    done
+
+    # Collecting ceph crash dump
+    for node in $(oc get nodes -l cluster.ocs.openshift.io/openshift-storage='' --no-headers | awk '/Ready/{print $1}'); do
+        printf "collecting crash logs  from node %s \n"  "${node}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+        CRASH_OUTPUT_DIR=${CEPH_COLLECTION_PATH}/crash_${node}
+        mkdir -p "${CRASH_OUTPUT_DIR}"
+        oc debug nodes/"${node}" --to-namespace="${ns}" -- bash -c "sleep 5m" &
+        sleep 60
+        oc rsync -n "${ns}" "$(oc get pods -n "${ns}"| awk '/debug/{print $1}')":/host/var/lib/rook/openshift-storage/crash/ "${CRASH_OUTPUT_DIR}"
+        wait
+    done
 done


### PR DESCRIPTION
add command to check for ceph crash info
for every crash and collect core dump of
rook crash.

Signed-off-by: crombus <pkundra@redhat.com>