### PR TITLE
Refactor device tuning code

### DIFF
--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -65,7 +65,7 @@ func (r *ReconcileStorageCluster) ensureCephCluster(sc *ocsv1.StorageCluster, re
 	for i, ds := range sc.Spec.StorageDeviceSets {
 		tuneSlow, tuneFast, err := r.checkTuneStorageDevices(*ds.DataPVCTemplate.Spec.StorageClassName)
 		if err != nil {
-			return fmt.Errorf("Failed to verify StorageClass provisioner. %+v", err)
+			return fmt.Errorf("Failed to check for known device types: %+v", err)
 		}
 		sc.Spec.StorageDeviceSets[i].Config.TuneSlowDeviceClass = tuneSlow
 		sc.Spec.StorageDeviceSets[i].Config.TuneFastDeviceClass = tuneFast

--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -65,12 +65,12 @@ func (r *ReconcileStorageCluster) ensureCephCluster(sc *ocsv1.StorageCluster, re
 	// this is for performance optimization of slow device class
 	//TODO: If for a StorageDeviceSet there is a separate metadata pvc template, check for StorageClass of data pvc template only
 	for i, ds := range sc.Spec.StorageDeviceSets {
-		throttleSlow, throttleFast, err := r.throttleStorageDevices(*ds.DataPVCTemplate.Spec.StorageClassName)
+		tuneSlow, tuneFast, err := r.throttleStorageDevices(*ds.DataPVCTemplate.Spec.StorageClassName)
 		if err != nil {
 			return fmt.Errorf("Failed to verify StorageClass provisioner. %+v", err)
 		}
-		sc.Spec.StorageDeviceSets[i].Config.TuneSlowDeviceClass = throttleSlow
-		sc.Spec.StorageDeviceSets[i].Config.TuneFastDeviceClass = throttleFast
+		sc.Spec.StorageDeviceSets[i].Config.TuneSlowDeviceClass = tuneSlow
+		sc.Spec.StorageDeviceSets[i].Config.TuneFastDeviceClass = tuneFast
 	}
 
 	if isMultus(sc.Spec.Network) {

--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -509,6 +509,9 @@ func newCephDaemonResources(custom map[string]corev1.ResourceRequirements) map[s
 	return resources
 }
 
+// The checkTuneStorageDevices function checks whether devices from the given
+// storage class are a known type that should expclitly be tuned for fast or
+// slow access.
 func (r *ReconcileStorageCluster) checkTuneStorageDevices(storageClassName string) (bool, bool, error) {
 	storageClass := &storagev1.StorageClass{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: storageClassName}, storageClass)

--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -25,9 +25,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-var throttleDiskTypes = []string{"gp2", "io1"}
+var knownSlowDiskTypes = []string{"gp2", "io1"}
 
-var throttleFastDiskTypes = []string{"managed-premium"}
+var knownFastDiskTypes = []string{"managed-premium"}
 
 const (
 	// Hardcoding networkProvider to multus and this can be changed later to accomodate other providers
@@ -499,11 +499,11 @@ func (r *ReconcileStorageCluster) throttleStorageDevices(storageClassName string
 
 	switch storageClass.Provisioner {
 	case string(EBS):
-		if contains(throttleDiskTypes, storageClass.Parameters["type"]) {
+		if contains(knownSlowDiskTypes, storageClass.Parameters["type"]) {
 			return true, false, nil
 		}
 	case string(AzureDisk):
-		if contains(throttleFastDiskTypes, storageClass.Parameters["type"]) {
+		if contains(knownFastDiskTypes, storageClass.Parameters["type"]) {
 			return false, true, nil
 		}
 	}

--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -65,7 +65,7 @@ func (r *ReconcileStorageCluster) ensureCephCluster(sc *ocsv1.StorageCluster, re
 	// this is for performance optimization of slow device class
 	//TODO: If for a StorageDeviceSet there is a separate metadata pvc template, check for StorageClass of data pvc template only
 	for i, ds := range sc.Spec.StorageDeviceSets {
-		tuneSlow, tuneFast, err := r.throttleStorageDevices(*ds.DataPVCTemplate.Spec.StorageClassName)
+		tuneSlow, tuneFast, err := r.checkTuneStorageDevices(*ds.DataPVCTemplate.Spec.StorageClassName)
 		if err != nil {
 			return fmt.Errorf("Failed to verify StorageClass provisioner. %+v", err)
 		}
@@ -509,7 +509,7 @@ func newCephDaemonResources(custom map[string]corev1.ResourceRequirements) map[s
 	return resources
 }
 
-func (r *ReconcileStorageCluster) throttleStorageDevices(storageClassName string) (bool, bool, error) {
+func (r *ReconcileStorageCluster) checkTuneStorageDevices(storageClassName string) (bool, bool, error) {
 	storageClass := &storagev1.StorageClass{}
 	err := r.client.Get(context.TODO(), types.NamespacedName{Namespace: "", Name: storageClassName}, storageClass)
 	if err != nil {

--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -61,9 +61,7 @@ func (r *ReconcileStorageCluster) ensureCephCluster(sc *ocsv1.StorageCluster, re
 	if sc.Spec.ExternalStorage.Enable && len(sc.Spec.StorageDeviceSets) != 0 {
 		return fmt.Errorf("'StorageDeviceSets' should not be initialized in an external CephCluster")
 	}
-	// if StorageClass is "gp2" or "io1" based, set tuneSlowDeviceClass to true
-	// this is for performance optimization of slow device class
-	//TODO: If for a StorageDeviceSet there is a separate metadata pvc template, check for StorageClass of data pvc template only
+
 	for i, ds := range sc.Spec.StorageDeviceSets {
 		tuneSlow, tuneFast, err := r.checkTuneStorageDevices(*ds.DataPVCTemplate.Spec.StorageClassName)
 		if err != nil {

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -253,8 +253,7 @@ func TestThrottleStorageDevices(t *testing.T) {
 		label          string
 		storageClass   *storagev1.StorageClass
 		storageCluster *api.StorageCluster
-		expectedSlow   bool
-		expectedFast   bool
+		expectedSpeed  diskSpeed
 	}{
 		{
 			label: "Case 1", // storageclass is gp2 or io1
@@ -268,8 +267,7 @@ func TestThrottleStorageDevices(t *testing.T) {
 				},
 			},
 			storageCluster: &api.StorageCluster{},
-			expectedSlow:   true,
-			expectedFast:   false,
+			expectedSpeed:  diskSpeedSlow,
 		},
 		{
 			label: "Case 2", // storageclass is neither gp2 nor io1
@@ -283,8 +281,7 @@ func TestThrottleStorageDevices(t *testing.T) {
 				},
 			},
 			storageCluster: &api.StorageCluster{},
-			expectedSlow:   false,
-			expectedFast:   false,
+			expectedSpeed:  diskSpeedUnknown,
 		},
 		{
 			label: "Case 3", // storageclass is managed-premium
@@ -298,17 +295,15 @@ func TestThrottleStorageDevices(t *testing.T) {
 				},
 			},
 			storageCluster: &api.StorageCluster{},
-			expectedSlow:   false,
-			expectedFast:   true,
+			expectedSpeed:  diskSpeedFast,
 		},
 	}
 
 	for _, tc := range testcases {
 		reconciler := createFakeStorageClusterReconciler(t, tc.storageCluster, tc.storageClass)
-		actualSlow, actualFast, err := reconciler.checkTuneStorageDevices(tc.storageClass.Name)
+		actualSpeed, err := reconciler.checkTuneStorageDevices(tc.storageClass.Name)
 		assert.NoError(t, err)
-		assert.Equalf(t, tc.expectedSlow, actualSlow, "[%q]: failed to get expected output", tc.label)
-		assert.Equalf(t, tc.expectedFast, actualFast, "[%q]: failed to get expected output", tc.label)
+		assert.Equalf(t, tc.expectedSpeed, actualSpeed, "[%q]: failed to get expected output", tc.label)
 	}
 }
 

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -305,7 +305,7 @@ func TestThrottleStorageDevices(t *testing.T) {
 
 	for _, tc := range testcases {
 		reconciler := createFakeStorageClusterReconciler(t, tc.storageCluster, tc.storageClass)
-		actualSlow, actualFast, err := reconciler.throttleStorageDevices(tc.storageClass.Name)
+		actualSlow, actualFast, err := reconciler.checkTuneStorageDevices(tc.storageClass.Name)
 		assert.NoError(t, err)
 		assert.Equalf(t, tc.expectedSlow, actualSlow, "[%q]: failed to get expected output", tc.label)
 		assert.Equalf(t, tc.expectedFast, actualFast, "[%q]: failed to get expected output", tc.label)


### PR DESCRIPTION
Reviewing PR #864 made me consider the naming of functions and variables and the structure of functions. I found it confusing that it talked about throttling internally and converted this to tuning toggles for rook, while ocs-operator is not doing any throttling. Furthermore, having two lists of fast and slow device storage classes, but having the the detection function hardcode which provisioner to apply each list against did not seem very intuitive and robust to me.

This PR refactors the code to be (IMHO) more obvious and more prone to future expansions of known devices.