### PR TITLE
added node affinity to schedule osd on its parent prepare pod FD

### DIFF
--- a/controllers/storagecluster/placement.go
+++ b/controllers/storagecluster/placement.go
@@ -121,8 +121,9 @@ func (m MatchingLabelsSelector) ApplyToList(opts *client.ListOptions) {
 
 // setTopologyForAffinity assigns topology related values to the affinity placements
 func setTopologyForAffinity(placement *rookv1.Placement, selectorValue string, topologyKey string) {
-	placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.TopologyKey = topologyKey
-
+	if placement.PodAntiAffinity != nil {
+		placement.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution[0].PodAffinityTerm.TopologyKey = topologyKey
+	}
 	nodeZoneSelector := corev1.NodeSelectorRequirement{
 		Key:      topologyKey,
 		Operator: corev1.NodeSelectorOpIn,


### PR DESCRIPTION
This PR fixes the differences seen in the ceph osd tree and the actual osd placement 

- Added node affinity for prepare/osd placements thus making the OSD schedule on the same failure domain as of prepare pod

Signed-off-by: kesavan <kvellalo@redhat.com>