### PR TITLE
Set failure domain to host if flexibleScaling is enabled

### DIFF
--- a/controllers/storagecluster/topology.go
+++ b/controllers/storagecluster/topology.go
@@ -65,6 +65,9 @@ func setFailureDomain(sc *ocsv1.StorageCluster) {
 	// as we need +1 scaling
 	if sc.Spec.FlexibleScaling {
 		failureDomain = "host"
+		sc.Status.FailureDomain = failureDomain
+		sc.Status.FailureDomainKey, sc.Status.FailureDomainValues = sc.Status.NodeTopologies.GetKeyValues(sc.Status.FailureDomain)
+		return
 	}
 
 	// If sufficient zones are available then we select zone as the failure domain


### PR DESCRIPTION
Set the failure domain to host if flexible scaling is enabled
even if there are 3 or more zones.

Signed-off-by: N Balachandran <nibalach@redhat.com>