### PR TITLE
Non default sc unit tests

### DIFF
--- a/controllers/storagecluster/initialization_reconciler_test.go
+++ b/controllers/storagecluster/initialization_reconciler_test.go
@@ -105,6 +105,12 @@ func createUpdateRuntimeObjects(cp *Platform) []runtime.Object {
 func initStorageClusterResourceCreateUpdateTestWithPlatform(
 	t *testing.T, platform *Platform, runtimeObjs []runtime.Object) (*testing.T, StorageClusterReconciler, *api.StorageCluster, reconcile.Request) {
 	cr := createDefaultStorageCluster()
+	t, reconciler, request := initStorageClusterResourceCreateUpdateTestWithPlatformAndSC(t, platform, runtimeObjs, cr)
+	return t, reconciler, cr, request
+}
+
+func initStorageClusterResourceCreateUpdateTestWithPlatformAndSC(
+	t *testing.T, platform *Platform, runtimeObjs []runtime.Object, cr *api.StorageCluster) (*testing.T, StorageClusterReconciler, reconcile.Request) {
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Name:      "ocsinit",
@@ -136,7 +142,7 @@ func initStorageClusterResourceCreateUpdateTestWithPlatform(
 	assert.NoError(t, err)
 	assert.Equal(t, reconcile.Result{}, result)
 
-	return t, reconciler, cr, request
+	return t, reconciler, request
 }
 
 func createFakeInitializationStorageClusterReconciler(t *testing.T, obj ...runtime.Object) StorageClusterReconciler {


### PR DESCRIPTION
Enable non-default StorageClusters for unit testing

Prior to this change, creation of a default StorageCluster was
tightly coupled with test initialization functions. As such, many
of our unit tests only cover the default happy path. This change
introduces the option of providing a non-default StorageCluster
for test initialization while leaving the signatures of existing
initialization functions unchanged. It also uses this framework
for the testing of ObjectStore gateway instances, as this was
the case that inspired the change as a whole.
    
Signed-off-by: egafford <egafford@redhat.com>