### PR TITLE
Delete kms resources while uninstalling StorageCluster

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -98,10 +98,15 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 	if sc.Spec.ExternalStorage.Enable {
 		cephCluster = newExternalCephCluster(sc, r.images.Ceph, r.monitoringIP, r.monitoringPort)
 	} else {
-		kmsConfigMap, err := getKMSConfigMap(sc, r.Client, reachKMSProvider)
+		kmsConfigMap, err := getKMSConfigMap(sc, r.Client)
 		if err != nil {
 			r.Log.Error(err, "failed to procure KMS config")
 			return err
+		}
+		if kmsConfigMap != nil {
+			if err = reachKMSProvider(kmsConfigMap); err != nil {
+				return err
+			}
 		}
 		cephCluster = newCephCluster(sc, r.images.Ceph, r.nodeCount, r.serverVersion, kmsConfigMap, r.Log)
 	}

--- a/controllers/storagecluster/kms_resources.go
+++ b/controllers/storagecluster/kms_resources.go
@@ -30,18 +30,9 @@ var (
 	}
 )
 
-// kmsConfigMapValidateFunc is a functional type,
-// which validates the given configmap and returns an error if any
-type kmsConfigMapValidateFunc func(*corev1.ConfigMap) error
-
-var (
-	// just to make sure 'reachKMSProvider' function follows the validate function type
-	_ kmsConfigMapValidateFunc = reachKMSProvider
-)
-
 // getKMSConfigMap function try to return a KMS ConfigMap.
 // if 'kmsValidateFunc' function is present it try to validate the retrieved config map.
-func getKMSConfigMap(instance *ocsv1.StorageCluster, client client.Client, kmsValidateFunc kmsConfigMapValidateFunc) (*corev1.ConfigMap, error) {
+func getKMSConfigMap(instance *ocsv1.StorageCluster, client client.Client) (*corev1.ConfigMap, error) {
 	// if 'KMS' is not enabled, nothing to fetch
 	if !instance.Spec.Encryption.KeyManagementService.Enable {
 		return nil, nil
@@ -56,10 +47,6 @@ func getKMSConfigMap(instance *ocsv1.StorageCluster, client client.Client, kmsVa
 	)
 	if err != nil {
 		return nil, err
-	}
-	// if validation function is provided, use it
-	if kmsValidateFunc != nil {
-		err = kmsValidateFunc(&kmsConfigMap)
 	}
 	return &kmsConfigMap, err
 }

--- a/controllers/storagecluster/kms_resources.go
+++ b/controllers/storagecluster/kms_resources.go
@@ -35,7 +35,7 @@ var (
 type kmsConfigMapValidateFunc func(*corev1.ConfigMap) error
 
 var (
-	// just to make sure 'isKMSProviderReachable' function follows the validate function type
+	// just to make sure 'reachKMSProvider' function follows the validate function type
 	_ kmsConfigMapValidateFunc = reachKMSProvider
 )
 

--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -146,7 +146,7 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 	// Add KMS details to Noobaa spec, if available
 	// no need to pass any validation function,
 	// as validation already done during cephcluster creation time.
-	if kmsConfig, err := getKMSConfigMap(sc, r.Client, nil); err != nil {
+	if kmsConfig, err := getKMSConfigMap(sc, r.Client); err != nil {
 		return err
 	} else if kmsConfig != nil {
 		nb.Spec.Security.KeyManagementService.ConnectionDetails = kmsConfig.Data

--- a/controllers/storagecluster/uninstall_reconciler.go
+++ b/controllers/storagecluster/uninstall_reconciler.go
@@ -311,6 +311,11 @@ func (r *StorageClusterReconciler) deleteResources(sc *ocsv1.StorageCluster) err
 		return err
 	}
 
+	err = deleteKMSResources(r, sc)
+	if err != nil {
+		return err
+	}
+
 	// TODO: skip the deletion of these labels till we figure out a way to wait
 	// for the cleanup jobs
 	//err = r.deleteNodeAffinityKeyFromNodes(sc)


### PR DESCRIPTION
KMS resources, such as ConfigMaps and SecretToken which were created at the time of StorageCluster creation, are lurking around even after we uninstall the StorageCluster.

This PR is to delete those resources at the time of StorageCluster uninstallation.