### PR TITLE
Fix "OpenShift(R)" usage in Quickstarts

### DIFF
--- a/controllers/storagecluster/quickstart_constants.go
+++ b/controllers/storagecluster/quickstart_constants.go
@@ -13,7 +13,7 @@ spec:
   durationMinutes: 10
   icon: data:image/svg+xml;base64,PHN2ZyBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxMDAgMTAwIiBoZWlnaHQ9IjEwMCIgdmlld0JveD0iMCAwIDEwMCAxMDAiIHdpZHRoPSIxMDAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTY2LjcgNTUuOGM2LjYgMCAxNi4xLTEuNCAxNi4xLTkuMiAwLS42IDAtMS4yLS4yLTEuOGwtMy45LTE3Yy0uOS0zLjctMS43LTUuNC04LjMtOC43LTUuMS0yLjYtMTYuMi02LjktMTkuNS02LjktMy4xIDAtNCA0LTcuNiA0LTMuNSAwLTYuMS0yLjktOS40LTIuOS0zLjIgMC01LjIgMi4xLTYuOCA2LjYgMCAwLTQuNCAxMi41LTUgMTQuMy0uMS4zLS4xLjctLjEgMSAuMSA0LjcgMTkuMiAyMC42IDQ0LjcgMjAuNm0xNy4xLTZjLjkgNC4zLjkgNC44LjkgNS4zIDAgNy40LTguMyAxMS40LTE5LjEgMTEuNC0yNC42IDAtNDYuMS0xNC40LTQ2LjEtMjMuOSAwLTEuMy4zLTIuNi44LTMuOS04LjkuNS0yMC4zIDIuMS0yMC4zIDEyLjIgMCAxNi41IDM5LjIgMzYuOSA3MC4yIDM2LjkgMjMuOCAwIDI5LjgtMTAuNyAyOS44LTE5LjIgMC02LjctNS44LTE0LjMtMTYuMi0xOC44IiBmaWxsPSIjZWQxYzI0Ii8+PHBhdGggZD0ibTgzLjggNDkuOGMuOSA0LjMuOSA0LjguOSA1LjMgMCA3LjQtOC4zIDExLjQtMTkuMSAxMS40LTI0LjYgMC00Ni4xLTE0LjQtNDYuMS0yMy45IDAtMS4zLjMtMi42LjgtMy45bDEuOS00LjhjLS4xLjMtLjEuNy0uMSAxIDAgNC44IDE5LjEgMjAuNyA0NC43IDIwLjcgNi42IDAgMTYuMS0xLjQgMTYuMS05LjIgMC0uNiAwLTEuMi0uMi0xLjh6IiBmaWxsPSIjMDEwMTAxIi8+PC9zdmc+
   description: "Learn how to create persistent files, object storage and connect it with your applications."
-  introduction: "Getting started with OpenShift Container Storage
+  introduction: "Getting started with OpenShift® Container Storage
 
 
  RedHat OpenShift Container Storage provides a highly integrated collection of cloud storage and data services for OpenShift Container Platform.
@@ -151,7 +151,7 @@ spec:
     needs.
   prerequisites: ["Getting Started with OpenShift Container Storage"]
   introduction: In this tour you will learn about the various configurations available
-    to customize your OpenShift Container Storage deployment.
+    to customize your OpenShift® Container Storage deployment.
   tasks:
     - title: Expand the OCS Storage Cluster
       description: |-


### PR DESCRIPTION
Changes based on https://github.com/openshift/console-operator/pull/509#issuecomment-785383525, that addresses the ® symbol usage in Quickstarts.