### PR TITLE
StorageCluster: fix logic to determine minimum nodes

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -427,7 +427,14 @@ func getMinimumNodes(sc *ocsv1.StorageCluster) int {
 	// needs to override this assumption, we can provide a flag (like
 	// allowReplicasOnSameNode) in the future.
 
-	return getMinDeviceSetReplica(sc) * getReplicasPerFailureDomain(sc)
+	maxReplica := getMinDeviceSetReplica(sc)
+	for _, deviceSet := range sc.Spec.StorageDeviceSets {
+		if deviceSet.Replica > maxReplica {
+			maxReplica = deviceSet.Replica
+		}
+	}
+
+	return maxReplica * getReplicasPerFailureDomain(sc)
 }
 
 func getMonCount(nodeCount int, arbiter bool) int {

--- a/controllers/storagecluster/topology.go
+++ b/controllers/storagecluster/topology.go
@@ -219,12 +219,6 @@ func (r *StorageClusterReconciler) ensureNodeRacks(
 func (r *StorageClusterReconciler) reconcileNodeTopologyMap(sc *ocsv1.StorageCluster) error {
 	minNodes := getMinimumNodes(sc)
 
-	for _, deviceSet := range sc.Spec.StorageDeviceSets {
-		if deviceSet.Replica > minNodes {
-			minNodes = deviceSet.Replica
-		}
-	}
-
 	nodes, err := r.getStorageClusterEligibleNodes(sc)
 	if err != nil {
 		return err


### PR DESCRIPTION
The existing code was only applicable for clusters that had failure
domains per replica set to one. In case of arbiter, we have replicas per
failure domain set to 2.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>