### PR TITLE
Bug 1788492: use stricter podAntiAffinity rules for mons in non-stretched cluster

### DIFF
--- a/controllers/defaults/placements.go
+++ b/controllers/defaults/placements.go
@@ -27,8 +27,8 @@ var (
 
 		"mon": {
 			PodAntiAffinity: &corev1.PodAntiAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-					getWeightedPodAffinityTerm(100, "rook-ceph-mon"),
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+					getPodAffinityTerm("rook-ceph-mon"),
 				},
 			},
 		},

--- a/controllers/storagecluster/placement.go
+++ b/controllers/storagecluster/placement.go
@@ -21,6 +21,11 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookv1.Placement {
 		(&in).DeepCopyInto(&placement)
 	}
 
+	// ignore default PodAntiAffinity mon placement when arbiter is enabled
+	if component == "mon" && arbiterEnabled(sc) {
+		placement.PodAntiAffinity = &corev1.PodAntiAffinity{}
+	}
+
 	if component == "arbiter" {
 		if !sc.Spec.Arbiter.DisableMasterNodeToleration {
 			placement.Tolerations = append(placement.Tolerations, corev1.Toleration{

--- a/controllers/storagecluster/placement_test.go
+++ b/controllers/storagecluster/placement_test.go
@@ -3,6 +3,7 @@ package storagecluster
 import (
 	"testing"
 
+	api "github.com/openshift/ocs-operator/api/v1"
 	ocsv1 "github.com/openshift/ocs-operator/api/v1"
 	"github.com/openshift/ocs-operator/controllers/defaults"
 	rookv1 "github.com/rook/rook/pkg/apis/rook.io/v1"
@@ -105,15 +106,17 @@ var customPlacement = rookv1.Placement{
 func TestGetPlacement(t *testing.T) {
 	cases := []struct {
 		label              string
+		storageCluster     *api.StorageCluster
 		placements         rookv1.PlacementSpec
 		labelSelector      *metav1.LabelSelector
 		expectedPlacements rookv1.PlacementSpec
 		topologyMap        *ocsv1.NodeTopologyMap
 	}{
 		{
-			label:         "Test Case 1: Defaults are preserved i.e no placement and no label selector",
-			placements:    rookv1.PlacementSpec{},
-			labelSelector: nil,
+			label:          "Case 1: Defaults are preserved i.e no placement and no label selector",
+			storageCluster: mockStorageCluster,
+			placements:     rookv1.PlacementSpec{},
+			labelSelector:  nil,
 			expectedPlacements: rookv1.PlacementSpec{
 				"all": {
 					NodeAffinity: defaults.DefaultNodeAffinity,
@@ -126,9 +129,10 @@ func TestGetPlacement(t *testing.T) {
 			},
 		},
 		{
-			label:         "Case 2: The configured Placements override the defaults",
-			placements:    emptyPlacements,
-			labelSelector: nil,
+			label:          "Case 2: The configured Placements override the defaults",
+			storageCluster: mockStorageCluster,
+			placements:     emptyPlacements,
+			labelSelector:  nil,
 			expectedPlacements: rookv1.PlacementSpec{
 				"all": {
 					NodeAffinity: defaults.DefaultNodeAffinity,
@@ -140,9 +144,10 @@ func TestGetPlacement(t *testing.T) {
 			},
 		},
 		{
-			label:         "Case 3: LabelSelector to modify the default Placements correctly",
-			placements:    rookv1.PlacementSpec{},
-			labelSelector: &workerLabelSelector,
+			label:          "Case 3: LabelSelector to modify the default Placements correctly",
+			storageCluster: mockStorageCluster,
+			placements:     rookv1.PlacementSpec{},
+			labelSelector:  &workerLabelSelector,
 			expectedPlacements: rookv1.PlacementSpec{
 				"all": {
 					NodeAffinity: &workerNodeAffinity,
@@ -155,9 +160,10 @@ func TestGetPlacement(t *testing.T) {
 			},
 		},
 		{
-			label:         "Case 4: LabelSelector modifies an empty NodeAffinity",
-			placements:    emptyPlacements,
-			labelSelector: &workerLabelSelector,
+			label:          "Case 4: LabelSelector modifies an empty NodeAffinity",
+			storageCluster: mockStorageCluster,
+			placements:     emptyPlacements,
+			labelSelector:  &workerLabelSelector,
 			expectedPlacements: rookv1.PlacementSpec{
 				"all": {
 					NodeAffinity: &workerNodeAffinity,
@@ -169,9 +175,10 @@ func TestGetPlacement(t *testing.T) {
 			},
 		},
 		{
-			label:         "Case 5: LabelSelector modifies a configured NodeAffinity",
-			placements:    workerPlacements,
-			labelSelector: &masterLabelSelector,
+			label:          "Case 5: LabelSelector modifies a configured NodeAffinity",
+			storageCluster: mockStorageCluster,
+			placements:     workerPlacements,
+			labelSelector:  &masterLabelSelector,
 			expectedPlacements: rookv1.PlacementSpec{
 				"all": {
 					NodeAffinity: &corev1.NodeAffinity{
@@ -210,9 +217,10 @@ func TestGetPlacement(t *testing.T) {
 			},
 		},
 		{
-			label:         "Case 6: Empty LabelSelector sets no NodeAffinity",
-			placements:    rookv1.PlacementSpec{},
-			labelSelector: &emptyLabelSelector,
+			label:          "Case 6: Empty LabelSelector sets no NodeAffinity",
+			storageCluster: mockStorageCluster,
+			placements:     rookv1.PlacementSpec{},
+			labelSelector:  &emptyLabelSelector,
 			expectedPlacements: rookv1.PlacementSpec{
 				"all": {
 					Tolerations: defaults.DaemonPlacements["all"].Tolerations,
@@ -223,7 +231,8 @@ func TestGetPlacement(t *testing.T) {
 			},
 		},
 		{
-			label: "Case 7: Custom placement is applied without failure",
+			label:          "Case 7: Custom placement is applied without failure",
+			storageCluster: mockStorageCluster,
 			placements: rookv1.PlacementSpec{
 				"mon": customPlacement,
 			},
@@ -239,7 +248,8 @@ func TestGetPlacement(t *testing.T) {
 			},
 		},
 		{
-			label: "Case 8: Custom placement is modified by labelSelector",
+			label:          "Case 8: Custom placement is modified by labelSelector",
+			storageCluster: mockStorageCluster,
 			placements: rookv1.PlacementSpec{
 				"mon": customPlacement,
 			},
@@ -256,8 +266,9 @@ func TestGetPlacement(t *testing.T) {
 			},
 		},
 		{
-			label:      "Case 9: NodeTopologyMap modifies default mon placement",
-			placements: rookv1.PlacementSpec{},
+			label:          "Case 9: NodeTopologyMap modifies default mon placement",
+			storageCluster: mockStorageCluster,
+			placements:     rookv1.PlacementSpec{},
 			expectedPlacements: rookv1.PlacementSpec{
 				"all": {
 					NodeAffinity: defaults.DefaultNodeAffinity,
@@ -266,21 +277,18 @@ func TestGetPlacement(t *testing.T) {
 				"mon": {
 					NodeAffinity: defaults.DefaultNodeAffinity,
 					PodAntiAffinity: &corev1.PodAntiAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
 							{
-								Weight: 100,
-								PodAffinityTerm: corev1.PodAffinityTerm{
-									LabelSelector: &metav1.LabelSelector{
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "app",
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{"rook-ceph-mon"},
-											},
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "app",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"rook-ceph-mon"},
 										},
 									},
-									TopologyKey: zoneTopologyLabel,
 								},
+								TopologyKey: zoneTopologyLabel,
 							},
 						},
 					},
@@ -296,12 +304,28 @@ func TestGetPlacement(t *testing.T) {
 				},
 			},
 		},
+		{
+			label:          "Case 10: skip podAntiAffinity in mon placement in case of stretched cluster",
+			storageCluster: mockStorageClusterWithArbiter,
+			placements:     rookv1.PlacementSpec{},
+			labelSelector:  nil,
+			expectedPlacements: rookv1.PlacementSpec{
+				"all": {
+					NodeAffinity: defaults.DefaultNodeAffinity,
+					Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
+				},
+				"mon": {
+					NodeAffinity:    defaults.DefaultNodeAffinity,
+					PodAntiAffinity: &corev1.PodAntiAffinity{},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
 		var actualPlacement rookv1.Placement
 		sc := &ocsv1.StorageCluster{}
-		mockStorageCluster.DeepCopyInto(sc)
+		c.storageCluster.DeepCopyInto(sc)
 		sc.Spec.Placement = c.placements
 		sc.Spec.LabelSelector = c.labelSelector
 		sc.Status.NodeTopologies = c.topologyMap

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -60,6 +60,21 @@ var mockStorageCluster = &api.StorageCluster{
 	},
 }
 
+var mockStorageClusterWithArbiter = &api.StorageCluster{
+	TypeMeta: metav1.TypeMeta{
+		Kind: "StorageCluster",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      mockStorageClusterRequest.Name,
+		Namespace: mockStorageClusterRequest.Namespace,
+	},
+	Spec: api.StorageClusterSpec{
+		Arbiter: api.ArbiterSpec{
+			Enable: true,
+		},
+	},
+}
+
 var mockCephCluster = &rookCephv1.CephCluster{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      generateNameForCephCluster(mockStorageCluster),


### PR DESCRIPTION
use requiredDuringSchedulingIgnoredDuringExecution for podAntiAffinity for mons failure domain topology key to prevent two mons from starting in the same failure domain.

Tested on 4 node AWS cluster.
1. Intial placement of mons:
```
ip-10-0-154-79.ec2.internal --> us-east-1a
mon-b --> ip-10-0-155-80.ec2.internal --> us-east-1a
mon-a --> ip-10-0-161-91.ec2.internal --> us-east-1b
mon-c --> ip-10-0-199-137.ec2.internal --> us-east-1c
```
```
rook-ceph-mon-a-76b5745b8c-kw88k                                  2/2     Running     0          5m26s   10.128.2.23    ip-10-0-161-91.ec2.internal    <none>           <none>
rook-ceph-mon-b-b877796bc-nrm8c                                   2/2     Running     0          4m33s   10.129.2.19    ip-10-0-155-80.ec2.internal    <none>           <none>
rook-ceph-mon-c-77cc877bbc-js9nf                                  2/2     Running     0          4m10s   10.131.0.19    ip-10-0-199-137.ec2.internal   <none>           <none>
```

2. drained node ip-10-0-199-137.ec2.internal (us-east-1c) 
```
$ oc get nodes                            
NAME                           STATUS                     ROLES    AGE   VERSION
ip-10-0-151-150.ec2.internal   Ready                      master   55m   v1.19.0+d59ce34
ip-10-0-154-79.ec2.internal    Ready                      worker   44m   v1.19.0+d59ce34
ip-10-0-155-80.ec2.internal    Ready                      worker   45m   v1.19.0+d59ce34
ip-10-0-161-91.ec2.internal    Ready                      worker   47m   v1.19.0+d59ce34
ip-10-0-185-187.ec2.internal   Ready                      master   55m   v1.19.0+d59ce34
ip-10-0-199-137.ec2.internal   Ready,SchedulingDisabled   worker   47m   v1.19.0+d59ce34
ip-10-0-211-210.ec2.internal   Ready                      master   55m   v1.19.0+d59ce34
```

3. mon-c remained in pending state. 
```
rook-ceph-mon-a-76b5745b8c-kw88k                                  2/2     Running     0          11m     10.128.2.23    ip-10-0-161-91.ec2.internal    <none>           <none>
rook-ceph-mon-b-b877796bc-nrm8c                                   2/2     Running     0          10m     10.129.2.19    ip-10-0-155-80.ec2.internal    <none>           <none>
rook-ceph-mon-c-77cc877bbc-658z9                                  0/2     Pending     0          4m3s    <none>         <none>                         <none>           <none>
```

4. waited for 10 minutes for mon-c failover to mon-d. mon-d failover was not successfull as mon-d canary pod was in pending state.
```
rook-ceph-mon-a-76b5745b8c-kw88k                                  2/2     Running     0          22m   10.128.2.23    ip-10-0-161-91.ec2.internal    <none>           <none>
rook-ceph-mon-b-b877796bc-nrm8c                                   2/2     Running     0          21m   10.129.2.19    ip-10-0-155-80.ec2.internal    <none>           <none>
rook-ceph-mon-d-canary-5cdbccf6dc-qdjvd                           0/2     Pending     0          40s   <none>         <none>                         <none>           <none>
```


5. drained node was uncordoned. 
`kubectl uncordon  ip-10-0-199-137.ec2.internal`
  
  mon-d got created on the ip-10-0-199-137.ec2.internal

```
rook-ceph-mon-a-76b5745b8c-kw88k                                  2/2     Running     0          25m   10.128.2.23    ip-10-0-161-91.ec2.internal    <none>           <none>
rook-ceph-mon-b-b877796bc-nrm8c                                   2/2     Running     0          24m   10.129.2.19    ip-10-0-155-80.ec2.internal    <none>           <none>
rook-ceph-mon-d-8477cf9c75-x2mnl                                  2/2     Running     0          82s   10.131.0.27    ip-10-0-199-137.ec2.internal   <none>           <none>
```

6. New placement for mons:

```
affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: cluster.ocs.openshift.io/openshift-storage
            operator: Exists
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchExpressions:
          - key: app
            operator: In
            values:
            - rook-ceph-mon
        topologyKey: failure-domain.beta.kubernetes.io/zone
      - labelSelector:
          matchLabels:
            app: rook-ceph-mon
        topologyKey: kubernetes.io/hostname
```

Testing in a stretched cluster:
1.  Placement config in ceph cluster
```
placement:
    all:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: cluster.ocs.openshift.io/openshift-storage
              operator: Exists
      tolerations:
      - effect: NoSchedule
        key: node.ocs.openshift.io/storage
        operator: Equal
        value: "true"
    arbiter:
      tolerations:
      - effect: NoSchedule
        key: node-role.kubernetes.io/master
        operator: Exists
    mon:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: cluster.ocs.openshift.io/openshift-storage
              operator: Exists
      podAntiAffinity: {}
```

2. Mon placements:
```
rook-ceph-mon-a-5f8f4fbc48-97dfh                              2/2     Running            0          8m7s    10.131.0.10    ip-10-0-135-220.us-east-2.compute.internal   <none>           <none>
rook-ceph-mon-b-6996d9bd8-fcdtm                               2/2     Running            0          7m24s   10.131.2.9     ip-10-0-154-224.us-east-2.compute.internal   <none>           <none>
rook-ceph-mon-c-7446bcd6bb-x8wjd                              2/2     Running            0          6m36s   10.129.2.13    ip-10-0-163-201.us-east-2.compute.internal   <none>           <none>
rook-ceph-mon-d-c5b7c6d6-z7tjt                                2/2     Running            0          6m4s    10.128.2.18    ip-10-0-167-191.us-east-2.compute.internal   <none>           <none>
rook-ceph-mon-e-55778d77d6-rvkqw                              2/2     Running            0          5m      10.130.2.12    ip-10-0-206-27.us-east-2.compute.internal    <none>           <none>

```

```
ip-10-0-135-220.us-east-2.compute.internal - topology.kubernetes.io/zone=us-east-2a
ip-10-0-154-224.us-east-2.compute.internal - topology.kubernetes.io/zone=us-east-2a
ip-10-0-163-201.us-east-2.compute.internal - topology.kubernetes.io/zone=us-east-2b
ip-10-0-167-191.us-east-2.compute.internal - topology.kubernetes.io/zone=us-east-2b
ip-10-0-206-27.us-east-2.compute.internal  - topology.kubernetes.io/zone=us-east-2c
```

3. Mon Placement config on the mon pods:
```
affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: topology.kubernetes.io/zone
            operator: In
            values:
            - us-east-2a
          - key: cluster.ocs.openshift.io/openshift-storage
            operator: Exists
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
      - labelSelector:
          matchLabels:
            app: rook-ceph-mon
        topologyKey: kubernetes.io/hostname
```


Signed-off-by: Santosh Pillai <sapillai@redhat.com>