### PR TITLE
Remove OCS CPU telemetry metric rules

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -8,19 +8,6 @@ metadata:
   namespace: openshift-storage
 spec:
   groups:
-  - name: ocs-telemeter.rules
-    rules:
-    - expr: "sum(\n  max(\n    (\n      kube_pod_container_resource_requests_cpu_cores{namespace=\"openshift-storage\",
-        pod =~\"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)\"} *
-        0 +1 \n    ) * on(node) group_left() node:node_num_cpu:sum\n  ) by (node)\n)\n"
-      record: ocs:node_num_cpu:sum
-    - expr: |
-        sum(
-          rate(
-            container_cpu_usage_seconds_total{namespace="openshift-storage",container="",pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)"} [5m]
-          )
-        )
-      record: ocs:container_cpu_usage:sum
   - name: external-cluster-services-alert.rules
     rules:
     - alert: ClusterObjectStoreState

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -8,19 +8,6 @@ metadata:
   namespace: openshift-storage
 spec:
   groups:
-  - name: ocs-telemeter.rules
-    rules:
-    - expr: "sum(\n  max(\n    (\n      kube_pod_container_resource_requests_cpu_cores{namespace=\"openshift-storage\",
-        pod =~\"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)\"} *
-        0 +1 \n    ) * on(node) group_left() node:node_num_cpu:sum\n  ) by (node)\n)\n"
-      record: ocs:node_num_cpu:sum
-    - expr: |
-        sum(
-          rate(
-            container_cpu_usage_seconds_total{namespace="openshift-storage",container="",pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)"} [5m]
-          )
-        )
-      record: ocs:container_cpu_usage:sum
   - name: cluster-services-alert.rules
     rules:
     - alert: ClusterObjectStoreState

--- a/metrics/mixin/rules/rules.libsonnet
+++ b/metrics/mixin/rules/rules.libsonnet
@@ -1,33 +1,4 @@
 {
   prometheusRules+:: {
-    groups+: [
-      {
-        name: 'ocs-telemeter.rules',
-        rules: [
-          {
-            record: 'ocs:node_num_cpu:sum',
-            expr: |||
-              sum(
-                max(
-                  (
-                    kube_pod_container_resource_requests_cpu_cores{namespace="openshift-storage", pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)"} * 0 +1 
-                  ) * on(node) group_left() node:node_num_cpu:sum
-                ) by (node)
-              )
-            ||| % $._config,
-          },
-          {
-            record: 'ocs:container_cpu_usage:sum',
-            expr: |||
-              sum(
-                rate(
-                  container_cpu_usage_seconds_total{namespace="openshift-storage",container="",pod =~"(noobaa-core.*|noobaa-db.*|rook-ceph-(mon|osd|mgr|mds|rgw).*)"} [5m]
-                )
-              )
-            ||| % $._config,
-          },
-        ],
-      },
-    ],
   },
 }


### PR DESCRIPTION
The feature of gathering metrics for OCS telemetry is dropped due to better
alternatives available to achieve the same. Thus, reverting the addition of rules.

This PR needs to be backported to the 4.7 branches, as the rules will be unrequired there and will consume Prometheus bandwidth if not removed. 

Signed-off-by: Anmol Sachan <anmol13694@gmail.com>