### PR TITLE
Added OCS CPU telemetry metric rules

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -8,6 +8,19 @@ metadata:
   namespace: openshift-storage
 spec:
   groups:
+  - name: ocs_telemetry.rules
+    rules:
+    - expr: "sum(\n  max(\n    (\n      kube_pod_container_resource_requests_cpu_cores{namespace=\"openshift-storage\",
+        pod =~\"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)\"} *
+        0 +1 \n    ) * on(node) group_left() node:node_num_cpu:sum\n  ) by (node)\n)\n"
+      record: ocs:node_num_cpu:sum
+    - expr: |
+        sum(
+          rate(
+            container_cpu_usage_seconds_total{namespace="openshift-storage",container="",pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)"} [5m]
+          )
+        )
+      record: ocs:container_cpu_usage:sum
   - name: external-cluster-services-alert.rules
     rules:
     - alert: ClusterObjectStoreState

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -8,6 +8,19 @@ metadata:
   namespace: openshift-storage
 spec:
   groups:
+  - name: ocs_telemetry.rules
+    rules:
+    - expr: "sum(\n  max(\n    (\n      kube_pod_container_resource_requests_cpu_cores{namespace=\"openshift-storage\",
+        pod =~\"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)\"} *
+        0 +1 \n    ) * on(node) group_left() node:node_num_cpu:sum\n  ) by (node)\n)\n"
+      record: ocs:node_num_cpu:sum
+    - expr: |
+        sum(
+          rate(
+            container_cpu_usage_seconds_total{namespace="openshift-storage",container="",pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)"} [5m]
+          )
+        )
+      record: ocs:container_cpu_usage:sum
   - name: cluster-services-alert.rules
     rules:
     - alert: ClusterObjectStoreState

--- a/metrics/mixin/build/jsonnetfile.lock.json
+++ b/metrics/mixin/build/jsonnetfile.lock.json
@@ -1,14 +1,17 @@
 {
-    "dependencies": [
-        {
-            "name": "ksonnet",
-            "source": {
-                "git": {
-                    "remote": "https://github.com/ksonnet/ksonnet-lib",
-                    "subdir": ""
-                }
-            },
-            "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f"
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/ksonnet/ksonnet-lib.git",
+          "subdir": ""
         }
-    ]
+      },
+      "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f",
+      "sum": "h28BXZ7+vczxYJ2sCt8JuR9+yznRtU/iA6DCpQUrtEg=",
+      "name": "ksonnet"
+    }
+  ],
+  "legacyImports": false
 }

--- a/metrics/mixin/rules/rules.libsonnet
+++ b/metrics/mixin/rules/rules.libsonnet
@@ -1,4 +1,33 @@
 {
   prometheusRules+:: {
+    groups+: [
+      {
+        name: 'ocs_telemetry.rules',
+        rules: [
+          {
+            record: 'ocs:node_num_cpu:sum',
+            expr: |||
+              sum(
+                max(
+                  (
+                    kube_pod_container_resource_requests_cpu_cores{namespace="openshift-storage", pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)"} * 0 +1 
+                  ) * on(node) group_left() node:node_num_cpu:sum
+                ) by (node)
+              )
+            ||| % $._config,
+          },
+          {
+            record: 'ocs:container_cpu_usage:sum',
+            expr: |||
+              sum(
+                rate(
+                  container_cpu_usage_seconds_total{namespace="openshift-storage",container="",pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)"} [5m]
+                )
+              )
+            ||| % $._config,
+          },
+        ],
+      },
+    ],
   },
 }


### PR DESCRIPTION
[//]: # (Please describe your changes in detail)

This PR adds recording rules for Telemetry of OCS CPU metrics.

[//]: # (If your changes affect the CR fields, a syntax for the CR change should be provided)
[//]: # (If a bug is fixed then the behavior change of before and after should be mentioned)
[//]: # (Be sure to run ocs-operator ci before pushing `make ocs-operator-ci`)

**Description of your changes:**

Following metric recording rules will be deployed with OCS and will then be queried by OCP telemeter for the required metric.

Metrics: 
1) Amount of cores on OCS storage nodes

Definition of OCS storage nodes: Nodes on which following Pods are present in 'openshift-storage' namespace : pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)

Rule : ocs:node_num_cpu:sum

Query : sum(max((kube_pod_container_resource_requests_cpu_cores{namespace="openshift-storage", pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)"} * 0 +1 ) * on(node) group_left() node:node_num_cpu:sum) by (node))

Resultant : Cardinality = 1 . Total number of CPU

![Screenshot from 2020-12-01 17-01-47](https://user-images.githubusercontent.com/8753636/100752416-9772c600-340e-11eb-8c9a-ce5042cc148b.png)


2) CPU requested by OCS pods.

	Definition of OCS pods : pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*) (there are more pods, but these are the only ones we need the cpu usage for)

Rule : ocs_pod:container_cpu_usage:sum

Query :  sum(rate(container_cpu_usage_seconds_total{namespace="openshift-storage",container="",pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)"} [5m]))


Resultant : Cardinality = 1 . Total CPU usage

![Screenshot from 2020-12-01 17-02-16](https://user-images.githubusercontent.com/8753636/100752444-a194c480-340e-11eb-90d9-4c843105e5f8.png)


**Once this PR is merged, I will send a corresponding PR to openshift cluster-monitoring-operator to get these metrics whitelisted in the telemetry list.**

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Unit tests have been added, if necessary.
- [x] Generate CSV (`make gen-latest-csv`)
- [x] Raise Integration tests issue if necessary.
- [x] Code generation (`make update-generated`) has been run to update object specifications, if necessary.



Signed-off-by: Anmol Sachan <anmol13694@gmail.com>