### PR TITLE
Bug 1914203: [release-4.7] StorageCluster: fix logic to determine minimum nodes

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -395,7 +395,14 @@ func getMinimumNodes(sc *ocsv1.StorageCluster) int {
 	// needs to override this assumption, we can provide a flag (like
 	// allowReplicasOnSameNode) in the future.
 
-	return getMinDeviceSetReplica(sc) * getReplicasPerFailureDomain(sc)
+	maxReplica := getMinDeviceSetReplica(sc)
+	for _, deviceSet := range sc.Spec.StorageDeviceSets {
+		if deviceSet.Replica > maxReplica {
+			maxReplica = deviceSet.Replica
+		}
+	}
+
+	return maxReplica * getReplicasPerFailureDomain(sc)
 }
 
 func getMonCount(nodeCount int, arbiter bool) int {

--- a/controllers/storagecluster/topology.go
+++ b/controllers/storagecluster/topology.go
@@ -221,12 +221,6 @@ func (r *StorageClusterReconciler) ensureNodeRacks(
 func (r *StorageClusterReconciler) reconcileNodeTopologyMap(sc *ocsv1.StorageCluster, reqLogger logr.Logger) error {
 	minNodes := getMinimumNodes(sc)
 
-	for _, deviceSet := range sc.Spec.StorageDeviceSets {
-		if deviceSet.Replica > minNodes {
-			minNodes = deviceSet.Replica
-		}
-	}
-
 	nodes, err := r.getStorageClusterEligibleNodes(sc, reqLogger)
 	if err != nil {
 		return err


### PR DESCRIPTION
The existing code was only applicable for clusters that had failure
domains per replica set to one. In case of arbiter, we have replicas per
failure domain set to 2.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>
(cherry picked from commit 6836e24569a5f54a0b39661504f689321d2f9c35)