### PR TITLE
Added NodeAffinity for rgw pods.

### DIFF
--- a/pkg/controller/defaults/placements.go
+++ b/pkg/controller/defaults/placements.go
@@ -82,6 +82,22 @@ var (
 					getWeightedPodAffinityTerm(100, "rook-ceph-rgw"),
 				},
 			},
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: getOcsNodeSelector(),
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
+					corev1.PreferredSchedulingTerm{
+						Weight: 100,
+						Preference: corev1.NodeSelectorTerm{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								corev1.NodeSelectorRequirement{
+									Key:      NodeAffinityKey,
+									Operator: corev1.NodeSelectorOpExists,
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 
 		"mds": rook.Placement{


### PR DESCRIPTION
Fixes the issue where RGW pods were running on non-OCS nodes.

BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1883828

Signed-off-by: RAJAT SINGH <rajasing@redhat.com>