### PR TITLE
Upgrade rook to v1.5.3

### DIFF
--- a/deploy/csv-templates/crds/rook/cephclusters.ceph.rook.io.crds.yaml
+++ b/deploy/csv-templates/crds/rook/cephclusters.ceph.rook.io.crds.yaml
@@ -277,6 +277,10 @@ spec:
                         properties:
                           ip:
                             type: string
+                    externalMgrPrometheusPort:
+                      type: integer
+                      minimum: 0
+                      maximum: 65535
                 removeOSDsIfOutAndSafeToRemove:
                   type: boolean
                 external:
@@ -316,6 +320,13 @@ spec:
                           x-kubernetes-preserve-unknown-fields: true
                         tokenSecretName:
                           type: string
+                logCollector:
+                  type: object
+                  properties:
+                    enabled:
+                      type: boolean
+                    periodicity:
+                      type: string
                 annotations:
                   type: object
                   nullable: true

--- a/deploy/csv-templates/rook-csv.yaml.in
+++ b/deploy/csv-templates/rook-csv.yaml.in
@@ -13,7 +13,7 @@ metadata:
           },
           "spec": {
             "cephVersion": {
-              "image": "ceph/ceph:v15.2.5"
+              "image": "ceph/ceph:v15.2.7"
             },
             "dataDirHostPath": "/var/lib/rook",
             "mon": {

--- a/deploy/olm-catalog/ocs-operator/manifests/cephcluster.crd.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/cephcluster.crd.yaml
@@ -139,6 +139,13 @@ spec:
                 nullable: true
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
+              logCollector:
+                properties:
+                  enabled:
+                    type: boolean
+                  periodicity:
+                    type: string
+                type: object
               mgr:
                 properties:
                   modules:
@@ -194,6 +201,10 @@ spec:
                           type: string
                       type: object
                     type: array
+                  externalMgrPrometheusPort:
+                    maximum: 65535
+                    minimum: 0
+                    type: integer
                   rulesNamespace:
                     type: string
                 type: object

--- a/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -2430,7 +2430,7 @@ spec:
                 - name: OPERATOR_NAME
                   value: ocs-operator
                 - name: ROOK_CEPH_IMAGE
-                  value: rook/ceph:v1.5.1
+                  value: rook/ceph:v1.5.3
                 - name: CEPH_IMAGE
                   value: ceph/ceph:v14.2
                 - name: NOOBAA_CORE_IMAGE
@@ -2533,7 +2533,7 @@ spec:
                       fieldPath: metadata.namespace
                 - name: ROOK_OBC_WATCH_OPERATOR_NAMESPACE
                   value: "true"
-                image: rook/ceph:v1.5.1
+                image: rook/ceph:v1.5.3
                 name: rook-ceph-operator
                 resources: {}
                 volumeMounts:
@@ -2944,7 +2944,7 @@ spec:
   provider:
     name: Red Hat
   relatedImages:
-  - image: rook/ceph:v1.5.1
+  - image: rook/ceph:v1.5.3
     name: rook-container
   - image: ceph/ceph:v14.2
     name: ceph-container

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.43.0
 	github.com/prometheus/client_golang v1.8.0
 	github.com/prometheus/client_model v0.2.0
-	github.com/rook/rook v1.5.0-alpha.0.0.20201119164518-f86f8300f924
+	github.com/rook/rook v1.5.3
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -1565,6 +1565,8 @@ github.com/rollbar/rollbar-go v1.0.2/go.mod h1:AcFs5f0I+c71bpHlXNNDbOWJiKwjFDtIS
 github.com/rook/rook v1.4.6/go.mod h1:FQt7I3fXmOE5f/FEAnNWhB75JPTpJCf3MzXrwj9QjPw=
 github.com/rook/rook v1.5.0-alpha.0.0.20201119164518-f86f8300f924 h1:2T2XBguFMumW/Zu+DG364058uTTcoxyXSWPqCMLBfV4=
 github.com/rook/rook v1.5.0-alpha.0.0.20201119164518-f86f8300f924/go.mod h1:q+RpuxG7G8V+VJywuVN2pXUpwRlOzenPKg63qRjpQbU=
+github.com/rook/rook v1.5.3 h1:aS8PI1zED/atB5D3YRtDNJNroAtDqX5QfIZ8Y1PtjiI=
+github.com/rook/rook v1.5.3/go.mod h1:roeWqpWn20DVec1cRHeLCFDZLLaormP2vfkBSOKQhGI=
 github.com/rs/cors v1.6.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rubiojr/go-vhd v0.0.0-20200706105327-02e210299021/go.mod h1:DM5xW0nvfNNm2uytzsvhI3OnX8uzaRAg8UX/CnDqbto=
@@ -1675,6 +1677,7 @@ github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tebeka/strftime v0.1.3/go.mod h1:7wJm3dZlpr4l/oVK0t1HYIc4rMzQ2XJlOMIUJUJH6XQ=
+github.com/tevino/abool v1.2.0/go.mod h1:qc66Pna1RiIsPa7O4Egxxs9OqkuxDX55zznh9K07Tzg=
 github.com/thanos-io/thanos v0.8.1-0.20200109203923-552ffa4c1a0d/go.mod h1:usT/TxtJQ7DzinTt+G9kinDQmRS5sxwu0unVKZ9vdcw=
 github.com/thanos-io/thanos v0.11.0/go.mod h1:N/Yes7J68KqvmY+xM6J5CJqEvWIvKSR5sqGtmuD6wDc=
 github.com/thanos-io/thanos v0.13.1-0.20200731083140-69b87607decf/go.mod h1:G8caR6G7pSDreRDvFm9wFuyjEBztmr8Ag3kBYpa/fEc=

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -53,7 +53,7 @@ NOOBAA_CSV="$OUTDIR_TEMPLATES/noobaa-csv.yaml"
 ROOK_CSV="$OUTDIR_TEMPLATES/rook-csv.yaml.in"
 OCS_CSV="$OUTDIR_TEMPLATES/ocs-operator.csv.yaml.in"
 
-LATEST_ROOK_IMAGE="rook/ceph:v1.5.1"
+LATEST_ROOK_IMAGE="rook/ceph:v1.5.3"
 LATEST_NOOBAA_IMAGE="noobaa/noobaa-operator:5.7.0-20201216"
 LATEST_NOOBAA_CORE_IMAGE="noobaa/noobaa-core:5.7.0-20201216"
 LATEST_NOOBAA_DB_IMAGE="centos/mongodb-36-centos7"


### PR DESCRIPTION
Updating to latest rook version, v1.5.3, which brings the external port available through CephCluster spec.