### PR TITLE
Increase memory footprint for rook-ceph-osd pods

### DIFF
--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -12,11 +12,11 @@ var (
 		"osd": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("5Gi"),
+				corev1.ResourceMemory: resource.MustParse("10Gi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("2"),
-				corev1.ResourceMemory: resource.MustParse("5Gi"),
+				corev1.ResourceMemory: resource.MustParse("10Gi"),
 			},
 		},
 		"mon": {


### PR DESCRIPTION
In ppc64le environment, we are seeing OOM exceptions in osd pods
in ceph cluster. We would like to increase the memory footprint
for osd pods only to 10Gi from 5Gi.

Signed-off-by: gitsridhar <svenkat@us.ibm.com>