### PR TITLE
Job: Removes the OSD IDs from the label

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -620,7 +620,7 @@ func (obj *ocsJobTemplates) ensureDeleted(r *StorageClusterReconciler, sc *ocsv1
 
 func newCleanupJob(sc *ocsv1.StorageCluster) *batchv1.Job {
 	labels := map[string]string{
-		"app": "ceph-toolbox-job-${FAILED_OSD_IDS}",
+		"app": "ceph-toolbox-job",
 	}
 
 	// Annotation template.alpha.openshift.io/wait-for-ready ensures template readiness


### PR DESCRIPTION
When triggering the job for multiple OSDs removal,
the template includes comma along with failed OSD IDs in the label.
This fix will make a label valid in format.

Signed-off-by: Servesha Dudhgaonkar <sdudhgao@redhat.com>