### PR TITLE
Add a pkg custom events and start using it for storage cluster

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -205,7 +205,7 @@ func (r *StorageClusterReconciler) initializeImagesStatus(sc *ocsv1.StorageClust
 func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.StorageCluster, request reconcile.Request) error {
 	if err := versionCheck(instance, r.Log); err != nil {
 		r.Log.Error(err, "Failed to validate version")
-		r.recorder.ReportIfNotPresent(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
+		r.recorder.ReportIfNotPresent(instance, corev1.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 		instance.Status.Phase = statusutil.PhaseError
 		if updateErr := r.Client.Status().Update(context.TODO(), instance); updateErr != nil {
 			return updateErr
@@ -216,7 +216,7 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 	if !instance.Spec.ExternalStorage.Enable {
 		if err := r.validateStorageDeviceSets(instance); err != nil {
 			r.Log.Error(err, "Failed to validate StorageDeviceSets")
-			r.recorder.ReportIfNotPresent(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
+			r.recorder.ReportIfNotPresent(instance, corev1.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 			instance.Status.Phase = statusutil.PhaseError
 			if updateErr := r.Client.Status().Update(context.TODO(), instance); updateErr != nil {
 				return updateErr
@@ -227,7 +227,7 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 
 	if err := validateArbiterSpec(instance, r.Log); err != nil {
 		r.Log.Error(err, "Failed to validate ArbiterSpec")
-		r.recorder.ReportIfNotPresent(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
+		r.recorder.ReportIfNotPresent(instance, corev1.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 		instance.Status.Phase = statusutil.PhaseError
 		if updateErr := r.Client.Status().Update(context.TODO(), instance); updateErr != nil {
 			return updateErr
@@ -304,7 +304,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 		if contains(instance.GetFinalizers(), storageClusterFinalizer) {
 			if err := r.deleteResources(instance); err != nil {
 				r.Log.Info("Uninstall in progress", "Status", err)
-				r.recorder.ReportIfNotPresent(instance, statusutil.EventTypeWarning, statusutil.EventReasonUninstallPending, err.Error())
+				r.recorder.ReportIfNotPresent(instance, corev1.EventTypeWarning, statusutil.EventReasonUninstallPending, err.Error())
 				return reconcile.Result{RequeueAfter: time.Second * time.Duration(1)}, nil
 			}
 			r.Log.Info("Removing finalizer")

--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -205,7 +205,7 @@ func (r *StorageClusterReconciler) initializeImagesStatus(sc *ocsv1.StorageClust
 func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.StorageCluster, request reconcile.Request) error {
 	if err := versionCheck(instance, r.Log); err != nil {
 		r.Log.Error(err, "Failed to validate version")
-		r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
+		r.recorder.ReportIfNotPresent(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 		instance.Status.Phase = statusutil.PhaseError
 		if updateErr := r.Client.Status().Update(context.TODO(), instance); updateErr != nil {
 			return updateErr
@@ -216,7 +216,7 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 	if !instance.Spec.ExternalStorage.Enable {
 		if err := r.validateStorageDeviceSets(instance); err != nil {
 			r.Log.Error(err, "Failed to validate StorageDeviceSets")
-			r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
+			r.recorder.ReportIfNotPresent(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 			instance.Status.Phase = statusutil.PhaseError
 			if updateErr := r.Client.Status().Update(context.TODO(), instance); updateErr != nil {
 				return updateErr
@@ -227,7 +227,7 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 
 	if err := validateArbiterSpec(instance, r.Log); err != nil {
 		r.Log.Error(err, "Failed to validate ArbiterSpec")
-		r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
+		r.recorder.ReportIfNotPresent(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 		instance.Status.Phase = statusutil.PhaseError
 		if updateErr := r.Client.Status().Update(context.TODO(), instance); updateErr != nil {
 			return updateErr
@@ -304,7 +304,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 		if contains(instance.GetFinalizers(), storageClusterFinalizer) {
 			if err := r.deleteResources(instance); err != nil {
 				r.Log.Info("Uninstall in progress", "Status", err)
-				r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonUninstallPending, err.Error())
+				r.recorder.ReportIfNotPresent(instance, statusutil.EventTypeWarning, statusutil.EventReasonUninstallPending, err.Error())
 				return reconcile.Result{RequeueAfter: time.Second * time.Duration(1)}, nil
 			}
 			r.Log.Info("Removing finalizer")

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,7 +82,7 @@ type StorageClusterReconciler struct {
 	nodeCount      int
 	platform       *Platform
 	images         ImageMap
-	recorder       record.EventRecorder
+	recorder       *util.EventReporter
 }
 
 // SetupWithManager sets up a controller with manager
@@ -97,7 +96,7 @@ func (r *StorageClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	r.platform = &Platform{}
-	r.recorder = mgr.GetEventRecorderFor("controller_storagecluster")
+	r.recorder = util.NewEventReporter(mgr.GetEventRecorderFor("controller_storagecluster"))
 
 	// Compose a predicate that is an OR of the specified predicates
 	scPredicate := util.ComposePredicates(

--- a/controllers/util/events.go
+++ b/controllers/util/events.go
@@ -10,9 +10,6 @@ import (
 )
 
 const (
-	// EventTypeWarning is used to alert user of failures that require user action
-	EventTypeWarning = "Warning"
-
 	// EventReasonValidationFailed is used when the StorageCluster spec validation fails
 	EventReasonValidationFailed = "FailedValidation"
 

--- a/controllers/util/events.go
+++ b/controllers/util/events.go
@@ -1,5 +1,14 @@
 package util
 
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
 const (
 	// EventTypeWarning is used to alert user of failures that require user action
 	EventTypeWarning = "Warning"
@@ -10,3 +19,52 @@ const (
 	// EventReasonUninstallPending is used when the StorageCluster uninstall is Pending
 	EventReasonUninstallPending = "UninstallPending"
 )
+
+// EventReporter is custom events reporter type which allows user to limit the events
+type EventReporter struct {
+	recorder record.EventRecorder
+
+	// lastReportedEvent will have a last captured event
+	lastReportedEvent map[string]string
+
+	// lastReportedEventTime will be the time of lastReportedEvent
+	lastReportedEventTime map[string]time.Time
+}
+
+// NewEventReporter returns EventReporter object
+func NewEventReporter(recorder record.EventRecorder) *EventReporter {
+	return &EventReporter{
+		recorder:              recorder,
+		lastReportedEvent:     make(map[string]string),
+		lastReportedEventTime: make(map[string]time.Time),
+	}
+}
+
+// ReportIfNotPresent will report event if lastReportedEvent is not the same in last 60 minutes
+func (rep *EventReporter) ReportIfNotPresent(instance runtime.Object, eventType, eventReason, msg string) {
+
+	nameSpacedName, err := getNameSpacedName(instance)
+	if err != nil {
+		return
+	}
+
+	eventKey := getEventKey(eventType, eventReason, msg)
+
+	if rep.lastReportedEvent[nameSpacedName] != eventKey || rep.lastReportedEventTime[nameSpacedName].Add(time.Minute*60).Before(time.Now()) {
+		rep.lastReportedEvent[nameSpacedName] = eventKey
+		rep.lastReportedEventTime[nameSpacedName] = time.Now()
+		rep.recorder.Event(instance, eventType, eventReason, msg)
+	}
+}
+
+func getNameSpacedName(instance runtime.Object) (string, error) {
+	objMeta, err := meta.Accessor(instance)
+	if err != nil {
+		return "", err
+	}
+	return objMeta.GetNamespace() + ":" + objMeta.GetName(), nil
+}
+
+func getEventKey(eventType, eventReason, msg string) string {
+	return fmt.Sprintf("%s:%s:%s", eventType, eventReason, msg)
+}


### PR DESCRIPTION
The PR contains a new pkg `customevents` which will allow an operator to limit the events and stop spamming the APIServer.

cc @raghavendra-talur @rohantmp 

PS: I have added this as a new pkg because we need this at the rook layer also.