### PR TITLE
StorageCluster: add test cases for insufficient zones and regions

### DIFF
--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -36,8 +36,9 @@ import (
 )
 
 const (
-	zoneTopologyLabel = "failure-domain.kubernetes.io/zone"
-	hostnameLabel     = "kubernetes.io/hostname"
+	zoneTopologyLabel   = "failure-domain.kubernetes.io/zone"
+	regionTopologyLabel = "failure-domain.kubernetes.io/region"
+	hostnameLabel       = "kubernetes.io/hostname"
 )
 
 var mockStorageClusterRequest = reconcile.Request{


### PR DESCRIPTION
Add test cases which ensure that when insufficient zones/regions are
available, we assign racks automatically.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>