### PR TITLE
Update csv

### DIFF
--- a/deploy/csv-templates/crds/ocs.openshift.io_storageclusters_crd.yaml
+++ b/deploy/csv-templates/crds/ocs.openshift.io_storageclusters_crd.yaml
@@ -3562,7 +3562,7 @@ spec:
                   to distribute its data replicas for the default CephBlockPool
                 type: string
               images:
-                description: Images holds the image reconclie status for all images
+                description: Images holds the image reconcile status for all images
                   reconciled by the operator
                 type: object
                 properties:

--- a/deploy/olm-catalog/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/storagecluster.crd.yaml
@@ -2168,7 +2168,7 @@ spec:
                 description: FailureDomain is the base CRUSH element Ceph will use to distribute its data replicas for the default CephBlockPool
                 type: string
               images:
-                description: Images holds the image reconclie status for all images reconciled by the operator
+                description: Images holds the image reconcile status for all images reconciled by the operator
                 properties:
                   ceph:
                     description: ComponentImageStatus holds image status information for a specific component image


### PR DESCRIPTION
This was missing, and missing csv updates are not caught by the CI in
the PR... :-/

I don't actually understand where the typo 'reconclie' comes from.
It was added in PR #885, but that same PR added it correctly spelled
in the CRDs... Anyway.

Signed-off-by: Michael Adam <obnox@redhat.com>