### PR TITLE
Bug 1915807: [release-4.7] Enable new topology labels from Kubernetes

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -215,6 +215,16 @@ type StorageClusterStatus struct {
 	// +optional
 	FailureDomain string `json:"failureDomain,omitempty"`
 
+	// FailureDomainKey is the specific key used to find the locations available
+	// under a failure domain. For example topology.kubernetes.io/zone
+	// +optional
+	FailureDomainKey string `json:"failureDomainKey,omitempty"`
+
+	// FailureDomainValues is the list of locations available for a failure
+	// domain under the failure domain key.
+	// +optional
+	FailureDomainValues []string `json:"failureDomainValues,omitempty"`
+
 	// ExternalSecretHash holds the checksum value of external secret data.
 	ExternalSecretHash string `json:"externalSecretHash,omitempty"`
 

--- a/api/v1/topologymap.go
+++ b/api/v1/topologymap.go
@@ -41,6 +41,16 @@ func (m *NodeTopologyMap) Contains(topologyKey string, value string) bool {
 	return false
 }
 
+// ContainsKey checks whether the NodeTopologyMap contains any value for the
+// specified key
+func (m *NodeTopologyMap) ContainsKey(topologyKey string) bool {
+	if _, ok := m.Labels[topologyKey]; ok {
+		return true
+	}
+
+	return false
+}
+
 // Add adds a new value to the NodeTopologyMap under the specified key
 // USe it with Contains() to not allow duplicate values
 func (m *NodeTopologyMap) Add(topologyKey string, value string) {

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -514,6 +514,11 @@ func (in *StorageClusterStatus) DeepCopyInto(out *StorageClusterStatus) {
 		*out = new(NodeTopologyMap)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.FailureDomainValues != nil {
+		in, out := &in.FailureDomainValues, &out.FailureDomainValues
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	in.Images.DeepCopyInto(&out.Images)
 }
 

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -3803,6 +3803,16 @@ spec:
                 description: FailureDomain is the base CRUSH element Ceph will use
                   to distribute its data replicas for the default CephBlockPool
                 type: string
+              failureDomainKey:
+                description: FailureDomainKey is the specific key used to find the
+                  locations available under a failure domain. For example topology.kubernetes.io/zone
+                type: string
+              failureDomainValues:
+                description: FailureDomainValues is the list of locations available
+                  for a failure domain under the failure domain key.
+                items:
+                  type: string
+                type: array
               images:
                 description: Images holds the image reconcile status for all images
                   reconciled by the operator

--- a/controllers/storagecluster/cephblockpools.go
+++ b/controllers/storagecluster/cephblockpools.go
@@ -23,7 +23,7 @@ func (r *StorageClusterReconciler) newCephBlockPoolInstances(initData *ocsv1.Sto
 				Namespace: initData.Namespace,
 			},
 			Spec: cephv1.PoolSpec{
-				FailureDomain:  determineFailureDomain(initData),
+				FailureDomain:  getFailureDomain(initData),
 				Replicated:     generateCephReplicatedSpec(initData, "data"),
 				EnableRBDStats: true,
 			},

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -468,7 +468,7 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 
 		if noPlacement {
 			if topologyKey == "" {
-				topologyKey = determineFailureDomain(sc)
+				topologyKey = getFailureDomain(sc)
 			}
 
 			if topologyKey == "host" {
@@ -652,7 +652,7 @@ func allowUnsupportedCephVersion() bool {
 func generateStretchClusterSpec(sc *ocsv1.StorageCluster) *cephv1.StretchClusterSpec {
 	var zones []string
 	stretchClusterSpec := cephv1.StretchClusterSpec{}
-	stretchClusterSpec.FailureDomainLabel, zones = sc.Status.NodeTopologies.GetKeyValues(determineFailureDomain(sc))
+	stretchClusterSpec.FailureDomainLabel, zones = sc.Status.NodeTopologies.GetKeyValues(getFailureDomain(sc))
 
 	for _, zone := range zones {
 		if zone == sc.Spec.NodeTopologies.ArbiterLocation {

--- a/controllers/storagecluster/placement.go
+++ b/controllers/storagecluster/placement.go
@@ -53,7 +53,7 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookv1.Placement {
 		return placement
 	}
 
-	topologyKey := determineFailureDomain(sc)
+	topologyKey := getFailureDomain(sc)
 	topologyKey, _ = topologyMap.GetKeyValues(topologyKey)
 	if component == "mon" || component == "mds" || (component == "rgw" && getCephObjectStoreGatewayInstances(sc) > 1) {
 		if placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution != nil {

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -277,10 +277,6 @@ func (r *StorageClusterReconciler) reconcilePhases(
 			reqLogger.Error(err, "Failed to set node topology map")
 			return reconcile.Result{}, err
 		}
-
-		if instance.Status.FailureDomain == "" {
-			instance.Status.FailureDomain = determineFailureDomain(instance)
-		}
 	}
 
 	// in-memory conditions should start off empty. It will only ever hold

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -82,11 +82,36 @@ osd_memory_target_cgroup_limit_ratio = 0.5
 
 var storageClusterFinalizer = "storagecluster.ocs.openshift.io"
 
+const labelZoneRegionWithoutBeta = "failure-domain.kubernetes.io/region"
+const labelZoneFailureDomainWithoutBeta = "failure-domain.kubernetes.io/zone"
+const labelRookPrefix = "topology.rook.io"
+
 var validTopologyLabelKeys = []string{
-	"failure-domain.beta.kubernetes.io",
-	"failure-domain.kubernetes.io",
-	"kubernetes.io/hostname",
-	"topology.rook.io",
+	// This is the most preferred key as kubernetes recommends zone and region
+	// labels under this key.
+	corev1.LabelZoneRegionStable,
+
+	// These two are retained only to have backward compatibility; they are
+	// deprecated by kubernetes. If topology.kubernetes.io key has same label we
+	// will skip the next two from the topologyMap.
+	corev1.LabelZoneRegion,
+	labelZoneRegionWithoutBeta,
+
+	// This is the most preferred key as kubernetes recommends zone and region
+	// labels under this key.
+	corev1.LabelZoneFailureDomainStable,
+
+	// These two are retained only to have backward compatibility; they are
+	// deprecated by kubernetes. If topology.kubernetes.io key has same label we
+	// will skip the next two from the topologyMap.
+	corev1.LabelZoneFailureDomain,
+	labelZoneFailureDomainWithoutBeta,
+
+	// This is the kubernetes recommended label to select nodes.
+	corev1.LabelHostname,
+
+	// This label is used to assign rack based topology.
+	labelRookPrefix,
 }
 
 // +kubebuilder:rbac:groups=ocs.openshift.io,resources=*,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/storagecluster/topology.go
+++ b/controllers/storagecluster/topology.go
@@ -44,12 +44,18 @@ func getFailureDomain(sc *ocsv1.StorageCluster) string {
 	return sc.Status.FailureDomain
 }
 
+// getFailureDomainKey returns the failure domain key that was determined at the time of node topology reconcilation
+func getFailureDomainKey(sc *ocsv1.StorageCluster) string {
+	return sc.Status.FailureDomainKey
+}
+
 // setFailureDomain determines the appropriate Ceph failure domain based
 // on the storage cluster's topology map
 func setFailureDomain(sc *ocsv1.StorageCluster) {
 
 	// We don't change the failure domain after it is determined
 	if sc.Status.FailureDomain != "" {
+		sc.Status.FailureDomainKey, sc.Status.FailureDomainValues = sc.Status.NodeTopologies.GetKeyValues(sc.Status.FailureDomain)
 		return
 	}
 
@@ -73,6 +79,7 @@ func setFailureDomain(sc *ocsv1.StorageCluster) {
 	}
 
 	sc.Status.FailureDomain = failureDomain
+	sc.Status.FailureDomainKey, sc.Status.FailureDomainValues = sc.Status.NodeTopologies.GetKeyValues(sc.Status.FailureDomain)
 }
 
 // determinePlacementRack sorts the list of known racks in alphabetical order,
@@ -271,6 +278,7 @@ func (r *StorageClusterReconciler) reconcileNodeTopologyMap(sc *ocsv1.StorageClu
 
 	}
 
+	filterDuplicateLabels(sc, nodes, topologyMap)
 	setFailureDomain(sc)
 
 	if getFailureDomain(sc) == "rack" {
@@ -281,4 +289,87 @@ func (r *StorageClusterReconciler) reconcileNodeTopologyMap(sc *ocsv1.StorageClu
 	}
 
 	return nil
+}
+
+// nodesHaveIdenticalValuesForKeys will return true only if
+// a. all the nodes have all the keys in their map
+// b. for a given node, values for all the keys are the same
+func nodesHaveIdenticalValuesForKeys(nodes *corev1.NodeList, keys []string) bool {
+
+	var match = true
+	if len(keys) == 0 {
+		return match
+	}
+
+	for _, node := range nodes.Items {
+		v, found := node.Labels[keys[0]]
+		if !found {
+			match = false
+		}
+		for _, key := range keys {
+			vnext, found := node.Labels[key]
+			if !found {
+				match = false
+			}
+			if v != vnext {
+				match = false
+			}
+		}
+	}
+	return match
+}
+
+// filterDuplicateLabels modifies the topologyMap such that valid but redundant
+// labels are removed from it. The logic of determing which labels are redundant
+// should be all within this function.
+func filterDuplicateLabels(sc *ocsv1.StorageCluster, nodes *corev1.NodeList, topologyMap *ocsv1.NodeTopologyMap) {
+
+	if "" == getFailureDomain(sc) {
+		//This is the first time we are determining the failure domain
+
+		if topologyMap.ContainsKey(corev1.LabelZoneFailureDomainStable) {
+			// New label is found, use it and discard old
+			delete(topologyMap.Labels, corev1.LabelZoneFailureDomain)
+			delete(topologyMap.Labels, labelZoneFailureDomainWithoutBeta)
+		}
+		if topologyMap.ContainsKey(corev1.LabelZoneRegionStable) {
+			// New label is found, use it and discard old
+			delete(topologyMap.Labels, corev1.LabelZoneRegion)
+			delete(topologyMap.Labels, labelZoneRegionWithoutBeta)
+		}
+
+		// If the new label isn't found, we don't do anything. This leaves the behavior as it was before.
+		return
+	}
+
+	if corev1.LabelZoneFailureDomainStable == getFailureDomainKey(sc) || corev1.LabelZoneRegionStable == getFailureDomainKey(sc) {
+		// We are already using the new key, delete the old labels
+		delete(topologyMap.Labels, corev1.LabelZoneFailureDomain)
+		delete(topologyMap.Labels, labelZoneFailureDomainWithoutBeta)
+		delete(topologyMap.Labels, corev1.LabelZoneRegion)
+		delete(topologyMap.Labels, labelZoneRegionWithoutBeta)
+		return
+	}
+
+	// We have a failure domain selected already AND we know that it is not one
+	// of the new labels. Make a conservative switch to the new labels only if
+	// all the three zone labels have the same value for each node. To keep the
+	// behavior same as in the previous releases, we will delete the new labels
+	// from the topologyMap. If the user wishes to use new labels, they have to
+	// make sure values for the old and the new labels match
+	// TODO: revisit this in the upcoming releases
+	if nodesHaveIdenticalValuesForKeys(nodes, []string{corev1.LabelZoneFailureDomainStable, corev1.LabelZoneFailureDomain, labelZoneFailureDomainWithoutBeta}) {
+		delete(topologyMap.Labels, corev1.LabelZoneFailureDomain)
+		delete(topologyMap.Labels, labelZoneFailureDomainWithoutBeta)
+	} else {
+		delete(topologyMap.Labels, corev1.LabelZoneFailureDomainStable)
+	}
+
+	if nodesHaveIdenticalValuesForKeys(nodes, []string{corev1.LabelZoneRegionStable, corev1.LabelZoneRegion, labelZoneRegionWithoutBeta}) {
+		delete(topologyMap.Labels, corev1.LabelZoneRegion)
+		delete(topologyMap.Labels, labelZoneRegionWithoutBeta)
+	} else {
+		delete(topologyMap.Labels, corev1.LabelZoneRegionStable)
+	}
+
 }

--- a/controllers/storagecluster/topology_test.go
+++ b/controllers/storagecluster/topology_test.go
@@ -384,7 +384,8 @@ func TestFailureDomain(t *testing.T) {
 			label: "Case 1", // storagecluster has predefined failure domain of `zone`
 			storageCluster: &api.StorageCluster{
 				Status: api.StorageClusterStatus{
-					FailureDomain: "zone",
+					FailureDomain:  "zone",
+					NodeTopologies: ocsv1.NewNodeTopologyMap(),
 				},
 			},
 			expectedFailureDomain: "zone",
@@ -393,7 +394,8 @@ func TestFailureDomain(t *testing.T) {
 			label: "Case 2", // storagecluster has predefined failure domain of `rack`
 			storageCluster: &api.StorageCluster{
 				Status: api.StorageClusterStatus{
-					FailureDomain: "rack",
+					FailureDomain:  "rack",
+					NodeTopologies: ocsv1.NewNodeTopologyMap(),
 				},
 			},
 			expectedFailureDomain: "rack",
@@ -435,7 +437,8 @@ func TestFailureDomain(t *testing.T) {
 			label: "Case 5", // storagecluster has predefined failure domain of `host`
 			storageCluster: &api.StorageCluster{
 				Status: api.StorageClusterStatus{
-					FailureDomain: "host",
+					FailureDomain:  "host",
+					NodeTopologies: ocsv1.NewNodeTopologyMap(),
 				},
 			},
 			expectedFailureDomain: "host",
@@ -446,13 +449,17 @@ func TestFailureDomain(t *testing.T) {
 				Spec: api.StorageClusterSpec{
 					FlexibleScaling: true,
 				},
+				Status: api.StorageClusterStatus{
+					NodeTopologies: ocsv1.NewNodeTopologyMap(),
+				},
 			},
 			expectedFailureDomain: "host",
 		},
 	}
 
 	for _, tc := range testcases {
-		failureDomain := determineFailureDomain(tc.storageCluster)
+		setFailureDomain(tc.storageCluster)
+		failureDomain := getFailureDomain(tc.storageCluster)
 		assert.Equalf(t, tc.expectedFailureDomain, failureDomain, "[%s]: failed to get correct failure domain", tc.label)
 	}
 }

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -2352,6 +2352,14 @@ spec:
               failureDomain:
                 description: FailureDomain is the base CRUSH element Ceph will use to distribute its data replicas for the default CephBlockPool
                 type: string
+              failureDomainKey:
+                description: FailureDomainKey is the specific key used to find the locations available under a failure domain. For example topology.kubernetes.io/zone
+                type: string
+              failureDomainValues:
+                description: FailureDomainValues is the list of locations available for a failure domain under the failure domain key.
+                items:
+                  type: string
+                type: array
               images:
                 description: Images holds the image reconcile status for all images reconciled by the operator
                 properties:

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -3803,6 +3803,16 @@ spec:
                 description: FailureDomain is the base CRUSH element Ceph will use
                   to distribute its data replicas for the default CephBlockPool
                 type: string
+              failureDomainKey:
+                description: FailureDomainKey is the specific key used to find the
+                  locations available under a failure domain. For example topology.kubernetes.io/zone
+                type: string
+              failureDomainValues:
+                description: FailureDomainValues is the list of locations available
+                  for a failure domain under the failure domain key.
+                items:
+                  type: string
+                type: array
               images:
                 description: Images holds the image reconcile status for all images
                   reconciled by the operator


### PR DESCRIPTION
In ocs-operator we have been using two deprecated  topology label prefixes `failure-domain.beta.kubernetes.io` and `failure-domain.kubernetes.io`. 

The recommended label to use is `topology.kubernetes.io`. In this PR, we add support for the new label while also adhering to the following rules:
1. In a new install use only the new label
2. In existing setups, switch to the new label only if all the nodes have a equivalence of the labels i.e if node1 has zone1 set on the old labels then the new label should also have zone1 as its value.
3. In existing setups, if the values for all three labels don't match then we continue to use the old labels.
4. We also start persisting the failure domain key and values in the StorageCluster Status. This will probably make it easy to make a forced switch of label in a later release.

