### PR TITLE
Adjust mon_max_pg_per_osd for Rook-Ceph

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -47,6 +47,7 @@ const (
 mon_osd_full_ratio = .85
 mon_osd_backfillfull_ratio = .8
 mon_osd_nearfull_ratio = .75
+mon_max_pg_per_osd = 300
 [osd]
 osd_memory_target_cgroup_limit_ratio = 0.5
 `


### PR DESCRIPTION
This is a temporary workaround for a race condition with the Ceph PG
autoscaler. In cases where the autoscaler only detects our default RBD
and CephFS pools it will set the PG count for them to 128 instead of the
usual 32. In small clusters, this prevents the creation of additional
pools, e.g. for RGW. Setting mon_max_pg_per_osd to a higher value helps
account for the temporary state where few pools ar eusing a high number
of PGs.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>