### PR TITLE
Remove rgw-endpoint label hack

### DIFF
--- a/pkg/controller/storagecluster/external_resources.go
+++ b/pkg/controller/storagecluster/external_resources.go
@@ -34,12 +34,6 @@ const (
 	rookEnableCephFSCSIKey     = "ROOK_CSI_ENABLE_CEPHFS"
 )
 
-var (
-	// externalRgwEndpoint is the rgw endpoint as discovered in the Secret externalClusterDetailsSecret
-	// It is used for independent mode only. It will be passed to the Noobaa CR as a label
-	externalRgwEndpoint string
-)
-
 // ExternalResource containes a list of External Cluster Resources
 type ExternalResource struct {
 	Kind string            `json:"kind"`
@@ -313,9 +307,6 @@ func (r *ReconcileStorageCluster) createExternalStorageClusterResources(instance
 				// created an issue in rook to add `CephObjectStore` type directly in the JSON output
 				// https://github.com/rook/rook/issues/6165
 				delete(d.Data, externalCephRgwEndpointKey)
-				// Set the external rgw endpoint variable for later use on the Noobaa CR (as a label)
-				// Replace the colon with an underscore, otherwise the label will be invalid
-				externalRgwEndpoint = strings.Replace(rgwEndpoint, ":", "_", -1)
 
 				// 'sc' points to OBC StorageClass
 				sc = scs[2]

--- a/pkg/controller/storagecluster/noobaa_system_reconciler.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler.go
@@ -20,11 +20,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	// externalRgwEndpointLabelName is the name of the label that will be used by Noobaa to configure the S3 endpoint
-	externalRgwEndpointLabelName = "rgw-endpoint"
-)
-
 func (r *ReconcileStorageCluster) ensureNoobaaSystem(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
 	// Everything other than ReconcileStrategyIgnore means we reconcile
 	if sc.Spec.MultiCloudGateway != nil {
@@ -100,11 +95,6 @@ func (r *ReconcileStorageCluster) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *ocs
 
 	nb.Labels = map[string]string{
 		"app": "noobaa",
-	}
-	// If independent mode, we pass the endpoint value as a label to Noobaa
-	// so it can connect to the RGW S3 endpoint
-	if sc.Spec.ExternalStorage.Enable {
-		nb.Labels[externalRgwEndpointLabelName] = externalRgwEndpoint
 	}
 	nb.Spec.DBStorageClass = &storageClassName
 	nb.Spec.PVPoolDefaultStorageClass = &storageClassName

--- a/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/pkg/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -359,9 +359,6 @@ func assertNoobaaResource(t *testing.T, reconciler ReconcileStorageCluster) {
 	// expectation is to get an appropriate Noobaa object
 	err = reconciler.client.Get(nil, request.NamespacedName, fNoobaa)
 	assert.NoError(t, err)
-	assert.NotEmpty(t, fNoobaa.Labels[externalRgwEndpointLabelName])
-	// The endpoint has its colon replaced by an underscore so that the label is valid
-	assert.Equal(t, fNoobaa.Labels[externalRgwEndpointLabelName], externalRgwEndpoint)
 }
 
 func getReconciler(t *testing.T, objs ...runtime.Object) ReconcileStorageCluster {


### PR DESCRIPTION
The hack was used to pass the address for an RGW endpoint in external mode before proper support introduced to noobaa operator

Signed-off-by: nb-ohad <mitrani.ohad@gmail.com>