### PR TITLE
[release-4.6] Bug 1886308: Enabling 'snapshotter' feature in external cluster mode

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -244,6 +244,7 @@ func (r *ReconcileStorageCluster) Reconcile(request reconcile.Request) (reconcil
 		ensureFs = []ensureFunc{
 			r.ensureExternalStorageClusterResources,
 			r.ensureCephCluster,
+			r.ensureSnapshotClasses,
 			r.ensureNoobaaSystem,
 		}
 	}


### PR DESCRIPTION
(cherry picked from commit 37fec692f039dad865a6e57f6decbc6fa85c37a6)
Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>