### PR TITLE
cephcluster: add annotation for each deviceType in cephCR

### DIFF
--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -471,6 +471,12 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 				placement = ds.Placement
 			}
 
+			// Annotation crushDeviceClass ensures osd with different CRUSH device class than the one detected by Ceph
+			annotations := map[string]string{
+				"crushDeviceClass": ds.DeviceType,
+			}
+			ds.DataPVCTemplate.Annotations = annotations
+
 			set := rook.StorageClassDeviceSet{
 				Name:                 fmt.Sprintf("%s-%d", ds.Name, i),
 				Count:                count,

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -70,8 +70,14 @@ var mockCephClusterNamespacedName = types.NamespacedName{
 
 var storageClassName = "gp2"
 var volMode = corev1.PersistentVolumeBlock
+var annotations = map[string]string{
+	"crushDeviceClass": "",
+}
 
 var mockDataPVCTemplate = corev1.PersistentVolumeClaim{
+	ObjectMeta: metav1.ObjectMeta{
+		Annotations: annotations,
+	},
 	Spec: corev1.PersistentVolumeClaimSpec{
 		AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		Resources: corev1.ResourceRequirements{


### PR DESCRIPTION
Problem:  crushDeviceClass annotations not being reflected in cephCR.

Important: So to verify that deviceClass for an osd is updated. Though it logical grouping. Won't effect the performance.

Solution: set annotation in cephCR.

Signed-off-by: crombus <pkundra@redhat.com>