### PR TITLE
Bug 1927885: [release-4.7] reverted readiness logic to match behavior of 4.6

### DIFF
--- a/controllers/storagecluster/readiness.go
+++ b/controllers/storagecluster/readiness.go
@@ -1,0 +1,25 @@
+package storagecluster
+
+import (
+	"errors"
+	"net/http"
+
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+var operatorReady bool
+
+var ReadinessChecker healthz.Checker = func(_ *http.Request) error {
+	if operatorReady {
+		return nil
+	}
+	return errors.New("StorageCluster is not ready yet")
+}
+
+func ReadinessSet() {
+	operatorReady = true
+}
+
+func ReadinessUnset() {
+	operatorReady = false
+}

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -341,11 +341,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 
 		// If no operator whose conditions we are watching reports an error, then it is safe
 		// to set readiness.
-		r := statusutil.NewFileReady()
-		if err := r.Set(); err != nil {
-			reqLogger.Error(err, "Failed to mark operator ready")
-			return reconcile.Result{}, err
-		}
+		ReadinessSet()
 		if instance.Status.Phase != statusutil.PhaseClusterExpanding &&
 			!instance.Spec.ExternalStorage.Enable {
 			instance.Status.Phase = statusutil.PhaseReady
@@ -374,11 +370,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 
 		// If for any reason we marked ourselves !upgradeable...then unset readiness
 		if conditionsv1.IsStatusConditionFalse(instance.Status.Conditions, conditionsv1.ConditionUpgradeable) {
-			r := statusutil.NewFileReady()
-			if err := r.Unset(); err != nil {
-				reqLogger.Error(err, "Failed to mark operator unready")
-				return reconcile.Result{}, err
-			}
+			ReadinessUnset()
 		}
 		if instance.Status.Phase != statusutil.PhaseClusterExpanding &&
 			!instance.Spec.ExternalStorage.Enable {

--- a/main.go
+++ b/main.go
@@ -44,7 +44,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	// +kubebuilder:scaffold:imports
 )
@@ -157,10 +156,11 @@ func main() {
 	}
 
 	// Add readiness probe
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("readyz", storagecluster.ReadinessChecker); err != nil {
 		setupLog.Error(err, "unable add a readiness check")
 		os.Exit(1)
 	}
+	storagecluster.ReadinessSet()
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {


### PR DESCRIPTION
With the move to operator-sdk v1, the readiness probe changed from a simple file
check to an HTTP GET call. In the process of accommodating this, the readiness
logic in 4.7 changed slightly: the ocs-operator would report ready even when the
StorageCluster was in a progressing phase.

The expected readiness behavior is as follows:
- When ocs-operator first gets created: 1/1
- When storagecluster creation is in progress: 0/1
- When storagecluster creation completes: 1/1
- When storagecluster is deleted: 1/1
- If the storagecluster is deleted while in progress: 0/1
- When storagecluster creation is reinitiated: 0/1

Backport of #1067 