### PR TITLE
Must-gather: add no headers in skip ceph collection

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -150,7 +150,7 @@ for ns in $namespaces; do
              done
         done
     }
-    if [ "$(oc get pods -n openshift-storage -l  must-gather-helper-pod='' | awk '{print $2}')" == "1/1" ] ; then
+    if [ "$(oc get pods --no-headers -n openshift-storage -l  must-gather-helper-pod='' | awk '{print $2}')" == "1/1" ] ; then
         ceph_collection
     else
         echo "skipping the ceph collection" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log


### PR DESCRIPTION
Problem: Must-gather continues to skip the ceph collection for every run.

solution: Adding --no-headers removes the` READY` keyword from the output which helps the condition to verify the state of pod without any intermittent issues hitting. The state being 1/1.

Signed-off-by: crombus <pkundra@redhat.com>