### PR TITLE
storagecluster: add MinimumNodes field

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -65,6 +65,9 @@ type StorageClusterSpec struct {
 	// ArbiterSpec specifies the storage cluster options related to arbiter.
 	// If Arbiter is enabled, ArbiterLocation in the NodeTopologies must be specified.
 	Arbiter ArbiterSpec `json:"arbiter,omitempty"`
+	// MinimumNodes explicitly defines the minimum number of nodes for the
+	// StorageCluster
+	MinimumNodes int `json:"minimumNodes,omitempty"`
 }
 
 // KeyManagementServiceSpec provides a way to enable KMS

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -398,6 +398,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              minimumNodes:
+                description: MinimumNodes explicitly defines the minimum number of
+                  nodes for the StorageCluster
+                type: integer
               monDataDirHostPath:
                 type: string
               monPVCTemplate:

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -419,6 +419,10 @@ func getCephPoolReplicatedSize(sc *ocsv1.StorageCluster) uint {
 
 // getMinimumNodes returns the minimum number of nodes that are required for the Storage Cluster of various configurations
 func getMinimumNodes(sc *ocsv1.StorageCluster) int {
+	if sc.Spec.MinimumNodes != 0 {
+		return sc.Spec.MinimumNodes
+	}
+
 	// Case 1: When replicasPerFailureDomain is 1.
 	// A node is the smallest failure domain that is possible. We definitely
 	// want the devices in the same device set to be in different failure

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -306,6 +306,9 @@ spec:
                         type: string
                     type: object
                 type: object
+              minimumNodes:
+                description: MinimumNodes explicitly defines the minimum number of nodes for the StorageCluster
+                type: integer
               monDataDirHostPath:
                 type: string
               monPVCTemplate:

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -398,6 +398,10 @@ spec:
                         type: string
                     type: object
                 type: object
+              minimumNodes:
+                description: MinimumNodes explicitly defines the minimum number of
+                  nodes for the StorageCluster
+                type: integer
               monDataDirHostPath:
                 type: string
               monPVCTemplate:


### PR DESCRIPTION
I think there is benefit to finally adding an field to explicitly specify the minimum number of nodes required for the StorageCluster, for admins that know what they want. This would override the current algorithm that tries to determine the minimum number of nodes based on the replica count of the configured StorageDeviceSets and a few other StorageCluster fields.

Due to continued confusion, we could also consider deprecating the `Replica` field for StorageDeviceSets in favor of just using `Count` to explicitly represent the total number of OSDs. In so doing, we could move to using the MinimumNodes field exclusively, with an implicit default of 3 (or 4 for arbiter mode).

The only potential downside is that this would no longer allow the StorageDeviceSet to represent an estimate of the total *available* space of the StorageCluster (once Ceph replication is taken into account). I've personally never been fond of it anyway, since the estimate is rarely ever going to be close to accurate. This change would have no impact on the OpenShift Console, since they use [hardcoded constants](https://github.com/openshift/console/blob/master/frontend/packages/ceph-storage-plugin/src/constants/common.ts#L16-L17) for their replica calculations anyway.