### PR TITLE
hack/source-manifests: Do not use quotes

### DIFF
--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -41,9 +41,11 @@ function dump_noobaa_csv() {
 	mkdir -p $noobaa_crds_outdir
 
 	echo "Dumping Noobaa csv using command: $IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_csv_cmd"
-	($IMAGE_RUN_CMD "$NOOBAA_IMAGE" "$noobaa_dump_csv_cmd") > $NOOBAA_CSV
+	# shellcheck disable=SC2086
+	($IMAGE_RUN_CMD "$NOOBAA_IMAGE" $noobaa_dump_csv_cmd) > $NOOBAA_CSV
 	echo "Dumping Noobaa crds using command: $IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_crds_cmd"
-	($IMAGE_RUN_CMD "$NOOBAA_IMAGE" "$noobaa_dump_crds_cmd") > $noobaa_crds_outdir/noobaa-crd.yaml
+	# shellcheck disable=SC2086
+	($IMAGE_RUN_CMD "$NOOBAA_IMAGE" $noobaa_dump_crds_cmd) > $noobaa_crds_outdir/noobaa-crd.yaml
 }
 
 # ==== DUMP ROOK YAMLS ====


### PR DESCRIPTION
We cannot use quotes around the noobaa dump csv cmd (olm csv yaml)
because otherwise, these will be treated as a single argument instead of
three arguments and the csv generation fails.

Signed-off-by: Boris Ranto <branto@redhat.com>