### PR TITLE
update crd changes for TuneFastDeviceClass

### DIFF
--- a/deploy/csv-templates/crds/ocs.openshift.io_storageclusters_crd.yaml
+++ b/deploy/csv-templates/crds/ocs.openshift.io_storageclusters_crd.yaml
@@ -1251,6 +1251,10 @@ spec:
                         rook-ceph'
                       type: object
                       properties:
+                        tuneFastDeviceClass:
+                          description: TuneFastDeviceClass tunes the OSD when running
+                            on a fast Device Class
+                          type: boolean
                         tuneSlowDeviceClass:
                           description: TuneSlowDeviceClass tunes the OSD when running
                             on a slow Device Class

--- a/deploy/olm-catalog/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/storagecluster.crd.yaml
@@ -796,6 +796,9 @@ spec:
                     config:
                       description: 'StorageDeviceSetConfig defines Ceph OSD specific config options for the StorageDeviceSet TODO: Fill in the members when the actual configurable options are defined in rook-ceph'
                       properties:
+                        tuneFastDeviceClass:
+                          description: TuneFastDeviceClass tunes the OSD when running on a fast Device Class
+                          type: boolean
                         tuneSlowDeviceClass:
                           description: TuneSlowDeviceClass tunes the OSD when running on a slow Device Class
                           type: boolean


### PR DESCRIPTION
A new property TuneFastDeviceClass was added to the Storage Cluster
spec in PR #864. This commit adds the generated changes for that.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>