### PR TITLE
noobaa must-gather - Add important notifications collection

### DIFF
--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -56,3 +56,13 @@ do
         { timeout 120 oc -n "${ns}" logs --all-containers "${pod}" &> "${LOG_DIR}"/"${pod}".log; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
     done
 done
+
+# Add important notfications to a notifications.txt file at the root of the noobaa collection path
+UNMANAGED_NOOBAA_NOTIF="The noobaa deployed on this cluster is not managed by the storagecluster CR and will not react to configuration changes made to storagecluster CR"
+
+NOOBAA_RECONCILE_STRATEGY=$( oc -n ${ns} get storagecluster -o jsonpath='{.items[0].spec.multiCloudGateway.reconcileStrategy}' 2> /dev/null)
+if [ "${NOOBAA_RECONCILE_STRATEGY}" = "ignore" ] || [ "${NOOBAA_RECONCILE_STRATEGY}" = "standalone" ]; then 
+    if [ "$(oc -n ${ns} get noobaa -o name 2> /dev/null) " ]; then 
+        echo "- ${UNMANAGED_NOOBAA_NOTIF}" >> ${NOOBAA_COLLLECTION_PATH}/notifications.txt
+    fi
+fi


### PR DESCRIPTION
- Add creation of a `notificaiton.txt` file to the noobaa must-gather flow
- Add a notification for the situation where noobaa is deployed in the cluster but it is not managed by the storagecluster CR