### PR TITLE
StorageCluster: fix the logic for the minimum number of nodes

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -439,14 +439,15 @@ func getMinimumNodes(sc *ocsv1.StorageCluster) int {
 	// needs to override this assumption, we can provide a flag (like
 	// allowReplicasOnSameNode) in the future.
 
-	maxReplica := getMinDeviceSetReplica(sc)
+	maxReplica := getMinDeviceSetReplica(sc) * getReplicasPerFailureDomain(sc)
+
 	for _, deviceSet := range sc.Spec.StorageDeviceSets {
 		if deviceSet.Replica > maxReplica {
 			maxReplica = deviceSet.Replica
 		}
 	}
 
-	return maxReplica * getReplicasPerFailureDomain(sc)
+	return maxReplica
 }
 
 func getMonCount(nodeCount int, arbiter bool) int {


### PR DESCRIPTION
We always want to rely on the internal defaults for minimum number of
nodes. They are 4 for arbiter cluster and 3 for non-arbiter cluster.

In cases where the storage device set has a value greater than the
default we make the assumption that the user wants that many nodes.

Co-authored-by: Michael Adam <obnox@redhat.com>
Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>