### PR TITLE
Changing NooBaa's SCC to RunAsAny instead of RunAsRange

### DIFF
--- a/controllers/ocsinitialization/sccs.go
+++ b/controllers/ocsinitialization/sccs.go
@@ -162,7 +162,7 @@ func newNooBaaSCC(namespace string) *secv1.SecurityContextConstraints {
 		"SETGID",
 	}
 	scc.RunAsUser = secv1.RunAsUserStrategyOptions{
-		Type: secv1.RunAsUserStrategyMustRunAsRange,
+		Type: secv1.RunAsUserStrategyRunAsAny,
 	}
 	scc.SELinuxContext = secv1.SELinuxContextStrategyOptions{
 		Type: secv1.SELinuxStrategyMustRunAs,


### PR DESCRIPTION
In order to support a fix to noobaa operator running db pod as a specific user
and not part of a changing uid range

Fix bug 1903573

Signed-off-by: jackyalbo <jalbo@redhat.com>