### PR TITLE
Increase mon failover timeout to 15 min for IBMCloudPlatformType

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	v1 "github.com/openshift/api/config/v1"
 	objectreferencesv1 "github.com/openshift/custom-resource-status/objectreferences/v1"
 	ocsv1 "github.com/openshift/ocs-operator/api/v1"
 	"github.com/openshift/ocs-operator/controllers/defaults"
@@ -116,9 +117,17 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 		return err
 	}
 
+	platform, err := r.platform.GetPlatform(r.Client)
+	if err != nil {
+		r.Log.Error(err, "Failed to get platform")
+	} else if platform == v1.IBMCloudPlatformType || platform == IBMCloudCosPlatformType {
+		r.Log.Info(fmt.Sprintf("Increasing Mon failover timeout to 15m for %s", platform))
+		cephCluster.Spec.HealthCheck.DaemonHealth.Monitor.Timeout = "15m"
+	}
+
 	// Check if this CephCluster already exists
 	found := &cephv1.CephCluster{}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: cephCluster.Name, Namespace: cephCluster.Namespace}, found)
+	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: cephCluster.Name, Namespace: cephCluster.Namespace}, found)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			if sc.Spec.ExternalStorage.Enable {

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v2/pkg/apis/noobaa/v1alpha1"
+	v1 "github.com/openshift/api/config/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	api "github.com/openshift/ocs-operator/api/v1"
 	"github.com/openshift/ocs-operator/controllers/defaults"
@@ -99,6 +100,52 @@ func TestEnsureCephCluster(t *testing.T) {
 			assert.Empty(t, reconciler.conditions)
 		}
 
+	}
+}
+
+func TestCephClusterMonTimeout(t *testing.T) {
+	// cases for testing
+	cases := []struct {
+		label    string
+		platform v1.PlatformType
+	}{
+		{
+			label:    "case 1", // when the platform is not identified
+			platform: v1.NonePlatformType,
+		},
+		{
+			label:    "case 2", // when platform is IBMCloudPlatformType
+			platform: v1.IBMCloudPlatformType,
+		},
+		{
+			label:    "case 3", // when platform is IBMCloudCosPlatformType
+			platform: IBMCloudCosPlatformType,
+		},
+	}
+
+	for _, c := range cases {
+		sc := &api.StorageCluster{}
+		mockStorageCluster.DeepCopyInto(sc)
+		sc.Status.Images.Ceph = &api.ComponentImageStatus{}
+
+		reconciler := createFakeStorageClusterReconciler(t, mockCephCluster)
+
+		reconciler.platform = &Platform{
+			platform: c.platform,
+		}
+
+		var obj ocsCephCluster
+		err := obj.ensureCreated(&reconciler, sc)
+		assert.NoError(t, err)
+
+		cc := newCephCluster(sc, "", 3, reconciler.serverVersion, nil, log)
+		err = reconciler.Client.Get(context.TODO(), mockCephClusterNamespacedName, cc)
+		assert.NoError(t, err)
+		if c.platform == v1.IBMCloudPlatformType || c.platform == IBMCloudCosPlatformType {
+			assert.Equal(t, "15m", cc.Spec.HealthCheck.DaemonHealth.Monitor.Timeout)
+		} else {
+			assert.Equal(t, "", cc.Spec.HealthCheck.DaemonHealth.Monitor.Timeout)
+		}
 	}
 }
 


### PR DESCRIPTION
mon C take time to come up on IBMCloudPlatform which timeouts and Mon d gets created. So increase the mon
failover timeout to 15 min for IBMCloudPlatformType to allow enough time
for mon c to come up.

Signed-off-by: rohan47 <rohgupta@redhat.com>