### PR TITLE
Updated OCS telemeter rule name to match with OCP pattern

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: openshift-storage
 spec:
   groups:
-  - name: ocs_telemetry.rules
+  - name: ocs-telemeter.rules
     rules:
     - expr: "sum(\n  max(\n    (\n      kube_pod_container_resource_requests_cpu_cores{namespace=\"openshift-storage\",
         pod =~\"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)\"} *

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: openshift-storage
 spec:
   groups:
-  - name: ocs_telemetry.rules
+  - name: ocs-telemeter.rules
     rules:
     - expr: "sum(\n  max(\n    (\n      kube_pod_container_resource_requests_cpu_cores{namespace=\"openshift-storage\",
         pod =~\"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)\"} *

--- a/metrics/mixin/rules/rules.libsonnet
+++ b/metrics/mixin/rules/rules.libsonnet
@@ -2,7 +2,7 @@
   prometheusRules+:: {
     groups+: [
       {
-        name: 'ocs_telemetry.rules',
+        name: 'ocs-telemeter.rules',
         rules: [
           {
             record: 'ocs:node_num_cpu:sum',


### PR DESCRIPTION
Signed-off-by: Anmol Sachan <anmol13694@gmail.com>

This is done to follow the convention OCP team follows as all the customers can see names of these rules.
