### PR TITLE
Removes the OSD IDs from the osd removal job name

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -631,7 +631,7 @@ func newCleanupJob(sc *ocsv1.StorageCluster) *batchv1.Job {
 			APIVersion: "batch/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "ocs-osd-removal-${FAILED_OSD_IDS}",
+			Name:        "ocs-osd-removal-job",
 			Namespace:   sc.Namespace,
 			Labels:      labels,
 			Annotations: annotations,


### PR DESCRIPTION
When triggering the job for multiple OSDs removal, the template includes comma along with OSD IDs in the job name. This will cause the template to fail.
This commit will give the osd removal job constant and valid name.

Signed-off-by: Servesha Dudhgaonkar <sdudhgao@redhat.com>