### PR TITLE
storagecluster: remove the deviceType from validateStorageDeviceSets

### DIFF
--- a/pkg/controller/storagecluster/reconcile.go
+++ b/pkg/controller/storagecluster/reconcile.go
@@ -426,9 +426,7 @@ func (r *ReconcileStorageCluster) validateStorageDeviceSets(sc *ocsv1.StorageClu
 			}
 		}
 		if ds.DeviceType != "" {
-			if (DeviceTypeSSD == strings.ToLower(ds.DeviceType)) || (DeviceTypeHDD == strings.ToLower(ds.DeviceType)) || (DeviceTypeNVMe == strings.ToLower(ds.DeviceType)) {
-				metav1.SetMetaDataAnnotation(&sc.ObjectMeta, "crushDeviceClass", ds.DeviceType)
-			} else {
+			if (DeviceTypeSSD != strings.ToLower(ds.DeviceType)) && (DeviceTypeHDD != strings.ToLower(ds.DeviceType)) && (DeviceTypeNVMe != strings.ToLower(ds.DeviceType)) {
 				return fmt.Errorf("failed to validate DeviceType %q: no Device of this type", ds.DeviceType)
 			}
 		}


### PR DESCRIPTION
Remove the metadata setting from storage cluster as it is benefiting nothing.
just check for invalid deviceType and throw error.


Signed-off-by: crombus <pkundra@redhat.com>