### PR TITLE
Bug 1936405: unmanage labels for exporter ServiceMonitor

### DIFF
--- a/pkg/controller/storagecluster/exporter.go
+++ b/pkg/controller/storagecluster/exporter.go
@@ -171,8 +171,8 @@ func CreateOrUpdateServiceMonitor(r *ReconcileStorageCluster, instance *ocsv1.St
 		}
 		return nil, fmt.Errorf("failed to retrieve metrics exporter servicemonitor %v. %v", namespacedName, err)
 	}
-	serviceMonitor.ResourceVersion = oldSm.ResourceVersion
-	err = r.client.Update(context.TODO(), serviceMonitor)
+	oldSm.Spec = serviceMonitor.Spec
+	err = r.client.Update(context.TODO(), oldSm)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update metrics exporter servicemonitor %v. %v", namespacedName, err)
 	}


### PR DESCRIPTION
Create ServiceMonitor with default labels but do not reconcile
on label updates. This allows users to add custom labels to
ServiceMonitor which can be used by custom Prometheus instances
for monitoring.

Backport of #1099

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>