### PR TITLE
Use the defaults.DeviceSetReplica value everywhere

### DIFF
--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -387,7 +387,7 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 			// enable the new behavior while the console is waiting
 			// to be updated.
 			// TODO: Remove this behavior when OCP console is updated
-			count = count / 3
+			count = count / defaults.DeviceSetReplica
 		}
 
 		for i := 0; i < replica; i++ {


### PR DESCRIPTION
instead of a hardcoded value

Signed-off-by: N Balachandran <nibalach@redhat.com>