### PR TITLE
StorageCluster: Check MCG.Reconcile before deleting Noobaa resources

### DIFF
--- a/pkg/controller/storagecluster/noobaa_system_reconciler.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler.go
@@ -150,6 +150,13 @@ func (r *ReconcileStorageCluster) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *ocs
 
 // Delete noobaa system in the namespace
 func (r *ReconcileStorageCluster) deleteNoobaaSystems(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
+	// Delete only if this is being managed by the OCS operator
+	if sc.Spec.MultiCloudGateway != nil {
+		reconcileStrategy := ReconcileStrategy(sc.Spec.MultiCloudGateway.ReconcileStrategy)
+		if reconcileStrategy == ReconcileStrategyIgnore || reconcileStrategy == ReconcileStrategyStandalone {
+			return nil
+		}
+	}
 	noobaa := &nbv1.NooBaa{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: "noobaa", Namespace: sc.Namespace}, noobaa)
 	if err != nil {

--- a/pkg/controller/storagecluster/uninstall_reconciler.go
+++ b/pkg/controller/storagecluster/uninstall_reconciler.go
@@ -249,7 +249,13 @@ func (r *ReconcileStorageCluster) setRookUninstallandCleanupPolicy(instance *ocs
 
 // setNoobaaUninstallMode sets the uninstall mode for Noobaa based on the annotation on the StorageCluster
 func (r *ReconcileStorageCluster) setNoobaaUninstallMode(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
-
+	// Do this if Noobaa is being managed by the OCS operator
+	if sc.Spec.MultiCloudGateway != nil {
+		reconcileStrategy := ReconcileStrategy(sc.Spec.MultiCloudGateway.ReconcileStrategy)
+		if reconcileStrategy == ReconcileStrategyIgnore || reconcileStrategy == ReconcileStrategyStandalone {
+			return nil
+		}
+	}
 	noobaa := &nbv1.NooBaa{}
 	var updateRequired bool
 


### PR DESCRIPTION
Delete Noobaa resources only if they are being managed by
the OCS operator.

Signed-off-by: N Balachandran <nibalach@redhat.com>