### PR TITLE
Make cephcluster monitoring port, in external cluster mode, configurable

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -241,25 +241,21 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 		switch d.Kind {
 		case "CephCluster":
 			monitoringIP, ok := d.Data["MonitoringEndpoint"]
-			if !ok {
+			if !ok || monitoringIP == "" {
 				err := fmt.Errorf(
 					"Monitoring Endpoint not present in the external cluster secret %s",
 					externalClusterDetailsSecret)
 				r.Log.Error(err, "Failed to get Monitoring IP.")
 				return err
 			}
-			monitoringPort, ok := d.Data["MonitoringPort"]
-			if !ok {
-				err := fmt.Errorf(
-					"Monitoring Port not present in the external cluster secret %s",
-					externalClusterDetailsSecret)
-				r.Log.Error(err, "Failed to get Monitoring Port.")
-				return err
-			}
-			err := checkEndpointReachable(net.JoinHostPort(monitoringIP, monitoringPort), 5*time.Second)
-			if err != nil {
-				r.Log.Error(err, "Monitoring validation failed")
-				return err
+			monitoringPort := d.Data["MonitoringPort"]
+			if monitoringPort != "" {
+				err := checkEndpointReachable(net.JoinHostPort(monitoringIP, monitoringPort), 5*time.Second)
+				if err != nil {
+					r.Log.Error(err, "Monitoring validation failed")
+					return err
+				}
+				r.monitoringPort = monitoringPort
 			}
 			r.Log.Info("Monitoring Information found. Monitoring will be enabled on the external cluster")
 			r.monitoringIP = monitoringIP

--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -256,7 +256,7 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 				r.Log.Error(err, "Failed to get Monitoring Port.")
 				return err
 			}
-			err := validateMonitoringEndpoint(monitoringIP, monitoringPort, r.Log)
+			err := checkEndpointReachable(net.JoinHostPort(monitoringIP, monitoringPort), 5*time.Second)
 			if err != nil {
 				r.Log.Error(err, "Monitoring validation failed")
 				return err
@@ -375,27 +375,5 @@ func (r *StorageClusterReconciler) createExternalStorageClusterSecret(sec *corev
 			return err
 		}
 	}
-	return nil
-}
-
-// To check if endpoint is a VALID ip and is REACHABLE or not
-func validateMonitoringEndpoint(monitoringIP string, monitoringPort string, reqLogger logr.Logger) error {
-	_, err := net.LookupIP(monitoringIP)
-	if err != nil {
-		reqLogger.Error(err, "Monitoring endpoint is not a valid IPv4 IP")
-		return err
-	}
-	endpoint := net.JoinHostPort(monitoringIP, monitoringPort)
-	con, err := net.DialTimeout("tcp", endpoint, 5*time.Second)
-	if err != nil {
-		reqLogger.Error(err, fmt.Sprintf("Monitoring Endpoint (%s) is not reachable", endpoint))
-		return err
-	}
-	defer func() {
-		err := con.Close()
-		if err != nil {
-			reqLogger.Error(err, "")
-		}
-	}()
 	return nil
 }

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -73,16 +73,17 @@ type ImageMap struct {
 //nolint
 type StorageClusterReconciler struct {
 	client.Client
-	Log           logr.Logger
-	Scheme        *runtime.Scheme
-	serverVersion *version.Info
-	conditions    []conditionsv1.Condition
-	phase         string
-	monitoringIP  string
-	nodeCount     int
-	platform      *Platform
-	images        ImageMap
-	recorder      record.EventRecorder
+	Log            logr.Logger
+	Scheme         *runtime.Scheme
+	serverVersion  *version.Info
+	conditions     []conditionsv1.Condition
+	phase          string
+	monitoringIP   string
+	monitoringPort string
+	nodeCount      int
+	platform       *Platform
+	images         ImageMap
+	recorder       record.EventRecorder
 }
 
 // SetupWithManager sets up a controller with manager


### PR DESCRIPTION
In external cluster mode, we provide (along with other details) both monitoring IP and Port. IP was being configured whereas Port value was neglected (ie; it was not propagated to CephCluster spec).
This PR is to make sure we pass `Port` as well to CephCluster spec.

PS: as the changes for accessing CephCluster external-monitoring-port is available only from rook-v1.5.3, this is dependent on PR https://github.com/openshift/ocs-operator/pull/965, which updates the rook version (to v1.5.3)