### PR TITLE
ceph: raise mon_max_pg_per_osd from 300 to 600

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -47,7 +47,7 @@ const (
 mon_osd_full_ratio = .85
 mon_osd_backfillfull_ratio = .8
 mon_osd_nearfull_ratio = .75
-mon_max_pg_per_osd = 300
+mon_max_pg_per_osd = 600
 [osd]
 osd_memory_target_cgroup_limit_ratio = 0.5
 `


### PR DESCRIPTION
Allow for creating more pools.
In e5292567c9eb7267ecaa530dd9d4bfd59368a647, we raised
the mon_max_pg_per_osd to 300 to prevent pool creations
from failing. It turns out that this wasn't quite enough.
Raising it to 600 now to allow for a few more rbd pools
to be created.

Signed-off-by: Michael Adam <obnox@redhat.com>