### PR TITLE
OCS-Operator now supports multiple external monitoring IPs

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -367,7 +367,12 @@ func newExternalCephCluster(sc *ocsv1.StorageCluster, cephImage, monitoringIP, m
 	if monitoringIP != "" {
 		monitoringSpec.Enabled = true
 		monitoringSpec.RulesNamespace = sc.Namespace
-		monitoringSpec.ExternalMgrEndpoints = []corev1.EndpointAddress{{IP: monitoringIP}}
+		// replace any comma with space and collect all the non-empty items
+		monIPArr := parseMonitoringIPs(monitoringIP)
+		monitoringSpec.ExternalMgrEndpoints = make([]corev1.EndpointAddress, len(monIPArr))
+		for idx, eachMonIP := range monIPArr {
+			monitoringSpec.ExternalMgrEndpoints[idx].IP = eachMonIP
+		}
 		if monitoringPort != "" {
 			if uint16Val, err := strconv.ParseUint(monitoringPort, 10, 16); err == nil {
 				monitoringSpec.ExternalMgrPrometheusPort = uint16(uint16Val)


### PR DESCRIPTION
A ceph cluster will contain an active 'mgr' (manager) and
(may have) multiple stand-by 'mgr'-s.
This change will allow OCS-Operator to accept multiple
(comma / space separated) endpoints/IP addresses, which
will be passed to external ceph-cluster spec.

This will help rook (which reads the ceph-cluster spec internally)
to change over to the next 'mgr' when the current active 'mgr' fails.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>