### PR TITLE
Makefile: re-add target update-generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,9 @@ manifests: controller-gen
 	@echo Updating generated manifests
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
-verify-generated: generate manifests
+update-generated: generate manifests
+
+verify-generated: update-generated
 	@echo "Verifying generated code and manifests"
 	hack/verify-generated.sh
 


### PR DESCRIPTION
The target update-generated was removed in the recent project structure
overhaul, but it was still listed PHONY and referenced in the
verify-generated script. It's useful to have this separate target, so
re-adding it instead of cleaning up.

Signed-off-by: Michael Adam <obnox@redhat.com>