### PR TITLE
Storageclass and snapshotclass refactor

### DIFF
--- a/pkg/controller/storagecluster/storageclasses.go
+++ b/pkg/controller/storagecluster/storageclasses.go
@@ -14,13 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-const (
-	// The following constants are the indices at which StorageClasses are returned from newStorageClasses and in
-	// which they should be passed to createStorageClasses.
-	cephFileSystemIndex = 0
-	cephBlockPoolIndex  = 1
-)
-
 // StorageClassConfiguration provides configuration options for a StorageClass.
 type StorageClassConfiguration struct {
 	storageClass      *storagev1.StorageClass

--- a/pkg/controller/storagecluster/storageclasses_test.go
+++ b/pkg/controller/storagecluster/storageclasses_test.go
@@ -37,7 +37,7 @@ func assertStorageClasses(t *testing.T, reconciler ReconcileStorageCluster, cr *
 	err = reconciler.client.Get(context.TODO(), request.NamespacedName, actualSc2)
 	assert.NoError(t, err)
 
-	expected, err := reconciler.newStorageClasses(cr)
+	expected, err := reconciler.newStorageClassConfigurations(cr)
 	assert.NoError(t, err)
 	request.Name = "ocsinit-ceph-rgw"
 	err = reconciler.client.Get(context.TODO(), request.NamespacedName, actualSc3)
@@ -51,11 +51,11 @@ func assertStorageClasses(t *testing.T, reconciler ReconcileStorageCluster, cr *
 		// if not a cloud platform, OBC Storage class should be created/updated
 		assert.Equal(t, len(expected), 3)
 		assert.NoError(t, err)
-		assert.Equal(t, len(expected[2].OwnerReferences), 0)
-		assert.Equal(t, expected[2].ObjectMeta.Name, actualSc3.ObjectMeta.Name)
-		assert.Equal(t, expected[2].Provisioner, actualSc3.Provisioner)
-		assert.Equal(t, expected[2].ReclaimPolicy, actualSc3.ReclaimPolicy)
-		assert.Equal(t, expected[2].Parameters, actualSc3.Parameters)
+		assert.Equal(t, len(expected[2].storageClass.OwnerReferences), 0)
+		assert.Equal(t, expected[2].storageClass.Name, actualSc3.ObjectMeta.Name)
+		assert.Equal(t, expected[2].storageClass.Provisioner, actualSc3.Provisioner)
+		assert.Equal(t, expected[2].storageClass.ReclaimPolicy, actualSc3.ReclaimPolicy)
+		assert.Equal(t, expected[2].storageClass.Parameters, actualSc3.Parameters)
 		// Doing a bit more validation for the RGW SC since some fields differ whether
 		// we do independent or converged mode, typically "objectStoreName" param must exist
 		assert.NotEmpty(t, actualSc3.Parameters["objectStoreName"], actualSc3.Parameters)
@@ -68,16 +68,16 @@ func assertStorageClasses(t *testing.T, reconciler ReconcileStorageCluster, cr *
 	// lead to other child resources getting GCd.
 	// Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1755623
 	// Ref: https://bugzilla.redhat.com/show_bug.cgi?id=1691546
-	assert.Equal(t, len(expected[0].OwnerReferences), 0)
-	assert.Equal(t, len(expected[1].OwnerReferences), 0)
+	assert.Equal(t, len(expected[0].storageClass.OwnerReferences), 0)
+	assert.Equal(t, len(expected[1].storageClass.OwnerReferences), 0)
 
-	assert.Equal(t, expected[0].ObjectMeta.Name, actualSc1.ObjectMeta.Name)
-	assert.Equal(t, expected[0].Provisioner, actualSc1.Provisioner)
-	assert.Equal(t, expected[0].ReclaimPolicy, actualSc1.ReclaimPolicy)
-	assert.Equal(t, expected[0].Parameters, actualSc1.Parameters)
+	assert.Equal(t, expected[0].storageClass.ObjectMeta.Name, actualSc1.ObjectMeta.Name)
+	assert.Equal(t, expected[0].storageClass.Provisioner, actualSc1.Provisioner)
+	assert.Equal(t, expected[0].storageClass.ReclaimPolicy, actualSc1.ReclaimPolicy)
+	assert.Equal(t, expected[0].storageClass.Parameters, actualSc1.Parameters)
 
-	assert.Equal(t, expected[1].ObjectMeta.Name, actualSc2.ObjectMeta.Name)
-	assert.Equal(t, expected[1].Provisioner, actualSc2.Provisioner)
-	assert.Equal(t, expected[1].ReclaimPolicy, actualSc2.ReclaimPolicy)
-	assert.Equal(t, expected[1].Parameters, actualSc2.Parameters)
+	assert.Equal(t, expected[1].storageClass.ObjectMeta.Name, actualSc2.ObjectMeta.Name)
+	assert.Equal(t, expected[1].storageClass.Provisioner, actualSc2.Provisioner)
+	assert.Equal(t, expected[1].storageClass.ReclaimPolicy, actualSc2.ReclaimPolicy)
+	assert.Equal(t, expected[1].storageClass.Parameters, actualSc2.Parameters)
 }

--- a/pkg/controller/storagecluster/uninstall_reconciler.go
+++ b/pkg/controller/storagecluster/uninstall_reconciler.go
@@ -566,8 +566,9 @@ func (r *ReconcileStorageCluster) deleteCephObjectStores(sc *ocsv1.StorageCluste
 // deleteSnapshotClasses deletes the storageClasses that the ocs-operator created
 func (r *ReconcileStorageCluster) deleteSnapshotClasses(instance *ocsv1.StorageCluster, reqLogger logr.Logger) error {
 
-	scs := newSnapshotClasses(instance)
-	for _, sc := range scs {
+	vsccs := newSnapshotClassConfigurations(instance)
+	for _, vscc := range vsccs {
+		sc := vscc.snapshotClass
 		existing := snapapi.VolumeSnapshotClass{}
 		err := r.client.Get(context.TODO(), types.NamespacedName{Name: sc.Name, Namespace: sc.Namespace}, &existing)
 

--- a/pkg/controller/storagecluster/uninstall_reconciler.go
+++ b/pkg/controller/storagecluster/uninstall_reconciler.go
@@ -44,12 +44,13 @@ const (
 // deleteStorageClasses deletes the storageClasses that the ocs-operator created
 func (r *ReconcileStorageCluster) deleteStorageClasses(instance *ocsv1.StorageCluster, reqLogger logr.Logger) error {
 
-	scs, err := r.newStorageClasses(instance)
+	sccs, err := r.newStorageClassConfigurations(instance)
 	if err != nil {
 		reqLogger.Error(err, fmt.Sprintf("Uninstall: Unable to determine the StorageClass names")) //nolint:gosimple
 		return nil
 	}
-	for _, sc := range scs {
+	for _, scc := range sccs {
+		sc := scc.storageClass
 		existing := storagev1.StorageClass{}
 		err := r.client.Get(context.TODO(), types.NamespacedName{Name: sc.Name, Namespace: sc.Namespace}, &existing)
 

--- a/pkg/controller/storagecluster/uninstall_reconciler_test.go
+++ b/pkg/controller/storagecluster/uninstall_reconciler_test.go
@@ -148,21 +148,21 @@ func assertTestDeleteStorageClasses(t *testing.T, reconciler ReconcileStorageClu
 		assert.NoError(t, err)
 	}
 
-	scs, err := reconciler.newStorageClasses(sc)
+	sccs, err := reconciler.newStorageClassConfigurations(sc)
 	assert.NoError(t, err)
 
-	for _, storageClass := range scs {
+	for _, scc := range sccs {
 		existing := storagev1.StorageClass{}
-		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: storageClass.Name}, &existing)
+		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: scc.storageClass.Name}, &existing)
 		assert.Equal(t, !storageClassExists, errors.IsNotFound(err))
 	}
 
 	err = reconciler.deleteStorageClasses(sc, reconciler.reqLogger)
 	assert.NoError(t, err)
 
-	for _, storageClass := range scs {
+	for _, scc := range sccs {
 		existing := storagev1.StorageClass{}
-		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: storageClass.Name}, &existing)
+		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: scc.storageClass.Name}, &existing)
 		assert.True(t, errors.IsNotFound(err))
 	}
 }

--- a/pkg/controller/storagecluster/uninstall_reconciler_test.go
+++ b/pkg/controller/storagecluster/uninstall_reconciler_test.go
@@ -202,20 +202,20 @@ func assertTestDeleteSnapshotClasses(
 		assert.NoError(t, err)
 	}
 
-	sscs := newSnapshotClasses(sc)
+	vsscs := newSnapshotClassConfigurations(sc)
 
-	for _, ssc := range sscs {
+	for _, vssc := range vsscs {
 		existing := snapapi.VolumeSnapshotClass{}
-		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: ssc.Name}, &existing)
+		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: vssc.snapshotClass.Name}, &existing)
 		assert.Equal(t, !SnapshotClassExists, errors.IsNotFound(err))
 	}
 
 	err := reconciler.deleteSnapshotClasses(sc, reconciler.reqLogger)
 	assert.NoError(t, err)
 
-	for _, ssc := range sscs {
+	for _, vssc := range vsscs {
 		existing := snapapi.VolumeSnapshotClass{}
-		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: ssc.Name}, &existing)
+		err := reconciler.client.Get(context.TODO(), types.NamespacedName{Name: vssc.snapshotClass.Name}, &existing)
 		assert.Equal(t, !SnapshotClassExists, errors.IsNotFound(err))
 		assert.True(t, errors.IsNotFound(err))
 	}


### PR DESCRIPTION
In order to create a minimal test halo for the release of version 4.6, minimal change to the handling of StorageClass and SnapshotClass suggested that we identify the Ceph storage type of each StorageClass or SnapshotClass by slice index for the purpose of looking up management options. This approach will often become somewhat brittle over time. To better support future changes, this patch set creates wrapping structs around StorageClasses and SnapshotClasses that bundle them with their deployment options.