### PR TITLE
hack: build netgo osusergo in binary instead of using clibs

### DIFF
--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -5,5 +5,5 @@ set -e
 source hack/common.sh
 
 mkdir -p ${OUTDIR_BIN}
-go build -i -ldflags="-s -w" -o ${OUTDIR_BIN}/ocs-operator ./cmd/manager
-go build -i -ldflags="-s -w" -o ${OUTDIR_BIN}/metrics-exporter ./metrics/main.go
+go build -i -tags 'netgo osusergo' -ldflags="-s -w" -o ${OUTDIR_BIN}/ocs-operator ./cmd/manager
+go build -i -tags 'netgo osusergo' -ldflags="-s -w" -o ${OUTDIR_BIN}/metrics-exporter ./metrics/main.go

--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -5,5 +5,5 @@ set -e
 source hack/common.sh
 
 mkdir -p ${OUTDIR_BIN}
-go build -i -tags 'netgo osusergo' -ldflags="-s -w" -o ${OUTDIR_BIN}/ocs-operator ./cmd/manager
-go build -i -tags 'netgo osusergo' -ldflags="-s -w" -o ${OUTDIR_BIN}/metrics-exporter ./metrics/main.go
+go build -tags 'netgo osusergo' -ldflags="-s -w" -o ${OUTDIR_BIN}/ocs-operator ./cmd/manager
+go build -tags 'netgo osusergo' -ldflags="-s -w" -o ${OUTDIR_BIN}/metrics-exporter ./metrics/main.go


### PR DESCRIPTION
Fix Error version `GLIBC_2.32' not found (required by ocs-operator)
via building static binary.

The Error is seen when the dynamic binary is built on a OS where higher
clibs version is installed and ran on the OS where lower clibs version
is installed.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>