### PR TITLE
functests: improvements to allow StorageCluster with different configurations

### DIFF
--- a/functests/config.go
+++ b/functests/config.go
@@ -43,6 +43,8 @@ func init() {
 	flag.StringVar(&UpgradeFromOcsSubscriptionChannel, "upgrade-from-ocs-subscription-channel", "", "The subscription channel to upgrade from")
 	flag.BoolVar(&ocsClusterUninstall, "ocs-cluster-uninstall", true, "Uninstall the ocs cluster after tests completion")
 
+	flag.Parse()
+
 	dm, err := deploymanager.NewDeployManager()
 	if err != nil {
 		panic(fmt.Sprintf("failed to initialize DeployManager: %v", err))

--- a/functests/ocs/cluster_upgrade_test.go
+++ b/functests/ocs/cluster_upgrade_test.go
@@ -1,8 +1,6 @@
 package ocs_test
 
 import (
-	"flag"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -12,7 +10,6 @@ import (
 var _ = PDescribe("Cluster upgrade", ClusterUpgradeTest)
 
 func ClusterUpgradeTest() {
-	flag.Parse()
 
 	BeforeEach(func() {
 		RegisterFailHandler(Fail)

--- a/functests/ocs/cluster_upgrade_test.go
+++ b/functests/ocs/cluster_upgrade_test.go
@@ -7,8 +7,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	tests "github.com/openshift/ocs-operator/functests"
-
-	deploymanager "github.com/openshift/ocs-operator/pkg/deploy-manager"
 )
 
 var _ = PDescribe("Cluster upgrade", ClusterUpgradeTest)
@@ -43,8 +41,7 @@ func ClusterUpgradeTest() {
 
 		Context("upgrade cluster", func() {
 			It("and verify deployment status", func() {
-				deployManager, err := deploymanager.NewDeployManager()
-				Expect(err).To(BeNil())
+				deployManager := tests.DeployManager
 
 				By("Getting the current csv before the upgrade")
 				csv, err := deployManager.GetCsv()

--- a/functests/ocs/storagecluster_creation_test.go
+++ b/functests/ocs/storagecluster_creation_test.go
@@ -11,7 +11,6 @@ import (
 	tests "github.com/openshift/ocs-operator/functests"
 	ocsv1 "github.com/openshift/ocs-operator/pkg/apis/ocs/v1"
 	"github.com/openshift/ocs-operator/pkg/controller/util"
-	deploymanager "github.com/openshift/ocs-operator/pkg/deploy-manager"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +31,7 @@ func initSCCreation() (*SCCreation, error) {
 }
 
 func (sccObj *SCCreation) populateDuplicateSC() error {
-	defaultStorageCluster, err := deploymanager.DefaultStorageCluster()
+	defaultStorageCluster, err := tests.DeployManager.DefaultStorageCluster()
 	if err != nil {
 		return err
 	}

--- a/functests/setup_teardown.go
+++ b/functests/setup_teardown.go
@@ -1,14 +1,11 @@
 package functests
 
 import (
-	"flag"
-
 	"github.com/onsi/gomega"
 )
 
 // BeforeTestSuiteSetup is the function called to initialize the test environment
 func BeforeTestSuiteSetup() {
-	flag.Parse()
 
 	debug("BeforeTestSuite: deploying OCS\n")
 	err := DeployManager.DeployOCSWithOLM(OcsRegistryImage, OcsSubscriptionChannel)
@@ -28,7 +25,6 @@ func BeforeTestSuiteSetup() {
 
 // AfterTestSuiteCleanup is the function called to tear down the test environment
 func AfterTestSuiteCleanup() {
-	flag.Parse()
 
 	debug("\n------------------------------\n")
 
@@ -52,7 +48,6 @@ func AfterTestSuiteCleanup() {
 
 // AfterUpgradeTestSuiteCleanup is the function called to tear down the test environment after upgrade failure
 func AfterUpgradeTestSuiteCleanup() {
-	flag.Parse()
 
 	err := DeployManager.DeleteNamespaceAndWait(TestNamespace)
 	gomega.Expect(err).To(gomega.BeNil())
@@ -64,7 +59,6 @@ func AfterUpgradeTestSuiteCleanup() {
 
 // BeforeUpgradeTestSuiteSetup is the function called to initialize the test environment to the upgrade_from version
 func BeforeUpgradeTestSuiteSetup() {
-	flag.Parse()
 
 	err := DeployManager.CreateNamespace(TestNamespace)
 	gomega.Expect(err).To(gomega.BeNil())

--- a/functests/setup_teardown.go
+++ b/functests/setup_teardown.go
@@ -4,26 +4,23 @@ import (
 	"flag"
 
 	"github.com/onsi/gomega"
-	deploymanager "github.com/openshift/ocs-operator/pkg/deploy-manager"
 )
 
 // BeforeTestSuiteSetup is the function called to initialize the test environment
 func BeforeTestSuiteSetup() {
 	flag.Parse()
 
-	t, err := deploymanager.NewDeployManager()
-	gomega.Expect(err).To(gomega.BeNil())
-
 	debug("BeforeTestSuite: deploying OCS\n")
-	err = t.DeployOCSWithOLM(OcsRegistryImage, OcsSubscriptionChannel)
+	err := DeployManager.DeployOCSWithOLM(OcsRegistryImage, OcsSubscriptionChannel)
 	gomega.Expect(err).To(gomega.BeNil())
 
 	debug("BeforeTestSuite: starting default StorageCluster\n")
-	err = t.StartDefaultStorageCluster()
+	err = DeployManager.StartDefaultStorageCluster()
+
 	gomega.Expect(err).To(gomega.BeNil())
 
 	debug("BeforeTestSuite: creating Namespace %s\n", TestNamespace)
-	err = t.CreateNamespace(TestNamespace)
+	err = DeployManager.CreateNamespace(TestNamespace)
 	gomega.Expect(err).To(gomega.BeNil())
 
 	debug("------------------------------\n")
@@ -33,25 +30,22 @@ func BeforeTestSuiteSetup() {
 func AfterTestSuiteCleanup() {
 	flag.Parse()
 
-	t, err := deploymanager.NewDeployManager()
-	gomega.Expect(err).To(gomega.BeNil())
-
 	debug("\n------------------------------\n")
 
 	// collect debug log before deleting namespace & cluster
 	if SuiteFailed {
 		debug("AfterTestSuite: collecting debug information\n")
-		err = RunMustGather()
+		err := RunMustGather()
 		gomega.Expect(err).To(gomega.BeNil())
 	}
 
 	debug("AfterTestSuite: deleting Namespace %s\n", TestNamespace)
-	err = t.DeleteNamespaceAndWait(TestNamespace)
+	err := DeployManager.DeleteNamespaceAndWait(TestNamespace)
 	gomega.Expect(err).To(gomega.BeNil())
 
 	if ocsClusterUninstall {
 		debug("AfterTestSuite: uninstalling OCS\n")
-		err = t.UninstallOCS(OcsRegistryImage, OcsSubscriptionChannel)
+		err = DeployManager.UninstallOCS(OcsRegistryImage, OcsSubscriptionChannel)
 		gomega.Expect(err).To(gomega.BeNil(), "error uninstalling OCS: %v", err)
 	}
 }
@@ -59,14 +53,12 @@ func AfterTestSuiteCleanup() {
 // AfterUpgradeTestSuiteCleanup is the function called to tear down the test environment after upgrade failure
 func AfterUpgradeTestSuiteCleanup() {
 	flag.Parse()
-	t, err := deploymanager.NewDeployManager()
-	gomega.Expect(err).To(gomega.BeNil())
 
-	err = t.DeleteNamespaceAndWait(TestNamespace)
+	err := DeployManager.DeleteNamespaceAndWait(TestNamespace)
 	gomega.Expect(err).To(gomega.BeNil())
 
 	// Only called after upgrade failures, so the cluster has to be uninstalled.
-	err = t.UninstallOCS(OcsRegistryImage, OcsSubscriptionChannel)
+	err = DeployManager.UninstallOCS(OcsRegistryImage, OcsSubscriptionChannel)
 	gomega.Expect(err).To(gomega.BeNil())
 }
 
@@ -74,15 +66,12 @@ func AfterUpgradeTestSuiteCleanup() {
 func BeforeUpgradeTestSuiteSetup() {
 	flag.Parse()
 
-	t, err := deploymanager.NewDeployManager()
+	err := DeployManager.CreateNamespace(TestNamespace)
 	gomega.Expect(err).To(gomega.BeNil())
 
-	err = t.CreateNamespace(TestNamespace)
+	err = DeployManager.DeployOCSWithOLM(UpgradeFromOcsRegistryImage, UpgradeFromOcsSubscriptionChannel)
 	gomega.Expect(err).To(gomega.BeNil())
 
-	err = t.DeployOCSWithOLM(UpgradeFromOcsRegistryImage, UpgradeFromOcsSubscriptionChannel)
-	gomega.Expect(err).To(gomega.BeNil())
-
-	err = t.StartDefaultStorageCluster()
+	err = DeployManager.StartDefaultStorageCluster()
 	gomega.Expect(err).To(gomega.BeNil())
 }

--- a/pkg/deploy-manager/config.go
+++ b/pkg/deploy-manager/config.go
@@ -27,8 +27,11 @@ const DefaultStorageClusterName = "test-storagecluster"
 // DefaultStorageClassRBD is the name of the ceph rbd storage class the test suite installs
 const DefaultStorageClassRBD = DefaultStorageClusterName + "-ceph-rbd"
 
-// MinOSDsCount represents the minimum number of OSDs required for this testsuite to run.
-const MinOSDsCount = 3
+const minOSDsCount = 3
+
+func (t *DeployManager) getMinOSDsCount() int {
+	return minOSDsCount
+}
 
 //nolint:errcheck // ignoring err check as causing failures
 func init() {

--- a/pkg/deploy-manager/config.go
+++ b/pkg/deploy-manager/config.go
@@ -40,14 +40,33 @@ func init() {
 	nbv1.SchemeBuilder.AddToScheme(scheme.Scheme)
 }
 
+// storageClusterConfig stores the configuration of the Storage Cluster that is/will be
+// created by the deploy manager.
+type storageClusterConfig struct {
+	// As deploy manager is mainly used as a replacement for openshift/console,
+	// this should capture the options that are presented in the console for OCS
+	// installation.
+	// For example Encryption, Arbiter etc
+	// Eligibility Check:
+	// Is this option presented in the console and/or does this option cause a
+	// change in the inital Storage Cluster CR provided to the ocs-operator? Yes, it belongs here.
+
+	// Functional tests also use the deploy manager for deployment and if any
+	// state needs to be stored for the storageCluster, it belongs here.
+
+	// TODO: Move all the in-built defaults to this struct. These defaults are
+	// either hardcoded or are defined as globals in the deploy manager.
+}
+
 // DeployManager is a util tool used by the functional tests
 type DeployManager struct {
-	olmClient      *olmclient.Clientset
-	k8sClient      *kubernetes.Clientset
-	rookClient     *rookclient.Clientset
-	ocsClient      *rest.RESTClient
-	crClient       crclient.Client
-	parameterCodec runtime.ParameterCodec
+	olmClient          *olmclient.Clientset
+	k8sClient          *kubernetes.Clientset
+	rookClient         *rookclient.Clientset
+	ocsClient          *rest.RESTClient
+	crClient           crclient.Client
+	parameterCodec     runtime.ParameterCodec
+	storageClusterConf *storageClusterConfig
 }
 
 // GetCrClient is the function used to retrieve the controller-runtime client
@@ -80,7 +99,7 @@ func (t *DeployManager) GetNamespace() string {
 	return InstallNamespace
 }
 
-// NewDeployManager is the way to create a DeployManager struct
+// NewDeployManager creates a DeployManager struct with default configuration
 func NewDeployManager() (*DeployManager, error) {
 	codecs := serializer.NewCodecFactory(scheme.Scheme)
 	parameterCodec := runtime.NewParameterCodec(scheme.Scheme)
@@ -149,12 +168,19 @@ func NewDeployManager() (*DeployManager, error) {
 		return nil, err
 	}
 
+	storageClusterConf := getDefaultStorageClusterConfig()
+
 	return &DeployManager{
-		olmClient:      olmClient,
-		k8sClient:      k8sClient,
-		rookClient:     rookClient,
-		ocsClient:      ocsClient,
-		crClient:       crClient,
-		parameterCodec: parameterCodec,
+		olmClient:          olmClient,
+		k8sClient:          k8sClient,
+		rookClient:         rookClient,
+		ocsClient:          ocsClient,
+		crClient:           crClient,
+		parameterCodec:     parameterCodec,
+		storageClusterConf: storageClusterConf,
 	}, nil
+}
+
+func getDefaultStorageClusterConfig() *storageClusterConfig {
+	return &storageClusterConfig{}
 }

--- a/pkg/deploy-manager/storagecluster.go
+++ b/pkg/deploy-manager/storagecluster.go
@@ -54,7 +54,7 @@ func (t *DeployManager) StartDefaultStorageCluster() error {
 }
 
 // DefaultStorageCluster returns a default StorageCluster manifest
-func DefaultStorageCluster() (*ocsv1.StorageCluster, error) {
+func (t *DeployManager) DefaultStorageCluster() (*ocsv1.StorageCluster, error) {
 	monQuantity, err := resource.ParseQuantity("10Gi")
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func DefaultStorageCluster() (*ocsv1.StorageCluster, error) {
 			StorageDeviceSets: []ocsv1.StorageDeviceSet{
 				{
 					Name:     "example-deviceset",
-					Count:    MinOSDsCount,
+					Count:    t.getMinOSDsCount(),
 					Portable: true,
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
@@ -174,7 +174,7 @@ func (t *DeployManager) getStorageCluster() (*ocsv1.StorageCluster, error) {
 func (t *DeployManager) createStorageCluster() (*ocsv1.StorageCluster, error) {
 	newSc := &ocsv1.StorageCluster{}
 
-	sc, err := DefaultStorageCluster()
+	sc, err := t.DefaultStorageCluster()
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +196,7 @@ func (t *DeployManager) createStorageCluster() (*ocsv1.StorageCluster, error) {
 
 // deleteStorageCluster is used to delete the test suite storage cluster
 func (t *DeployManager) deleteStorageCluster() error {
-	sc, err := DefaultStorageCluster()
+	sc, err := t.DefaultStorageCluster()
 	if err != nil {
 		return err
 	}
@@ -310,8 +310,8 @@ func (t *DeployManager) WaitOnStorageCluster() error {
 			}
 		}
 
-		if osdsOnline < MinOSDsCount {
-			lastReason = fmt.Sprintf("%d/%d expected OSDs are online", osdsOnline, MinOSDsCount)
+		if osdsOnline < t.getMinOSDsCount() {
+			lastReason = fmt.Sprintf("%d/%d expected OSDs are online", osdsOnline, t.getMinOSDsCount())
 		}
 
 		// expect noobaa-core pod with label selector (noobaa-core=noobaa) to be running
@@ -377,8 +377,8 @@ func (t *DeployManager) labelWorkerNodes() error {
 		labeledCount++
 	}
 
-	if labeledCount < MinOSDsCount {
-		return fmt.Errorf("Only %d worker nodes found when we need %d to deploy", labeledCount, MinOSDsCount)
+	if labeledCount < t.getMinOSDsCount() {
+		return fmt.Errorf("Only %d worker nodes found when we need %d to deploy", labeledCount, t.getMinOSDsCount())
 	}
 
 	return nil


### PR DESCRIPTION
This will be required for testing scenarios where we want to install StorageClusters that are not of default config.

This is in preparation to the arbiter feature.