### PR TITLE
Bug 1909793: Fix fasttune check for Azure storageclass

### DIFF
--- a/pkg/controller/storagecluster/cephcluster.go
+++ b/pkg/controller/storagecluster/cephcluster.go
@@ -26,7 +26,7 @@ import (
 
 var throttleDiskTypes = []string{"gp2", "io1"}
 
-var throttleFastDiskTypes = []string{"managed-premium"}
+var throttleFastDiskTypes = []string{"StandardSSD_LRS", "Premium_LRS", "UltraSSD_LRS"}
 
 const (
 	// Hardcoding networkProvider to multus and this can be changed later to accomodate other providers
@@ -447,7 +447,7 @@ func (r *ReconcileStorageCluster) throttleStorageDevices(storageClassName string
 			return true, false, nil
 		}
 	case string(AzureDisk):
-		if contains(throttleFastDiskTypes, storageClass.Parameters["type"]) {
+		if contains(throttleFastDiskTypes, storageClass.Parameters["storageaccounttype"]) {
 			return false, true, nil
 		}
 	}

--- a/pkg/controller/storagecluster/storagecluster_controller_test.go
+++ b/pkg/controller/storagecluster/storagecluster_controller_test.go
@@ -209,7 +209,7 @@ func TestThrottleStorageDevices(t *testing.T) {
 				},
 				Provisioner: string(AzureDisk),
 				Parameters: map[string]string{
-					"type": "managed-premium",
+					"storageaccounttype": "Premium_LRS",
 				},
 			},
 			storageCluster: &api.StorageCluster{},


### PR DESCRIPTION
The Azure Storage class does not have a "type" parameter.
Fixed to check for storageaccounttype instead.

Signed-off-by: N Balachandran <nibalach@redhat.com>