### PR TITLE
Bug 1927885: [Release 4.7] reverting readiness logic to match behavior of 4.6

### DIFF
--- a/controllers/storagecluster/readiness.go
+++ b/controllers/storagecluster/readiness.go
@@ -1,0 +1,25 @@
+package storagecluster
+
+import (
+	"errors"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+var ready bool
+
+var ReadinessChecker healthz.Checker = func(_ *http.Request) error {
+	if ready {
+		return nil
+	}
+	return errors.New("StorageCluster is not ready yet")
+}
+
+func ReadinessSet() {
+	ready = true
+}
+
+func ReadinessUnset() {
+	ready = false
+}

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -341,11 +341,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 
 		// If no operator whose conditions we are watching reports an error, then it is safe
 		// to set readiness.
-		r := statusutil.NewFileReady()
-		if err := r.Set(); err != nil {
-			reqLogger.Error(err, "Failed to mark operator ready")
-			return reconcile.Result{}, err
-		}
+		ReadinessSet()
 		if instance.Status.Phase != statusutil.PhaseClusterExpanding &&
 			!instance.Spec.ExternalStorage.Enable {
 			instance.Status.Phase = statusutil.PhaseReady
@@ -374,11 +370,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 
 		// If for any reason we marked ourselves !upgradeable...then unset readiness
 		if conditionsv1.IsStatusConditionFalse(instance.Status.Conditions, conditionsv1.ConditionUpgradeable) {
-			r := statusutil.NewFileReady()
-			if err := r.Unset(); err != nil {
-				reqLogger.Error(err, "Failed to mark operator unready")
-				return reconcile.Result{}, err
-			}
+			ReadinessUnset()
 		}
 		if instance.Status.Phase != statusutil.PhaseClusterExpanding &&
 			!instance.Spec.ExternalStorage.Enable {

--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -88,7 +88,7 @@ function gen_ocs_csv() {
 	$KUSTOMIZE edit set image ocs-dev/ocs-operator="$OCS_IMAGE"
 	popd
 	$KUSTOMIZE build config/manifests | $OPERATOR_SDK generate bundle -q --overwrite=false --version "$CSV_VERSION"
-	mv "$GOPATH"/src/github.com/openshift/ocs-operator/bundle/manifests/*clusterserviceversion.yaml $OCS_CSV
+	mv bundle/manifests/*clusterserviceversion.yaml $OCS_CSV
 	cp config/crd/bases/* $ocs_crds_outdir
 }
 
@@ -102,7 +102,7 @@ gen_ocs_csv
 echo "Manifests sourced into $OUTDIR_TEMPLATES directory"
 
 
-mv "$GOPATH"/src/github.com/openshift/ocs-operator/bundle/manifests $OCS_FINAL_DIR
-mv "$GOPATH"/src/github.com/openshift/ocs-operator/bundle/metadata "$(dirname $OCS_FINAL_DIR)"/metadata
-rm -rf "$GOPATH"/src/github.com/openshift/ocs-operator/bundle
-rm "$GOPATH"/src/github.com/openshift/ocs-operator/bundle.Dockerfile
+mv bundle/manifests $OCS_FINAL_DIR
+mv bundle/metadata "$(dirname $OCS_FINAL_DIR)"/metadata
+rm -rf bundle
+rm bundle.Dockerfile

--- a/main.go
+++ b/main.go
@@ -44,7 +44,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
 )
@@ -157,10 +156,12 @@ func main() {
 	}
 
 	// Add readiness probe
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", storagecluster.ReadinessChecker); err != nil {
 		setupLog.Error(err, "unable add a readiness check")
 		os.Exit(1)
 	}
+	storagecluster.ReadinessSet()
+	defer storagecluster.ReadinessUnset()
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
With the change to operator-sdk v1, the readiness probe changed from a simple file check to an HTTP get readiness probe.
In the process of accommodating this, the readiness logic in 4.7 changed slightly: [the ocs-operator would report ready even when the StorageCluster was in a progressing phase](https://bugzilla.redhat.com/show_bug.cgi?id=1927885). 

Through reading the code and manually testing, I found this to be the 4.6 readiness behavior:
  When ocs-operator first gets created: 1/1
  When storagecluster creation is in progress: 0/1
  When storagecluster creation completes: 1/1
  When storagecluster deleted: 1/1
  If the storagecluster is deleted while in progress: 0/1
  When storagecluster creation is reinitiated: 0/1

After making the changes, I deployed on an AWS Openshift cluster and manually checked that the behavior matches.
