### PR TITLE
Add a master branch configuration for openshift-ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ all: ocs-operator ocs-registry ocs-must-gather
 	verify-operator-bundle \
 	operator-index \
 	ocs-registry \
+	ocs-registry-master \
 	gen-release-csv \
 	gen-latest-csv \
 	gen-latest-deploy-yaml \
@@ -117,6 +118,10 @@ operator-index:
 ocs-registry:
 	@echo "Building ocs-registry image in appregistry format"
 	hack/build-appregistry.sh
+
+ocs-registry-master:
+	@echo "Building ocs-registry image in appregistry format using master images for all OCS components"
+	hack/build-master-appregistry.sh
 
 clean:
 	@echo "cleaning previous outputs"

--- a/hack/build-master-appregistry.sh
+++ b/hack/build-master-appregistry.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+source hack/common.sh
+
+$IMAGE_BUILD_CMD build --no-cache -t "$CATALOG_FULL_IMAGE_NAME" -f openshift-ci/Dockerfile.registry.master .
+echo
+echo "Run '${IMAGE_BUILD_CMD} push ${CATALOG_FULL_IMAGE_NAME}' to push ocs-registry to ${IMAGE_REGISTRY}."

--- a/hack/generate-master-appregistry.sh
+++ b/hack/generate-master-appregistry.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+CSV_VERSION=4.8.0
+source hack/generate-appregistry.sh
+
+CSV_FILE=build/_output/appregistry/olm-catalog/ocs-operator/${CSV_VERSION}/ocs-operator.v${CSV_VERSION}.clusterserviceversion.yaml
+
+latest_master_version() {
+  URL=https://registry.hub.docker.com/v2/repositories/$1/tags/
+  FILTER=${2:-.}
+  VERSION=$(curl -s -S "$URL" | jq '."results"[]["name"]' | grep "$FILTER" | sort -nr | head -n1 | tr -d '"')
+  echo "$VERSION"
+}
+
+CEPH_PATTERN="\(travisn\|ceph\)\/ceph:.*$"
+CEPH_VERSION=$(latest_master_version ceph/ceph)
+sed -i "s/${CEPH_PATTERN}/ceph\/ceph:${CEPH_VERSION}/" $CSV_FILE
+
+NOOBAA_CORE_PATTERN="noobaa\/noobaa-core:[0-9.-]*$"
+NOOBAA_CORE_VERSION=$(latest_master_version 'noobaa/noobaa-core' master)
+sed -i "s/${NOOBAA_CORE_PATTERN}/noobaa\/noobaa-core:${NOOBAA_CORE_VERSION}/" $CSV_FILE
+
+NOOBAA_OPERATOR_PATTERN="noobaa\/noobaa-operator:[0-9.-]*$"
+NOOBAA_OPERATOR_VERSION=$(latest_master_version noobaa/noobaa-operator master)
+sed -i "s/${NOOBAA_OPERATOR_PATTERN}/noobaa\/noobaa-operator:${NOOBAA_OPERATOR_VERSION}/" $CSV_FILE
+
+ROOK_PATTERN="rook\/ceph:v[0-9.-]*$"
+ROOK_VERSION="master"
+sed -i "s/${ROOK_PATTERN}/rook\/ceph:${ROOK_VERSION}/" ${CSV_FILE}

--- a/openshift-ci/Dockerfile.registry.build.master
+++ b/openshift-ci/Dockerfile.registry.build.master
@@ -1,0 +1,24 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS stage
+
+COPY . /ocs-operator
+
+WORKDIR /ocs-operator
+
+RUN microdnf install -y jq
+RUN hack/generate-master-appregistry.sh
+
+
+FROM quay.io/openshift/origin-operator-registry:latest
+
+COPY --from=stage /ocs-operator/build/_output/appregistry/olm-catalog /registry/ocs-catalog
+
+# replaces ocs-operator image with the one built by openshift ci
+RUN find /registry/ocs-catalog/ -type f -exec sed -i "s|image\: .*/ocs-operator:.*$|image: default-route-openshift-image-registry.apps.build02.ci.devcluster.openshift.com/${OPENSHIFT_BUILD_NAMESPACE}/stable:ocs-operator|g" {} \; || :
+
+# Initialize the database
+RUN initializer --manifests /registry/ocs-catalog --output bundles.db
+
+# There are multiple binaries in the origin-operator-registry
+# We want the registry-server
+ENTRYPOINT ["registry-server"]
+CMD ["--database", "bundles.db"]

--- a/openshift-ci/Dockerfile.registry.master
+++ b/openshift-ci/Dockerfile.registry.master
@@ -1,0 +1,21 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS stage
+
+COPY . /ocs-operator
+
+WORKDIR /ocs-operator
+
+RUN microdnf install -y jq
+RUN hack/generate-master-appregistry.sh
+
+
+FROM quay.io/openshift/origin-operator-registry:latest
+
+COPY --from=stage /ocs-operator/build/_output/appregistry/olm-catalog /registry/ocs-catalog
+
+# Initialize the database
+RUN initializer --manifests /registry/ocs-catalog --output bundles.db
+
+# There are multiple binaries in the origin-operator-registry
+# We want the registry-server
+ENTRYPOINT ["registry-server"]
+CMD ["--database", "bundles.db"]


### PR DESCRIPTION
At present, all OCS operator CI builds use fixed container versions
for each other OCS project. This will continue to be appropriate,
but a non-blocking CI job to notify us of compatibility issues
between the master branches of multiple OCS components would be
useful. This change introduces new scripts for the easy generation
of an OCS registry that will pull the most recent container image
from the master branch of each component project.

Notes on implementation:
- I chose to use the most recent published container image for each
  project, rather than building from the most recent code for each,
  in order to leave each project team fully responsible for their own
  build process and able to change it without breaking any CI jobs.
  This is a tradeoff, as teams may not update container images as
  often as code, but I chose maintainability.
- I also chose to use jq rather than parsing JSON using basic OS
  tools like awk and sed. Because of this, I opted to build from the
  ubi8/ubi-minimal image rather than the ubi8/go-toolset image
  (which requires subscription management to install tools).
  Because of this, I chose to alter the generated CSV rather than
  generating a CSV using env variables to specify master branch
  versions.

Signed-off-by: Elise Gafford <egafford@redhat.com>