### PR TITLE
cephcluster: tune disks according to plaftorm

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -641,6 +641,14 @@ func (r *StorageClusterReconciler) checkTuneStorageDevices(ds ocsv1.StorageDevic
 		return dt.speed, nil
 	}
 
+	tuneFastDevices, err := r.DevicesDefaultToFastForThisPlatform()
+	if err != nil {
+		return diskSpeedUnknown, err
+	}
+	if tuneFastDevices {
+		return diskSpeedFast, nil
+	}
+
 	// not a known disk type, don't tune
 	return diskSpeedUnknown, nil
 }

--- a/controllers/storagecluster/platform_detection.go
+++ b/controllers/storagecluster/platform_detection.go
@@ -18,6 +18,13 @@ var AvoidObjectStorePlatforms = []configv1.PlatformType{
 	configv1.AzurePlatformType,
 }
 
+// TuneFastPlatforms is a list of all PlatformTypes where TuneFastDeviceClass has to be set True.
+var TuneFastPlatforms = []configv1.PlatformType{
+	configv1.OvirtPlatformType,
+	configv1.IBMCloudPlatformType,
+	configv1.AzurePlatformType,
+}
+
 // Platform is used to get the CloudPlatformType of the running cluster in a thread-safe manner
 type Platform struct {
 	platform configv1.PlatformType
@@ -54,4 +61,20 @@ func avoidObjectStore(p configv1.PlatformType) bool {
 		}
 	}
 	return false
+}
+
+func (r *StorageClusterReconciler) DevicesDefaultToFastForThisPlatform() (bool, error) {
+	c := r.Client
+	platform, err := r.platform.GetPlatform(c)
+	if err != nil {
+		return false, err
+	}
+
+	for _, tfplatform := range TuneFastPlatforms {
+		if platform == tfplatform {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -852,7 +852,7 @@ func createFakeStorageClusterReconciler(t *testing.T, obj ...runtime.Object) Sto
 		Scheme:        scheme,
 		serverVersion: &k8sVersion.Info{},
 		Log:           logf.Log.WithName("controller_storagecluster_test"),
-		platform:      &Platform{},
+		platform:      &Platform{platform: configv1.NonePlatformType},
 	}
 }
 


### PR DESCRIPTION
set tunefastdeviceclass according to plaftorm
which are not correctly detected by ceph.
modify tc according to the changes.

Signed-off-by: crombus <pkundra@redhat.com>