### PR TITLE
Add configurable number of CephObjectStore gateway instances

### DIFF
--- a/deploy/crds/ocs.openshift.io_storageclusters_crd.yaml
+++ b/deploy/crds/ocs.openshift.io_storageclusters_crd.yaml
@@ -169,6 +169,9 @@ spec:
                     properties:
                       disableStorageClass:
                         type: boolean
+                      gatewayInstances:
+                        type: integer
+                        format: int32
                       reconcileStrategy:
                         type: string
               monDataDirHostPath:

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters_crd.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters_crd.yaml
@@ -169,6 +169,9 @@ spec:
                     properties:
                       disableStorageClass:
                         type: boolean
+                      gatewayInstances:
+                        type: integer
+                        format: int32
                       reconcileStrategy:
                         type: string
               monDataDirHostPath:

--- a/deploy/olm-catalog/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/storagecluster.crd.yaml
@@ -139,6 +139,9 @@ spec:
                     properties:
                       disableStorageClass:
                         type: boolean
+                      gatewayInstances:
+                        format: int32
+                        type: integer
                       reconcileStrategy:
                         type: string
                     type: object

--- a/pkg/apis/ocs/v1/storagecluster_types.go
+++ b/pkg/apis/ocs/v1/storagecluster_types.go
@@ -78,6 +78,7 @@ type ManageCephFilesystems struct {
 type ManageCephObjectStores struct {
 	ReconcileStrategy   string `json:"reconcileStrategy,omitempty"`
 	DisableStorageClass bool   `json:"disableStorageClass,omitempty"`
+	GatewayInstances    int32  `json:"gatewayInstances,omitempty"`
 }
 
 // ManageCephObjectStoreUsers defines how to reconcile CephObjectStoreUsers

--- a/pkg/controller/defaults/defaults.go
+++ b/pkg/controller/defaults/defaults.go
@@ -27,4 +27,6 @@ var (
 	// DeviceSetReplica is the default number of Rook-Ceph
 	// StorageClassDeviceSets per StorageCluster StorageDeviceSet
 	DeviceSetReplica = 3
+	// CephObjectStoreGatewayInstances is the default number of RGW instances to create
+	CephObjectStoreGatewayInstances = 1
 )

--- a/pkg/controller/storagecluster/cephobjectstores.go
+++ b/pkg/controller/storagecluster/cephobjectstores.go
@@ -83,6 +83,10 @@ func (r *ReconcileStorageCluster) createCephObjectStores(cephObjectStores []*cep
 // newCephObjectStoreInstances returns the cephObjectStore instances that should be created
 // on first run.
 func (r *ReconcileStorageCluster) newCephObjectStoreInstances(initData *ocsv1.StorageCluster, reqLogger logr.Logger) ([]*cephv1.CephObjectStore, error) {
+	gatewayInstances := initData.Spec.ManagedResources.CephObjectStores.GatewayInstances
+	if gatewayInstances == 0 {
+		gatewayInstances = int32(defaults.CephObjectStoreGatewayInstances)
+	}
 	ret := []*cephv1.CephObjectStore{
 		{
 			ObjectMeta: metav1.ObjectMeta{
@@ -106,7 +110,7 @@ func (r *ReconcileStorageCluster) newCephObjectStoreInstances(initData *ocsv1.St
 				},
 				Gateway: cephv1.GatewaySpec{
 					Port:      80,
-					Instances: 2,
+					Instances: gatewayInstances,
 					Placement: getPlacement(initData, "rgw"),
 					Resources: defaults.GetDaemonResources("rgw", initData.Spec.Resources),
 				},

--- a/pkg/controller/storagecluster/cephobjectstores_test.go
+++ b/pkg/controller/storagecluster/cephobjectstores_test.go
@@ -55,11 +55,15 @@ func assertCephObjectStores(t *testing.T, reconciler ReconcileStorageCluster, cr
 		assert.Equal(t, expectedCos[0].ObjectMeta.Name, actualCos.ObjectMeta.Name)
 		assert.Equal(t, expectedCos[0].Spec, actualCos.Spec)
 		assert.Condition(
-			t, func() bool { return expectedCos[0].Spec.Gateway.Instances > 1 },
-			"there should be multiple 'Spec.Gateway.Instances'")
+			t, func() bool { return expectedCos[0].Spec.Gateway.Instances == 1 },
+			"there should be one 'Spec.Gateway.Instances' by default")
 		assert.Equal(
 			t, expectedCos[0].Spec.Gateway.Placement, getPlacement(cr, "rgw"))
 	}
 
 	assert.Equal(t, len(expectedCos[0].OwnerReferences), 1)
+
+	cr.Spec.ManagedResources.CephObjectStores.GatewayInstances = 2
+	expectedCos, _ = reconciler.newCephObjectStoreInstances(cr, reconciler.reqLogger)
+	assert.Equal(t, expectedCos[0].Spec.Gateway.Instances, int32(2))
 }


### PR DESCRIPTION
In many use cases, 1 is the most sensible number of RGW instances
to create in a StorageCluster, but it is necessary to allow the
user to create more. This change makes this value configurable
with a default of 1.

Signed-off-by: egafford <egafford@redhat.com>