### PR TITLE
CSV generator for OCS on OpenShift Dedicated

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -12,6 +12,7 @@ GOARCH="${GOARCH:-amd64}"
 # Current DEV version of the CSV
 DEFAULT_CSV_VERSION="4.7.0"
 CSV_VERSION="${CSV_VERSION:-${DEFAULT_CSV_VERSION}}"
+GEN_OSD=${GEN_OSD:-"false"}
 
 IMAGE_BUILD_CMD="${IMAGE_BUILD_CMD}"
 if [ -z "$IMAGE_BUILD_CMD" ]; then
@@ -58,6 +59,7 @@ LATEST_NOOBAA_IMAGE="noobaa/noobaa-operator:2.3.0"
 LATEST_NOOBAA_CORE_IMAGE="noobaa/noobaa-core:5.5.0"
 LATEST_NOOBAA_DB_IMAGE="centos/mongodb-36-centos7"
 LATEST_CEPH_IMAGE="ceph/ceph:v14.2"
+LATEST_OSD_IMAGE="quay.io/johnstrunk/ocs-osd-deployer:latest"
 
 DEFAULT_IMAGE_REGISTRY="quay.io"
 DEFAULT_REGISTRY_NAMESPACE="ocs-dev"

--- a/hack/generate-latest-csv.sh
+++ b/hack/generate-latest-csv.sh
@@ -15,6 +15,7 @@ export NOOBAA_DB_IMAGE=${NOOBAA_DB_IMAGE:-${LATEST_NOOBAA_DB_IMAGE}}
 export CEPH_IMAGE=${CEPH_IMAGE:-${LATEST_CEPH_IMAGE}}
 export OCS_IMAGE=${OCS_IMAGE:-"${IMAGE_REGISTRY}/${REGISTRY_NAMESPACE}/${OPERATOR_IMAGE_NAME}:${IMAGE_TAG}"}
 export OCS_MUST_GATHER_IMAGE=${OCS_MUST_GATHER_IMAGE:-"${MUST_GATHER_FULL_IMAGE_NAME}"}
+export OSD_IMAGE=${OSD_IMAGE:-${LATEST_OSD_IMAGE}}
 
 echo "=== Generating DEV CSV with the following vars ==="
 echo -e "\tCSV_VERSION=$CSV_VERSION"
@@ -24,5 +25,8 @@ echo -e "\tNOOBAA_CORE_IMAGE=$NOOBAA_CORE_IMAGE"
 echo -e "\tNOOBAA_DB_IMAGE=$NOOBAA_DB_IMAGE"
 echo -e "\tCEPH_IMAGE=$CEPH_IMAGE"
 echo -e "\tOCS_IMAGE=$OCS_IMAGE"
+if [ "$GEN_OSD" = "true" ]; then
+    echo -e "\tOSD_IMAGE=$OSD_IMAGE"
+fi
 
 hack/generate-unified-csv.sh

--- a/hack/generate-unified-csv.sh
+++ b/hack/generate-unified-csv.sh
@@ -66,4 +66,6 @@ $CSV_MERGER \
 	--crds-directory="$OUTDIR_CRDS" \
 	--manifests-directory=$BUNDLEMANIFESTS_DIR \
 	--olm-bundle-directory="$OCS_FINAL_DIR" \
-	--timestamp="$TIMESTAMP"
+	--timestamp="$TIMESTAMP" \
+	--gen-osd="$GEN_OSD" \
+	--osd-image="$OSD_IMAGE"


### PR DESCRIPTION
For OCS on OpenShift Dedicated efforts, we have a new operator that will watch the Storage Cluster resource.
This new operator needs to be deployed along with the other operators.

However, this new deployment is only concerned with OCS on OpenShift Dedicated (OSD in short; not the Cpeh OSD). So, adding a flag to inject the deployment into CSV specially for OSD.

The generated CSV will not be committed into the OCS Operator repository in it's current state.
It might be worth looking into decoupling these generation tools and processes into it's own repository.

Usage:
`GEN_OSD=true make gen-latest-csv`

`GEN_OSD` is set to `false` by default.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>