### PR TITLE
allow crds.yaml files in addition to crd.yaml

### DIFF
--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -832,7 +832,7 @@ func copyCrds(ocsCSV *csvv1.ClusterServiceVersion) {
 
 	for _, crdFile := range crdFiles {
 		// only copy crd manifests, this will ignore cr manifests
-		if !strings.Contains(crdFile.Name(), "crd.yaml") {
+		if !strings.Contains(crdFile.Name(), "crd.yaml") && !strings.Contains(crdFile.Name(), "crds.yaml") {
 			continue
 		}
 


### PR DESCRIPTION
Rook changed its CRD file names staring with the PR
https://github.com/rook/rook/pull/6556.

This change in the csv merger tool accomodates the name change.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>