### PR TITLE
Source Manifest uses template instead of OCS_IMAGE for backward compatibility

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,2 @@
 resources:
 - manager.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-images:
-- name: ocs-dev/ocs-operator
-  newName: quay.io/ocs-dev/ocs-operator
-  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
         args:
         - --enable-leader-election
         - "--health-probe-bind-address=:8081"
-        image: ocs-dev/ocs-operator:latest
+        image: REPLACE_IMAGE
         imagePullPolicy: Always
         name: ocs-operator
         env:

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -243,7 +243,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/ocs-dev/ocs-operator:latest
+                image: {{.OcsOperatorImage}}
                 imagePullPolicy: Always
                 name: ocs-operator
                 readinessProbe:

--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -84,11 +84,14 @@ function gen_ocs_csv() {
 	gen_args="generate kustomize manifests -q"
 	# shellcheck disable=SC2086
 	$OPERATOR_SDK $gen_args
-	pushd config/manager
-	$KUSTOMIZE edit set image ocs-dev/ocs-operator="$OCS_IMAGE"
-	popd
 	$KUSTOMIZE build config/manifests | $OPERATOR_SDK generate bundle -q --overwrite=false --version "$CSV_VERSION"
 	mv "$GOPATH"/src/github.com/openshift/ocs-operator/bundle/manifests/*clusterserviceversion.yaml $OCS_CSV
+	# Make variables templated for csv-merger tool
+	if [ "$OS_TYPE" == "Darwin" ]; then
+		sed -i '' "s/REPLACE_IMAGE/{{.OcsOperatorImage}}/g" $OCS_CSV
+	else
+		sed -i "s/REPLACE_IMAGE/{{.OcsOperatorImage}}/g" $OCS_CSV
+	fi
 	cp config/crd/bases/* $ocs_crds_outdir
 }
 


### PR DESCRIPTION
Before migrating to new project structure and tools, CSV Merger was using templates added by source-manifests to inject OCS_IMAGE value. When we moved to using Kustomize, we set the images directly instead of first templating and replacing.
This broke the build pipeline as it didn't safeguard itself against uninitialized OCS_IMAGE var.

This PR reverts back to using templates instead of Kustomize to unblock the build pipeline.
Alternatively, build pipeline can set OCS_IMAGE env var a little early and all should be well (without this PR)