### PR TITLE
updates Dockerfile.registry for apiextensions/v1 support

### DIFF
--- a/build/Dockerfile.registry
+++ b/build/Dockerfile.registry
@@ -1,11 +1,13 @@
-FROM quay.io/openshift/origin-operator-registry:latest
+FROM quay.io/operator-framework/upstream-registry-builder as builder
 
-COPY build/_output/appregistry/olm-catalog /registry/ocs-catalog
+COPY build/_output/appregistry/olm-catalog manifests
+RUN /bin/initializer -o /bundles.db
 
-# Initialize the database
-RUN initializer --manifests /registry/ocs-catalog --output bundles.db
-
-# There are multiple binaries in the origin-operator-registry
-# We want the registry-server
-ENTRYPOINT ["registry-server"]
+FROM scratch
+COPY ["nsswitch.conf", "/etc/nsswitch.conf"]
+COPY --from=builder /bundles.db /bundles.db
+COPY --from=builder /bin/registry-server /registry-server
+COPY --from=builder /bin/grpc_health_probe /bin/grpc_health_probe
+EXPOSE 50051
+ENTRYPOINT ["/registry-server"]
 CMD ["--database", "bundles.db"]

--- a/nsswitch.conf
+++ b/nsswitch.conf
@@ -1,0 +1,1 @@
+hosts: files dns


### PR DESCRIPTION
updating Dockerfile.registry to be able to support operator
registry builds with CRDs using apiextensions/v1.

also adds nsswitch.conf to fix the issue with non-root
users not being able to write this config.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>