### PR TITLE
StorageCluster: generate cephReplicatedSpec to abstract out arbiter values

### DIFF
--- a/controllers/storagecluster/cephblockpools.go
+++ b/controllers/storagecluster/cephblockpools.go
@@ -14,20 +14,6 @@ import (
 
 type ocsCephBlockPools struct{}
 
-func generateCephReplicatedSpec(initData *ocsv1.StorageCluster) cephv1.ReplicatedSpec {
-	if arbiterEnabled(initData) {
-		return cephv1.ReplicatedSpec{
-			Size:                     4,
-			TargetSizeRatio:          .49,
-			ReplicasPerFailureDomain: 2,
-		}
-	}
-	return cephv1.ReplicatedSpec{
-		Size:            3,
-		TargetSizeRatio: .49,
-	}
-}
-
 // newCephBlockPoolInstances returns the cephBlockPool instances that should be created
 // on first run.
 func (r *StorageClusterReconciler) newCephBlockPoolInstances(initData *ocsv1.StorageCluster) ([]*cephv1.CephBlockPool, error) {
@@ -39,7 +25,7 @@ func (r *StorageClusterReconciler) newCephBlockPoolInstances(initData *ocsv1.Sto
 			},
 			Spec: cephv1.PoolSpec{
 				FailureDomain:  determineFailureDomain(initData),
-				Replicated:     generateCephReplicatedSpec(initData),
+				Replicated:     generateCephReplicatedSpec(initData, "data"),
 				EnableRBDStats: true,
 			},
 		},

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -408,6 +408,15 @@ func getReplicasPerFailureDomain(sc *ocsv1.StorageCluster) int {
 	return defaults.ReplicasPerFailureDomain
 }
 
+// getCephPoolReplicatedSize returns the default replica per cluster count for a
+// StorageCluster type
+func getCephPoolReplicatedSize(sc *ocsv1.StorageCluster) uint {
+	if arbiterEnabled(sc) {
+		return uint(4)
+	}
+	return uint(3)
+}
+
 // getMinimumNodes returns the minimum number of nodes that are required for the Storage Cluster of various configurations
 func getMinimumNodes(sc *ocsv1.StorageCluster) int {
 	// Case 1: When replicasPerFailureDomain is 1.

--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -26,17 +26,12 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initData *ocsv1.St
 			},
 			Spec: cephv1.FilesystemSpec{
 				MetadataPool: cephv1.PoolSpec{
-					Replicated: cephv1.ReplicatedSpec{
-						Size: 3,
-					},
+					Replicated:    generateCephReplicatedSpec(initData, "metadata"),
 					FailureDomain: initData.Status.FailureDomain,
 				},
 				DataPools: []cephv1.PoolSpec{
 					{
-						Replicated: cephv1.ReplicatedSpec{
-							Size:            3,
-							TargetSizeRatio: .49,
-						},
+						Replicated:    generateCephReplicatedSpec(initData, "data"),
 						FailureDomain: initData.Status.FailureDomain,
 					},
 				},

--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -137,16 +137,11 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 				PreservePoolsOnDelete: false,
 				DataPool: cephv1.PoolSpec{
 					FailureDomain: initData.Status.FailureDomain,
-					Replicated: cephv1.ReplicatedSpec{
-						Size:            3,
-						TargetSizeRatio: .49,
-					},
+					Replicated:    generateCephReplicatedSpec(initData, "data"),
 				},
 				MetadataPool: cephv1.PoolSpec{
 					FailureDomain: initData.Status.FailureDomain,
-					Replicated: cephv1.ReplicatedSpec{
-						Size: 3,
-					},
+					Replicated:    generateCephReplicatedSpec(initData, "metadata"),
 				},
 				Gateway: cephv1.GatewaySpec{
 					Port:      80,

--- a/controllers/storagecluster/generate.go
+++ b/controllers/storagecluster/generate.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	ocsv1 "github.com/openshift/ocs-operator/api/v1"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 )
 
 func generateNameForCephCluster(initData *ocsv1.StorageCluster) string {
@@ -54,4 +55,18 @@ func generateNameForSnapshotClassDriver(initData *ocsv1.StorageCluster, snapshot
 
 func generateNameForSnapshotClassSecret(snapshotType SnapshotterType) string {
 	return fmt.Sprintf("rook-csi-%s-provisioner", snapshotType)
+}
+
+// generateCephReplicatedSpec returns the ReplicatedSpec for the cephCluster
+// based on the StorageCluster configuration
+func generateCephReplicatedSpec(initData *ocsv1.StorageCluster, poolType string) cephv1.ReplicatedSpec {
+	crs := cephv1.ReplicatedSpec{}
+
+	crs.Size = getCephPoolReplicatedSize(initData)
+	crs.ReplicasPerFailureDomain = uint(getReplicasPerFailureDomain(initData))
+	if "data" == poolType {
+		crs.TargetSizeRatio = .49
+	}
+
+	return crs
 }


### PR DESCRIPTION
Instead of hardcoding it, we get the value generated using a function.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>