### PR TITLE
storagecluster: Change event type from error to warning

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -178,21 +178,21 @@ func (r *StorageClusterReconciler) initializeImagesStatus(sc *ocsv1.StorageClust
 func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.StorageCluster, request reconcile.Request) error {
 	if err := versionCheck(instance, r.Log); err != nil {
 		r.Log.Error(err, "Failed to validate version")
-		r.recorder.Event(instance, statusutil.EventTypeError, statusutil.EventReasonValidationFailed, err.Error())
+		r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 		return err
 	}
 
 	if !instance.Spec.ExternalStorage.Enable {
 		if err := r.validateStorageDeviceSets(instance); err != nil {
 			r.Log.Error(err, "Failed to validate StorageDeviceSets")
-			r.recorder.Event(instance, statusutil.EventTypeError, statusutil.EventReasonValidationFailed, err.Error())
+			r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 			return err
 		}
 	}
 
 	if err := validateArbiterSpec(instance, r.Log); err != nil {
 		r.Log.Error(err, "Failed to validate ArbiterSpec")
-		r.recorder.Event(instance, statusutil.EventTypeError, statusutil.EventReasonValidationFailed, err.Error())
+		r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 		return err
 	}
 	return nil

--- a/controllers/util/events.go
+++ b/controllers/util/events.go
@@ -1,9 +1,8 @@
 package util
 
 const (
-
-	// EventTypeError is used to alert user of failures that require user action
-	EventTypeError = "Error"
+	// EventTypeWarning is used to alert user of failures that require user action
+	EventTypeWarning = "Warning"
 
 	// EventReasonValidationFailed is used when the StorageCluster spec validation fails
 	EventReasonValidationFailed = "FailedValidation"


### PR DESCRIPTION
Fix Error via changing event type
"E0210 23:17:48.027136       1 event.go:334] Unsupported event type: 'Error'"

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Fix https://bugzilla.redhat.com/show_bug.cgi?id=1913357#c8