### PR TITLE
Bug 1915737: [release-4.7] storagecluster: Enhance Noobaa ensureDeleted logging

### DIFF
--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -177,7 +177,7 @@ func (r *StorageClusterReconciler) deleteNoobaaSystems(sc *ocsv1.StorageCluster,
 				return err
 			}
 			if len(pvcs.Items) > 0 {
-				return fmt.Errorf("Uninstall: Waiting on NooBaa system and PVCs to be deleted")
+				return fmt.Errorf("Uninstall: Waiting on NooBaa PVCs to be deleted")
 			}
 			reqLogger.Info("Uninstall: NooBaa and noobaa-db PVC not found.")
 			return nil
@@ -194,17 +194,17 @@ func (r *StorageClusterReconciler) deleteNoobaaSystems(sc *ocsv1.StorageCluster,
 	}
 	if !isOwned {
 		// if the noobaa found is not owned by our storagecluster, we skip it from deletion.
-		reqLogger.Info("Uninstall: NooBaa object found, but ownerReference not set to storagecluster. Skipping")
+		reqLogger.Info("Uninstall: NooBaa object %v found, but ownerReference not set to storagecluster. Skipping", noobaa.ObjectMeta.Name)
 		return nil
 	}
 
 	if noobaa.GetDeletionTimestamp().IsZero() {
-		reqLogger.Info("Uninstall: Deleting NooBaa system")
+		reqLogger.Info("Uninstall: Deleting NooBaa system %v", noobaa.ObjectMeta.Name)
 		err = r.Client.Delete(context.TODO(), noobaa)
 		if err != nil {
-			reqLogger.Error(err, "Uninstall: Failed to delete NooBaa system")
-			return fmt.Errorf("Uninstall: Failed to delete NooBaa system: %v", err)
+			reqLogger.Error(err, "Uninstall: Failed to delete NooBaa system %v", noobaa.ObjectMeta.Name)
+			return fmt.Errorf("Uninstall: Failed to delete NooBaa system %v : %v", noobaa.ObjectMeta.Name, err)
 		}
 	}
-	return fmt.Errorf("Uninstall: Waiting on NooBaa system to be deleted")
+	return fmt.Errorf("Uninstall: Waiting on NooBaa system %v to be deleted", noobaa.ObjectMeta.Name)
 }


### PR DESCRIPTION
Add resource names in Noobaa's ensureDeleted func logging.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=1915737

backport of https://github.com/openshift/ocs-operator/pull/992