### PR TITLE
StorageCluster:Fixed placement config for rack failure domain and modified labelselector

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -541,11 +541,19 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 					if noPreparePlacement {
 						in := getPlacement(sc, "osd-prepare-tsc")
 						(&in).DeepCopyInto(&preparePlacement)
+					}
 
-						if len(topologyKeyValues) >= replica {
-							// If topologyKey is not host, append additional topology spread constarint to the
-							// default preparePlacement. This serves even distribution at the host level
-							// within a failure domain (zone/rack).
+					if len(topologyKeyValues) >= replica {
+						// Hard constraints are set in OSD placement for portable volumes with rack failure domain
+						// domain as there is no node affinity in PVs. This restricts the movement of OSDs
+						// between failure domain.
+						if portable && !strings.Contains(topologyKey, "zone") {
+							addStrictFailureDomainTSC(&placement, topologyKey)
+						}
+						// If topologyKey is not host, append additional topology spread constarint to the
+						// default preparePlacement. This serves even distribution at the host level
+						// within a failure domain (zone/rack).
+						if noPreparePlacement {
 							if topologyKey != corev1.LabelHostname {
 								addStrictFailureDomainTSC(&preparePlacement, topologyKey)
 							} else {

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -338,7 +338,19 @@ func TestStorageClassDeviceSetCreation(t *testing.T) {
 			assert.Equal(t, deviceSet.DataPVCTemplate, scds.VolumeClaimTemplates[0])
 			assert.Equal(t, true, scds.Portable)
 			assert.Equal(t, c.sc.Spec.Encryption.Enable, scds.Encrypted)
-			assert.Equal(t, getPlacement(c.sc, "osd-tsc"), scds.Placement)
+			if scds.Portable && c.topologyKey == "rack" {
+				assert.Equal(t, scds.Placement.TopologySpreadConstraints[0].WhenUnsatisfiable, corev1.UnsatisfiableConstraintAction("DoNotSchedule"))
+				assert.Equal(t, len(scds.Placement.TopologySpreadConstraints), 2)
+				assert.Equal(t, scds.Placement.TopologySpreadConstraints[0].TopologyKey, defaults.RackTopologyKey)
+				placementOsd := getPlacement(c.sc, "osd-tsc")
+				newTSC := placementOsd.TopologySpreadConstraints[0]
+				newTSC.TopologyKey = defaults.RackTopologyKey
+				newTSC.WhenUnsatisfiable = corev1.UnsatisfiableConstraintAction("DoNotSchedule")
+				placementOsd.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{newTSC, placementOsd.TopologySpreadConstraints[0]}
+				assert.Equal(t, placementOsd, scds.Placement)
+			} else {
+				assert.Equal(t, getPlacement(c.sc, "osd-tsc"), scds.Placement)
+			}
 			if c.lenOfMatchExpression == 0 {
 				assert.Nil(t, scds.Placement.NodeAffinity)
 			} else {


### PR DESCRIPTION
This PR provides the folowing changes

- To have effective OSD distribution, 
    - Added changes to have a common key as topology spread label selector as it matches both prepare and OSD pod.
    - Added hard constraints for prepare placement failure domain(zone/rack) in case of multiple topology spread constraints.  


- Restricts the movement of portable volumes between failure domain (rack) while node drain by imposing hard constraint in topology spread. 

Signed-off-by: kesavan <kvellalo@redhat.com>