### PR TITLE
install ginkgo but don't edit the go.mod file

### DIFF
--- a/hack/build-functest.sh
+++ b/hack/build-functest.sh
@@ -10,8 +10,8 @@ GINKGO=$GOBIN/ginkgo
 
 if ! [ -x "$GINKGO" ]; then
 	echo "Retrieving ginkgo and gomega build dependencies"
-	go get github.com/onsi/ginkgo/ginkgo
-	go get github.com/onsi/gomega/...
+	go install github.com/onsi/ginkgo/ginkgo
+	go install github.com/onsi/gomega/...
 else
 	echo "GINKO binary found at $GINKGO"
 fi


### PR DESCRIPTION
If ginkgo binary is not found on the system when running the functest,
we were installing ginkgo using go get. The downside to that is that it
updates the go.mod and go.sum file. It is not the intention.

Go has install command which helps us to only install the binary without
updating go.mod and go.sum. This commit updates the hack script to only
install ginkgo.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>