### PR TITLE
[release-4.7] Source Manifest uses template instead of OCS_IMAGE for backward compatibility

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,8 +1,2 @@
 resources:
 - manager.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-images:
-- name: ocs-dev/ocs-operator
-  newName: quay.io/ocs-dev/ocs-operator
-  newTag: latest

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,7 +27,7 @@ spec:
         args:
         - --enable-leader-election
         - "--health-probe-bind-address=:8081"
-        image: ocs-dev/ocs-operator:latest
+        image: REPLACE_IMAGE
         imagePullPolicy: Always
         name: ocs-operator
         env:

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -243,7 +243,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/ocs-dev/ocs-operator:latest
+                image: {{.OcsOperatorImage}}
                 imagePullPolicy: Always
                 name: ocs-operator
                 readinessProbe:


### PR DESCRIPTION
Backport of #973 

#972  is not required as this makes it obsolete.