### PR TITLE
Support Wal pvc for a given OSD

### DIFF
--- a/deploy/crds/ocs.openshift.io_storageclusters_crd.yaml
+++ b/deploy/crds/ocs.openshift.io_storageclusters_crd.yaml
@@ -3297,6 +3297,223 @@ spec:
                         the StorageClassDeviceSets will be distributed across. Ignored
                         if Placement is set
                       type: string
+                    walPVCTemplate:
+                      description: PersistentVolumeClaim is a user's request for and
+                        claim to a persistent volume
+                      type: object
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          type: object
+                        spec:
+                          description: 'Spec defines the desired characteristics of
+                            a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: object
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              type: array
+                              items:
+                                type: string
+                            dataSource:
+                              description: 'This field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                - Beta) * An existing PVC (PersistentVolumeClaim)
+                                * An existing custom resource/object that implements
+                                data population (Alpha) In order to use VolumeSnapshot
+                                object types, the appropriate feature gate must be
+                                enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                If the provisioner or an external controller can support
+                                the specified data source, it will create a new volume
+                                based on the contents of the specified data source.
+                                If the specified data source is not supported, the
+                                volume will not be created and the failure will be
+                                reported as an event. In the future, we plan to support
+                                more data source types and the behavior of the provisioner
+                                may change.'
+                              type: object
+                              required:
+                              - kind
+                              - name
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                            resources:
+                              description: 'Resources represents the minimum resources
+                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              type: object
+                              properties:
+                                limits:
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                  additionalProperties:
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                requests:
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                  additionalProperties:
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                            selector:
+                              description: A label query over volumes to consider
+                                for binding.
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  type: array
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                            storageClassName:
+                              description: 'Name of the StorageClass required by the
+                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: VolumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                        status:
+                          description: 'Status represents the current information/status
+                            of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: object
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the actual access
+                                modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              type: array
+                              items:
+                                type: string
+                            capacity:
+                              description: Represents the actual resources of the
+                                underlying volume.
+                              type: object
+                              additionalProperties:
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            conditions:
+                              description: Current Condition of persistent volume
+                                claim. If underlying persistent volume is being resized
+                                then the Condition will be set to 'ResizeStarted'.
+                              type: array
+                              items:
+                                description: PersistentVolumeClaimCondition contails
+                                  details about state of pvc
+                                type: object
+                                required:
+                                - status
+                                - type
+                                properties:
+                                  lastProbeTime:
+                                    description: Last time we probed the condition.
+                                    type: string
+                                    format: date-time
+                                  lastTransitionTime:
+                                    description: Last time the condition transitioned
+                                      from one status to another.
+                                    type: string
+                                    format: date-time
+                                  message:
+                                    description: Human-readable message indicating
+                                      details about last transition.
+                                    type: string
+                                  reason:
+                                    description: Unique, this should be a short, machine
+                                      understandable string that gives the reason
+                                      for condition's last transition. If it reports
+                                      "ResizeStarted" that means the underlying persistent
+                                      volume is being resized.
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    description: PersistentVolumeClaimConditionType
+                                      is a valid value of PersistentVolumeClaimCondition.Type
+                                    type: string
+                            phase:
+                              description: Phase represents the current phase of PersistentVolumeClaim.
+                              type: string
               version:
                 description: Version specifies the version of StorageCluster
                 type: string

--- a/deploy/csv-templates/crds/ocs.openshift.io_storageclusters_crd.yaml
+++ b/deploy/csv-templates/crds/ocs.openshift.io_storageclusters_crd.yaml
@@ -3297,6 +3297,223 @@ spec:
                         the StorageClassDeviceSets will be distributed across. Ignored
                         if Placement is set
                       type: string
+                    walPVCTemplate:
+                      description: PersistentVolumeClaim is a user's request for and
+                        claim to a persistent volume
+                      type: object
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of
+                            this representation of an object. Servers should convert
+                            recognized schemas to the latest internal value, and may
+                            reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST
+                            resource this object represents. Servers may infer this
+                            from the endpoint the client submits requests to. Cannot
+                            be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          type: object
+                        spec:
+                          description: 'Spec defines the desired characteristics of
+                            a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: object
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the desired access
+                                modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              type: array
+                              items:
+                                type: string
+                            dataSource:
+                              description: 'This field can be used to specify either:
+                                * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot
+                                - Beta) * An existing PVC (PersistentVolumeClaim)
+                                * An existing custom resource/object that implements
+                                data population (Alpha) In order to use VolumeSnapshot
+                                object types, the appropriate feature gate must be
+                                enabled (VolumeSnapshotDataSource or AnyVolumeDataSource)
+                                If the provisioner or an external controller can support
+                                the specified data source, it will create a new volume
+                                based on the contents of the specified data source.
+                                If the specified data source is not supported, the
+                                volume will not be created and the failure will be
+                                reported as an event. In the future, we plan to support
+                                more data source types and the behavior of the provisioner
+                                may change.'
+                              type: object
+                              required:
+                              - kind
+                              - name
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource
+                                    being referenced. If APIGroup is not specified,
+                                    the specified Kind must be in the core API group.
+                                    For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being
+                                    referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being
+                                    referenced
+                                  type: string
+                            resources:
+                              description: 'Resources represents the minimum resources
+                                the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              type: object
+                              properties:
+                                limits:
+                                  description: 'Limits describes the maximum amount
+                                    of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                  additionalProperties:
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                                requests:
+                                  description: 'Requests describes the minimum amount
+                                    of compute resources required. If Requests is
+                                    omitted for a container, it defaults to Limits
+                                    if that is explicitly specified, otherwise to
+                                    an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                  additionalProperties:
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    x-kubernetes-int-or-string: true
+                            selector:
+                              description: A label query over volumes to consider
+                                for binding.
+                              type: object
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  type: array
+                                  items:
+                                    description: A label selector requirement is a
+                                      selector that contains values, a key, and an
+                                      operator that relates the key and values.
+                                    type: object
+                                    required:
+                                    - key
+                                    - operator
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship
+                                          to a set of values. Valid operators are
+                                          In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string
+                                          values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the
+                                          operator is Exists or DoesNotExist, the
+                                          values array must be empty. This array is
+                                          replaced during a strategic merge patch.
+                                        type: array
+                                        items:
+                                          type: string
+                                matchLabels:
+                                  description: matchLabels is a map of {key,value}
+                                    pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions,
+                                    whose key field is "key", the operator is "In",
+                                    and the values array contains only "value". The
+                                    requirements are ANDed.
+                                  type: object
+                                  additionalProperties:
+                                    type: string
+                            storageClassName:
+                              description: 'Name of the StorageClass required by the
+                                claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume
+                                is required by the claim. Value of Filesystem is implied
+                                when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: VolumeName is the binding reference to
+                                the PersistentVolume backing this claim.
+                              type: string
+                        status:
+                          description: 'Status represents the current information/status
+                            of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          type: object
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the actual access
+                                modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              type: array
+                              items:
+                                type: string
+                            capacity:
+                              description: Represents the actual resources of the
+                                underlying volume.
+                              type: object
+                              additionalProperties:
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                x-kubernetes-int-or-string: true
+                            conditions:
+                              description: Current Condition of persistent volume
+                                claim. If underlying persistent volume is being resized
+                                then the Condition will be set to 'ResizeStarted'.
+                              type: array
+                              items:
+                                description: PersistentVolumeClaimCondition contails
+                                  details about state of pvc
+                                type: object
+                                required:
+                                - status
+                                - type
+                                properties:
+                                  lastProbeTime:
+                                    description: Last time we probed the condition.
+                                    type: string
+                                    format: date-time
+                                  lastTransitionTime:
+                                    description: Last time the condition transitioned
+                                      from one status to another.
+                                    type: string
+                                    format: date-time
+                                  message:
+                                    description: Human-readable message indicating
+                                      details about last transition.
+                                    type: string
+                                  reason:
+                                    description: Unique, this should be a short, machine
+                                      understandable string that gives the reason
+                                      for condition's last transition. If it reports
+                                      "ResizeStarted" that means the underlying persistent
+                                      volume is being resized.
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    description: PersistentVolumeClaimConditionType
+                                      is a valid value of PersistentVolumeClaimCondition.Type
+                                    type: string
+                            phase:
+                              description: Phase represents the current phase of PersistentVolumeClaim.
+                              type: string
               version:
                 description: Version specifies the version of StorageCluster
                 type: string

--- a/deploy/csv-templates/noobaa-csv.yaml
+++ b/deploy/csv-templates/noobaa-csv.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
-    alm-examples: '[{"kind":"NooBaa","apiVersion":"noobaa.io/v1alpha1","metadata":{"name":"noobaa","creationTimestamp":null,"labels":{"app":"noobaa"}},"spec":{"cleanupPolicy":{}},"status":{}},{"kind":"BackingStore","apiVersion":"noobaa.io/v1alpha1","metadata":{"name":"aws1","creationTimestamp":null,"labels":{"app":"noobaa"},"finalizers":["noobaa.io/finalizer"]},"spec":{"type":""},"status":{"mode":{}}},{"kind":"BucketClass","apiVersion":"noobaa.io/v1alpha1","metadata":{"name":"default","creationTimestamp":null,"labels":{"app":"noobaa"}},"spec":{"placementPolicy":{"tiers":[{"backingStores":["aws1"]}]}},"status":{}}]'
+    alm-examples: '[{"kind":"NooBaa","apiVersion":"noobaa.io/v1alpha1","metadata":{"name":"noobaa","creationTimestamp":null},"spec":{"cleanupPolicy":{}},"status":{}},{"kind":"BackingStore","apiVersion":"noobaa.io/v1alpha1","metadata":{"name":"default","creationTimestamp":null},"spec":{"type":""},"status":{"mode":{}}},{"kind":"BucketClass","apiVersion":"noobaa.io/v1alpha1","metadata":{"name":"default","creationTimestamp":null},"spec":{"placementPolicy":{"tiers":[{"backingStores":["aws1"]}]}},"status":{}}]'
     capabilities: Basic Install
     categories: Storage,Big Data
     certified: "false"

--- a/deploy/olm-catalog/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/storagecluster.crd.yaml
@@ -954,9 +954,7 @@ spec:
                           type: object
                       type: object
                     deviceType:
-                      description: DeviceType is the value of device type in this
-                        StorageDeviceSet. It can have one of the three values (SSD,
-                        HDD, NVMe)
+                      description: DeviceType is the value of device type in this StorageDeviceSet. It can have one of the three values (SSD, HDD, NVMe)
                       enum:
                       - SSD
                       - ssd
@@ -1973,6 +1971,155 @@ spec:
                     topologyKey:
                       description: TopologyKey is the Kubernetes topology label that the StorageClassDeviceSets will be distributed across. Ignored if Placement is set
                       type: string
+                    walPVCTemplate:
+                      description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
+                      properties:
+                        apiVersion:
+                          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                          type: string
+                        kind:
+                          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                          type: string
+                        metadata:
+                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                          type: object
+                        spec:
+                          description: 'Spec defines the desired characteristics of a volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            dataSource:
+                              description: 'This field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot - Beta) * An existing PVC (PersistentVolumeClaim) * An existing custom resource/object that implements data population (Alpha) In order to use VolumeSnapshot object types, the appropriate feature gate must be enabled (VolumeSnapshotDataSource or AnyVolumeDataSource) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. If the specified data source is not supported, the volume will not be created and the failure will be reported as an event. In the future, we plan to support more data source types and the behavior of the provisioner may change.'
+                              properties:
+                                apiGroup:
+                                  description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                  type: string
+                                kind:
+                                  description: Kind is the type of resource being referenced
+                                  type: string
+                                name:
+                                  description: Name is the name of resource being referenced
+                                  type: string
+                              required:
+                              - kind
+                              - name
+                              type: object
+                            resources:
+                              description: 'Resources represents the minimum resources the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                              properties:
+                                limits:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                                requests:
+                                  additionalProperties:
+                                    anyOf:
+                                    - type: integer
+                                    - type: string
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                                  type: object
+                              type: object
+                            selector:
+                              description: A label query over volumes to consider for binding.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the selector applies to.
+                                        type: string
+                                      operator:
+                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                            storageClassName:
+                              description: 'Name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                              type: string
+                            volumeMode:
+                              description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                              type: string
+                            volumeName:
+                              description: VolumeName is the binding reference to the PersistentVolume backing this claim.
+                              type: string
+                          type: object
+                        status:
+                          description: 'Status represents the current information/status of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                          properties:
+                            accessModes:
+                              description: 'AccessModes contains the actual access modes the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                              items:
+                                type: string
+                              type: array
+                            capacity:
+                              additionalProperties:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: Represents the actual resources of the underlying volume.
+                              type: object
+                            conditions:
+                              description: Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.
+                              items:
+                                description: PersistentVolumeClaimCondition contails details about state of pvc
+                                properties:
+                                  lastProbeTime:
+                                    description: Last time we probed the condition.
+                                    format: date-time
+                                    type: string
+                                  lastTransitionTime:
+                                    description: Last time the condition transitioned from one status to another.
+                                    format: date-time
+                                    type: string
+                                  message:
+                                    description: Human-readable message indicating details about last transition.
+                                    type: string
+                                  reason:
+                                    description: Unique, this should be a short, machine understandable string that gives the reason for condition's last transition. If it reports "ResizeStarted" that means the underlying persistent volume is being resized.
+                                    type: string
+                                  status:
+                                    type: string
+                                  type:
+                                    description: PersistentVolumeClaimConditionType is a valid value of PersistentVolumeClaimCondition.Type
+                                    type: string
+                                required:
+                                - status
+                                - type
+                                type: object
+                              type: array
+                            phase:
+                              description: Phase represents the current phase of PersistentVolumeClaim.
+                              type: string
+                          type: object
+                      type: object
                   required:
                   - count
                   - dataPVCTemplate

--- a/pkg/apis/ocs/v1/storagecluster_types.go
+++ b/pkg/apis/ocs/v1/storagecluster_types.go
@@ -43,7 +43,7 @@ type StorageClusterSpec struct {
 	// If enabled, sets the failureDomain to host, allowing devices to be
 	// distributed evenly across all nodes, regardless of distribution in zones
 	// or racks.
-	FlexibleScaling  bool     `json:"flexibleScaling,omitempty"`
+	FlexibleScaling bool `json:"flexibleScaling,omitempty"`
 }
 
 // ManagedResourcesSpec defines how to reconcile auxiliary resources

--- a/pkg/apis/ocs/v1/storagecluster_types.go
+++ b/pkg/apis/ocs/v1/storagecluster_types.go
@@ -124,6 +124,7 @@ type StorageDeviceSet struct {
 	Config              StorageDeviceSetConfig        `json:"config,omitempty"`
 	DataPVCTemplate     corev1.PersistentVolumeClaim  `json:"dataPVCTemplate"`
 	MetadataPVCTemplate *corev1.PersistentVolumeClaim `json:"metadataPVCTemplate,omitempty"`
+	WalPVCTemplate      *corev1.PersistentVolumeClaim `json:"walPVCTemplate,omitempty"`
 }
 
 // StorageDeviceSetConfig defines Ceph OSD specific config options for the StorageDeviceSet

--- a/pkg/apis/ocs/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/ocs/v1/zz_generated.deepcopy.go
@@ -453,6 +453,11 @@ func (in *StorageDeviceSet) DeepCopyInto(out *StorageDeviceSet) {
 		*out = new(corev1.PersistentVolumeClaim)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.WalPVCTemplate != nil {
+		in, out := &in.WalPVCTemplate, &out.WalPVCTemplate
+		*out = new(corev1.PersistentVolumeClaim)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -455,7 +455,11 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 
 			if ds.MetadataPVCTemplate != nil {
 				ds.MetadataPVCTemplate.ObjectMeta.Name = metadataPVCName
-				set.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{ds.DataPVCTemplate, *ds.MetadataPVCTemplate}
+				set.VolumeClaimTemplates = append(set.VolumeClaimTemplates, *ds.MetadataPVCTemplate)
+			}
+			if ds.WalPVCTemplate != nil {
+				ds.WalPVCTemplate.ObjectMeta.Name = walPVCName
+				set.VolumeClaimTemplates = append(set.VolumeClaimTemplates, *ds.WalPVCTemplate)
 			}
 
 			storageClassDeviceSets = append(storageClassDeviceSets, set)

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -49,7 +49,7 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	monCountOverrideEnvVar = "MON_COUNT_OVERRIDE"
 	// EBS represents AWS EBS provisioner for StorageClass
 	EBS StorageClassProvisionerType = "kubernetes.io/aws-ebs"
-	//Name of MetadataPVCTemplate
+	// Name of MetadataPVCTemplate
 	metadataPVCName = "metadata"
 	// Name of WalPVCTemplate
 	walPVCName = "wal"

--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -51,6 +51,8 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 	EBS StorageClassProvisionerType = "kubernetes.io/aws-ebs"
 	//Name of MetadataPVCTemplate
 	metadataPVCName = "metadata"
+	// Name of WalPVCTemplate
+	walPVCName = "wal"
 
 	// ReconcileStrategyUnknown is the same as default
 	ReconcileStrategyUnknown ReconcileStrategy = ""
@@ -414,6 +416,11 @@ func (r *ReconcileStorageCluster) validateStorageDeviceSets(sc *ocsv1.StorageClu
 		if ds.MetadataPVCTemplate != nil {
 			if ds.MetadataPVCTemplate.Spec.StorageClassName == nil || *ds.MetadataPVCTemplate.Spec.StorageClassName == "" {
 				return fmt.Errorf("failed to validate StorageDeviceSet %d: no StorageClass specified for metadataPVCTemplate", i)
+			}
+		}
+		if ds.WalPVCTemplate != nil {
+			if ds.WalPVCTemplate.Spec.StorageClassName == nil || *ds.WalPVCTemplate.Spec.StorageClassName == "" {
+				return fmt.Errorf("failed to validate StorageDeviceSet %d: no StorageClass specified for walPVCTemplate", i)
 			}
 		}
 		if ds.DeviceType != "" {

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -98,33 +98,11 @@ var mockMetaDataPVCTemplate = &corev1.PersistentVolumeClaim{
 
 var mockDeviceSets = []api.StorageDeviceSet{
 	{
-		Name:  "mock-sds",
-		Count: 3,
-		DataPVCTemplate: corev1.PersistentVolumeClaim{
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Ti"),
-					},
-				},
-				StorageClassName: &storageClassName,
-				VolumeMode:       &volMode,
-			},
-		},
-		MetadataPVCTemplate: &corev1.PersistentVolumeClaim{
-			Spec: corev1.PersistentVolumeClaimSpec{
-				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-				Resources: corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("1Ti"),
-					},
-				},
-				StorageClassName: &storageClassName,
-				VolumeMode:       &volMode,
-			},
-		},
-		Portable: true,
+		Name:                "mock-sds",
+		Count:               3,
+		DataPVCTemplate:     mockDataPVCTemplate,
+		MetadataPVCTemplate: mockMetaDataPVCTemplate,
+		Portable:            true,
 	},
 }
 

--- a/test/crd_validation_test.go
+++ b/test/crd_validation_test.go
@@ -30,6 +30,7 @@ const (
 	pathLabelSelector        = "/spec/labelSelector"
 	pathPlacement            = "/spec/placement"
 	pathMetadataPVCTemplate  = "/spec/storageDeviceSets/metadataPVCTemplate/"
+	pathWalPVCTemplate       = "/spec/storageDeviceSets/walPVCTemplate/"
 )
 
 func TestSampleCustomResources(t *testing.T) {
@@ -90,6 +91,7 @@ func TestCompleteCRD(t *testing.T) {
 			pathLabelSelector,
 			pathPlacement,
 			pathMetadataPVCTemplate,
+			pathWalPVCTemplate,
 		}
 		for _, missing := range missingEntries {
 			skipAsOmission := false


### PR DESCRIPTION
**Description :**

- Rook has added support to configure a wal PVC for an OSD in https://github.com/rook/rook/pull/5580

- This PR is about enabling the same support via OCS

- It can be used by creating a new walPVCTemplate.

A template will look like this:
```
dataPVCTemplate:
    spec:
      # IMPORTANT: Change the storage class depending on your environment
      storageClassName: local-block
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          # Replace the size with the size of localPV prepared
          storage: 500Gi
      volumeMode: Block
walPVCTemplate:
    spec:
      # IMPORTANT: Change the storage class depending on your environment
      storageClassName: local-block-wal
      accessModes:
        - ReadWriteOnce
      resources:
        requests:
          # Replace the size with the size of localPV prepared
          storage: 100Gi
      volumeMode: Block

```