### PR TITLE
Enabling 'snapshotter' feature in external cluster mode

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -246,6 +246,7 @@ func (r *ReconcileStorageCluster) Reconcile(request reconcile.Request) (reconcil
 		ensureFs = []ensureFunc{
 			r.ensureExternalStorageClusterResources,
 			r.ensureCephCluster,
+			r.ensureSnapshotClasses,
 			r.ensureNoobaaSystem,
 		}
 	}


### PR DESCRIPTION
A very minor change to enable `Snapshotter` feature in external cluster mode.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>