### PR TITLE
Refactor: Remove redundant logger from StorageClusterReconciler methods

### DIFF
--- a/controllers/ocsinitialization/sccs.go
+++ b/controllers/ocsinitialization/sccs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	secv1 "github.com/openshift/api/security/v1"
 	ocsv1 "github.com/openshift/ocs-operator/api/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -12,20 +11,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (r *OCSInitializationReconciler) ensureSCCs(initialData *ocsv1.OCSInitialization, reqLogger logr.Logger) error {
+func (r *OCSInitializationReconciler) ensureSCCs(initialData *ocsv1.OCSInitialization) error {
 	sccs := getAllSCCs(initialData.Namespace)
 	for _, scc := range sccs {
 		found, err := r.SecurityClient.SecurityContextConstraints().Get(context.TODO(), scc.Name, metav1.GetOptions{})
 
 		if err != nil && errors.IsNotFound(err) {
-			reqLogger.Info(fmt.Sprintf("Creating %s SecurityContextConstraint", scc.Name))
+			r.Log.Info(fmt.Sprintf("Creating %s SecurityContextConstraint", scc.Name))
 			_, err := r.SecurityClient.SecurityContextConstraints().Create(context.TODO(), scc, metav1.CreateOptions{})
 			if err != nil {
 				return fmt.Errorf("unable to create SCC %+v: %v", scc, err)
 			}
 		} else if err == nil {
 			scc.ObjectMeta = found.ObjectMeta
-			reqLogger.Info(fmt.Sprintf("Updating %s SecurityContextConstraint", scc.Name))
+			r.Log.Info(fmt.Sprintf("Updating %s SecurityContextConstraint", scc.Name))
 			_, err := r.SecurityClient.SecurityContextConstraints().Update(context.TODO(), scc, metav1.UpdateOptions{})
 			if err != nil {
 				return fmt.Errorf("unable to update SCC %+v: %v", scc, err)

--- a/controllers/storagecluster/cephobjectstores_test.go
+++ b/controllers/storagecluster/cephobjectstores_test.go
@@ -36,7 +36,7 @@ func TestCephObjectStores(t *testing.T) {
 	}
 }
 func assertCephObjectStores(t *testing.T, reconciler StorageClusterReconciler, cr *api.StorageCluster, request reconcile.Request) {
-	expectedCos, err := reconciler.newCephObjectStoreInstances(cr, reconciler.Log)
+	expectedCos, err := reconciler.newCephObjectStoreInstances(cr)
 	assert.NoError(t, err)
 
 	actualCos := &cephv1.CephObjectStore{
@@ -64,6 +64,6 @@ func assertCephObjectStores(t *testing.T, reconciler StorageClusterReconciler, c
 	assert.Equal(t, len(expectedCos[0].OwnerReferences), 1)
 
 	cr.Spec.ManagedResources.CephObjectStores.GatewayInstances = 2
-	expectedCos, _ = reconciler.newCephObjectStoreInstances(cr, reconciler.Log)
+	expectedCos, _ = reconciler.newCephObjectStoreInstances(cr)
 	assert.Equal(t, expectedCos[0].Spec.Gateway.Instances, int32(2))
 }

--- a/controllers/storagecluster/cephobjectstoreusers.go
+++ b/controllers/storagecluster/cephobjectstoreusers.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	ocsv1 "github.com/openshift/ocs-operator/api/v1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -58,7 +57,7 @@ func (obj *ocsCephObjectStoreUsers) ensureCreated(r *StorageClusterReconciler, i
 	if err != nil {
 		return err
 	}
-	err = r.createCephObjectStoreUsers(cephObjectStoreUsers, instance, r.Log)
+	err = r.createCephObjectStoreUsers(cephObjectStoreUsers, instance)
 	if err != nil {
 		r.Log.Error(err, "could not create CephObjectStoresUsers")
 		return err
@@ -107,7 +106,7 @@ func (obj *ocsCephObjectStoreUsers) ensureDeleted(r *StorageClusterReconciler, s
 }
 
 // createCephObjectStoreUsers creates CephObjectStoreUsers in the desired state
-func (r *StorageClusterReconciler) createCephObjectStoreUsers(cephObjectStoreUsers []*cephv1.CephObjectStoreUser, instance *ocsv1.StorageCluster, reqLogger logr.Logger) error {
+func (r *StorageClusterReconciler) createCephObjectStoreUsers(cephObjectStoreUsers []*cephv1.CephObjectStoreUser, instance *ocsv1.StorageCluster) error {
 	for _, cephObjectStoreUser := range cephObjectStoreUsers {
 		existing := cephv1.CephObjectStoreUser{}
 		err := r.Client.Get(context.TODO(), types.NamespacedName{Name: cephObjectStoreUser.Name, Namespace: cephObjectStoreUser.Namespace}, &existing)
@@ -118,11 +117,11 @@ func (r *StorageClusterReconciler) createCephObjectStoreUsers(cephObjectStoreUse
 				return nil
 			}
 			if existing.DeletionTimestamp != nil {
-				reqLogger.Info(fmt.Sprintf("Unable to restore init object because %s is marked for deletion", existing.Name))
+				r.Log.Info(fmt.Sprintf("Unable to restore init object because %s is marked for deletion", existing.Name))
 				return fmt.Errorf("failed to restore initialization object %s because it is marked for deletion", existing.Name)
 			}
 
-			reqLogger.Info(fmt.Sprintf("Restoring original cephObjectStoreUser %s", cephObjectStoreUser.Name))
+			r.Log.Info(fmt.Sprintf("Restoring original cephObjectStoreUser %s", cephObjectStoreUser.Name))
 			existing.ObjectMeta.OwnerReferences = cephObjectStoreUser.ObjectMeta.OwnerReferences
 			cephObjectStoreUser.ObjectMeta = existing.ObjectMeta
 			err = r.Client.Update(context.TODO(), cephObjectStoreUser)
@@ -130,7 +129,7 @@ func (r *StorageClusterReconciler) createCephObjectStoreUsers(cephObjectStoreUse
 				return err
 			}
 		case errors.IsNotFound(err):
-			reqLogger.Info(fmt.Sprintf("Creating cephObjectStoreUser %s", cephObjectStoreUser.Name))
+			r.Log.Info(fmt.Sprintf("Creating cephObjectStoreUser %s", cephObjectStoreUser.Name))
 			err = r.Client.Create(context.TODO(), cephObjectStoreUser)
 			if err != nil {
 				return err

--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -387,7 +387,7 @@ func assertCephObjectStore(t *testing.T, reconciler StorageClusterReconciler, re
 		assert.Error(t, err)
 	} else {
 		assert.NoError(t, err)
-		extRs, err := reconciler.retrieveExternalSecretData(sc, reconciler.Log)
+		extRs, err := reconciler.retrieveExternalSecretData(sc)
 		assert.NoError(t, err)
 		extR, err := findNamedResourceFromArray(extRs, "ceph-rgw")
 		assert.NoError(t, err)
@@ -426,7 +426,7 @@ func assertReconciliationOfExternalResource(t *testing.T, reconciler StorageClus
 	assert.NoError(t, err)
 	firstExtSecretChecksum := sc.Status.ExternalSecretHash
 
-	extRsrcs, err := reconciler.retrieveExternalSecretData(sc, reconciler.Log)
+	extRsrcs, err := reconciler.retrieveExternalSecretData(sc)
 	assert.NoError(t, err)
 	rgwRsrc, err := findNamedResourceFromArray(extRsrcs, cephRgwStorageClassName)
 	assert.NoError(t, err)

--- a/controllers/storagecluster/topology_test.go
+++ b/controllers/storagecluster/topology_test.go
@@ -98,7 +98,7 @@ func TestReconcileNodeTopologyMap(t *testing.T) {
 		mockNodeList.DeepCopyInto(tc.nodeList)
 		tc.storageCluster.Status.FailureDomain = tc.failureDomain
 		reconciler := createFakeStorageClusterReconciler(t, tc.storageCluster, tc.nodeList)
-		err := reconciler.reconcileNodeTopologyMap(tc.storageCluster, reconciler.Log)
+		err := reconciler.reconcileNodeTopologyMap(tc.storageCluster)
 		assert.NoError(t, err)
 		assert.Equalf(t, tc.expectedNodeCount, reconciler.nodeCount, "[%s]: failed to get correct node count", tc.label)
 
@@ -200,7 +200,7 @@ func TestNodeTopologyMapOnDifferentAZ(t *testing.T) {
 		}
 
 		reconciler := createFakeStorageClusterReconciler(t, tc.storageCluster, tc.nodeList)
-		err := reconciler.reconcileNodeTopologyMap(tc.storageCluster, reconciler.Log)
+		err := reconciler.reconcileNodeTopologyMap(tc.storageCluster)
 		assert.NoError(t, err)
 
 		err = reconciler.Client.Status().Update(context.TODO(), tc.storageCluster)
@@ -246,7 +246,7 @@ func TestReconcileNodeTopologyMapFailure(t *testing.T) {
 		}
 		tc.storageCluster.Spec.StorageDeviceSets[0].Replica = tc.repilcaCount
 		reconciler := createFakeStorageClusterReconciler(t, mockStorageCluster, tc.nodeList)
-		err := reconciler.reconcileNodeTopologyMap(tc.storageCluster, reconciler.Log)
+		err := reconciler.reconcileNodeTopologyMap(tc.storageCluster)
 		assert.Errorf(t, err, "[%s]: failed to test ReconcileNodeTopologyMap failure condition", tc.label)
 	}
 }
@@ -399,7 +399,7 @@ func TestStorageClusterEligibleNodes(t *testing.T) {
 		mockStorageCluster.DeepCopyInto(tc.storageCluster)
 		tc.storageCluster.Spec.LabelSelector = tc.labelSelectors
 		reconciler := createFakeStorageClusterReconciler(t, tc.storageCluster, tc.nodeList)
-		actualNodes, err := reconciler.getStorageClusterEligibleNodes(tc.storageCluster, reconciler.Log)
+		actualNodes, err := reconciler.getStorageClusterEligibleNodes(tc.storageCluster)
 		assert.NoError(t, err)
 		assert.Equalf(t, tc.expectedNodeCount, len(actualNodes.Items), "[%s]: failed to get eligible nodes", tc.label)
 	}
@@ -510,7 +510,7 @@ func TestEnsureNodeRack(t *testing.T) {
 
 	for _, tc := range testcases {
 		reconciler := createFakeStorageClusterReconciler(t, tc.nodeList)
-		err := reconciler.ensureNodeRacks(tc.nodeList, tc.minRacks, tc.nodeRacks, tc.topologyMap, reconciler.Log)
+		err := reconciler.ensureNodeRacks(tc.nodeList, tc.minRacks, tc.nodeRacks, tc.topologyMap)
 		assert.NoError(t, err)
 
 		actualNodeList := &corev1.NodeList{}

--- a/controllers/storagecluster/uninstall_reconciler_test.go
+++ b/controllers/storagecluster/uninstall_reconciler_test.go
@@ -50,7 +50,7 @@ func assertStorageClusterUninstallAnnotation(
 	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster,
 	CleanupPolicy CleanupPolicyType, UninstallMode UninstallModeType) {
 
-	err := reconciler.reconcileUninstallAnnotations(sc, reconciler.Log)
+	err := reconciler.reconcileUninstallAnnotations(sc)
 	assert.NoError(t, err)
 
 	if val, found := sc.ObjectMeta.Annotations[UninstallModeAnnotation]; !found {
@@ -75,7 +75,7 @@ func TestSetRookUninstallandCleanupPolicy(t *testing.T) {
 		// there are two annotations which will be 4 combinations, test all 4 combinations
 
 		// set default uninstall annotations
-		err := reconciler.reconcileUninstallAnnotations(sc, reconciler.Log)
+		err := reconciler.reconcileUninstallAnnotations(sc)
 		assert.NoError(t, err)
 
 		combinationsList := []struct {
@@ -105,7 +105,7 @@ func assertCephClusterCleanupPolicy(
 	CleanupPolicyConfirmation cephv1.CleanupConfirmationProperty, AllowUninstallWithVolumes bool) {
 
 	// verify it set the cleanup policy and uninstall mode on cephCluster wrt annotations
-	err := reconciler.setRookUninstallandCleanupPolicy(sc, reconciler.Log)
+	err := reconciler.setRookUninstallandCleanupPolicy(sc)
 	assert.NoError(t, err)
 
 	cephCluster := &cephv1.CephCluster{}
@@ -261,7 +261,7 @@ func assertTestDeleteNodeAffinityKeyFromNodes(
 	}
 
 	// verify there are eligible nodes
-	nodes, err := reconciler.getStorageClusterEligibleNodes(sc, reconciler.Log)
+	nodes, err := reconciler.getStorageClusterEligibleNodes(sc)
 	assert.NoError(t, err)
 	assert.NotEqual(t, 0, len(nodes.Items))
 
@@ -274,10 +274,10 @@ func assertTestDeleteNodeAffinityKeyFromNodes(
 	}
 
 	// delete NodeAffinityKey
-	err = reconciler.deleteNodeAffinityKeyFromNodes(sc, reconciler.Log)
+	err = reconciler.deleteNodeAffinityKeyFromNodes(sc)
 	assert.NoError(t, err)
 
-	nodes, err = reconciler.getStorageClusterEligibleNodes(sc, reconciler.Log)
+	nodes, err = reconciler.getStorageClusterEligibleNodes(sc)
 	assert.NoError(t, err)
 
 	if !createUserDefinedKey {
@@ -351,10 +351,10 @@ func assertTestDeleteNodeTaint(
 	}
 
 	// delete node taints
-	err := reconciler.deleteNodeTaint(sc, reconciler.Log)
+	err := reconciler.deleteNodeTaint(sc)
 	assert.NoError(t, err)
 
-	nodes, err := reconciler.getStorageClusterEligibleNodes(sc, reconciler.Log)
+	nodes, err := reconciler.getStorageClusterEligibleNodes(sc)
 	assert.NoError(t, err)
 	assert.NotEqual(t, 0, len(nodes.Items))
 
@@ -368,7 +368,7 @@ func assertTestDeleteNodeTaint(
 
 func addDefaultNodeTaintOnNodes(t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster) {
 
-	nodes, err := reconciler.getStorageClusterEligibleNodes(sc, reconciler.Log)
+	nodes, err := reconciler.getStorageClusterEligibleNodes(sc)
 	assert.NoError(t, err)
 	assert.NotEqual(t, 0, len(nodes.Items))
 
@@ -727,7 +727,7 @@ func assertTestDeleteCephObjectStores(
 		assert.NoError(t, err)
 	}
 
-	cephStores, err := reconciler.newCephObjectStoreInstances(sc, reconciler.Log)
+	cephStores, err := reconciler.newCephObjectStoreInstances(sc)
 	assert.NoError(t, err)
 
 	for _, cephStore := range cephStores {
@@ -806,12 +806,12 @@ func assertTestSetNoobaaUninstallMode(
 	t *testing.T, reconciler StorageClusterReconciler, sc *api.StorageCluster,
 	UninstallMode UninstallModeType, NoobaaUninstallMode nbv1.CleanupConfirmationProperty) {
 
-	err := reconciler.reconcileUninstallAnnotations(sc, reconciler.Log)
+	err := reconciler.reconcileUninstallAnnotations(sc)
 	assert.NoError(t, err)
 
 	sc.ObjectMeta.Annotations[UninstallModeAnnotation] = string(UninstallMode)
 
-	err = reconciler.setNoobaaUninstallMode(sc, reconciler.Log)
+	err = reconciler.setNoobaaUninstallMode(sc)
 	assert.NoError(t, err)
 
 	noobaa := &nbv1.NooBaa{}


### PR DESCRIPTION
refactor StorageClusterReconciler methods to use
StorageClusterReconciler logger and remove
logr.Logger type argument from methods.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>