### PR TITLE
Update operator capabilities to level 4

### DIFF
--- a/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -54,7 +54,7 @@ metadata:
               }
           }
       ]
-    capabilities: Full Lifecycle
+    capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:4.6.0
     description: Red Hat OpenShift Container Storage provides hyperconverged storage

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -668,7 +668,7 @@ The NooBaa operator deploys and manages the [NooBaa][2] Multi-Cloud Gateway on O
 	ocsCSV.Annotations["containerImage"] = "quay.io/ocs-dev/ocs-operator:" + ocsversion.Version
 	ocsCSV.Annotations["description"] = "Red Hat OpenShift Container Storage provides hyperconverged storage for applications within an OpenShift cluster."
 	ocsCSV.Annotations["support"] = "Red Hat"
-	ocsCSV.Annotations["capabilities"] = "Full Lifecycle"
+	ocsCSV.Annotations["capabilities"] = "Deep Insights"
 	ocsCSV.Annotations["categories"] = "Storage"
 	ocsCSV.Annotations["operatorframework.io/suggested-namespace"] = "openshift-storage"
 	ocsCSV.Annotations["operatorframework.io/cluster-monitoring"] = "true"


### PR DESCRIPTION
This commit updates the OCS Operator's capabilities level to 4, "Deep
Insights". Per the [Operator SDK documentation][1], we now fulfill the
following requirements:

- Operator exposing metrics about its health
- Operator exposes health and performance metrics about the Operand
- Operand sends useful alerts
- Custom Resources emit custom events

The following criteria was determined by the Operator SDK team to not be
required, and indeed may soon be removed:

- Operator leverages Operator Metering

Though we may not fully have metrics for all aspects of our operations,
simply having the level we currently do is sufficient to meet the
criteria.

[1]: https://sdk.operatorframework.io/docs/advanced-topics/operator-capabilities/operator-capabilities/#level-4---deep-insights

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>