### PR TITLE
Generate ci-operator bundle for master branches of all projects

### DIFF
--- a/hack/generate-master-appregistry.sh
+++ b/hack/generate-master-appregistry.sh
@@ -7,25 +7,4 @@ source hack/generate-appregistry.sh
 
 CSV_FILE=build/_output/appregistry/olm-catalog/ocs-operator/${CSV_VERSION}/ocs-operator.v${CSV_VERSION}.clusterserviceversion.yaml
 
-latest_master_version() {
-  URL=https://registry.hub.docker.com/v2/repositories/$1/tags/
-  FILTER=${2:-.}
-  VERSION=$(curl -s -S "$URL" | jq '."results"[]["name"]' | grep "$FILTER" | sort -nr | head -n1 | tr -d '"')
-  echo "$VERSION"
-}
-
-CEPH_PATTERN="\(travisn\|ceph\)\/ceph:.*$"
-CEPH_VERSION=$(latest_master_version ceph/ceph)
-sed -i "s/${CEPH_PATTERN}/ceph\/ceph:${CEPH_VERSION}/" $CSV_FILE
-
-NOOBAA_CORE_PATTERN="noobaa\/noobaa-core:[0-9.-]*$"
-NOOBAA_CORE_VERSION=$(latest_master_version 'noobaa/noobaa-core' master)
-sed -i "s/${NOOBAA_CORE_PATTERN}/noobaa\/noobaa-core:${NOOBAA_CORE_VERSION}/" $CSV_FILE
-
-NOOBAA_OPERATOR_PATTERN="noobaa\/noobaa-operator:[0-9.-]*$"
-NOOBAA_OPERATOR_VERSION=$(latest_master_version noobaa/noobaa-operator master)
-sed -i "s/${NOOBAA_OPERATOR_PATTERN}/noobaa\/noobaa-operator:${NOOBAA_OPERATOR_VERSION}/" $CSV_FILE
-
-ROOK_PATTERN="rook\/ceph:v[0-9.-]*$"
-ROOK_VERSION="master"
-sed -i "s/${ROOK_PATTERN}/rook\/ceph:${ROOK_VERSION}/" ${CSV_FILE}
+source hack/generate-master-csv.sh

--- a/hack/generate-master-bundle.sh
+++ b/hack/generate-master-bundle.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+CSV_VERSION=4.8.0
+source hack/common.sh
+
+CSV_FILE=/manifests/ocs-operator.clusterserviceversion.yaml
+
+source hack/generate-master-csv.sh

--- a/hack/generate-master-csv.sh
+++ b/hack/generate-master-csv.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -e
+
+latest_master_version() {
+  URL=https://registry.hub.docker.com/v2/repositories/$1/tags/
+  FILTER=${2:-.}
+  VERSION=$(curl -s -S "$URL" | jq '."results"[]["name"]' | grep "$FILTER" | sort -nr | head -n1 | tr -d '"')
+  echo "$VERSION"
+}
+
+CEPH_PATTERN="ceph\/daemon-base:.*$"
+CEPH_VERSION=$(latest_master_version ceph/daemon-base)
+sed -i "s/${CEPH_PATTERN}/ceph\/daemon-base:${CEPH_VERSION}/" "$CSV_FILE"
+
+NOOBAA_CORE_PATTERN="noobaa\/noobaa-core:[0-9.-]*$"
+NOOBAA_CORE_VERSION=$(latest_master_version 'noobaa/noobaa-core' master)
+sed -i "s/${NOOBAA_CORE_PATTERN}/noobaa\/noobaa-core:${NOOBAA_CORE_VERSION}/" "$CSV_FILE"
+
+NOOBAA_OPERATOR_PATTERN="noobaa\/noobaa-operator:[0-9.-]*$"
+NOOBAA_OPERATOR_VERSION=$(latest_master_version noobaa/noobaa-operator master)
+sed -i "s/${NOOBAA_OPERATOR_PATTERN}/noobaa\/noobaa-operator:${NOOBAA_OPERATOR_VERSION}/" "$CSV_FILE"
+
+ROOK_PATTERN="rook\/ceph:v[a-zA-Z0-9.-]*$"
+ROOK_VERSION="master"
+sed -i "s/${ROOK_PATTERN}/rook\/ceph:${ROOK_VERSION}/" "${CSV_FILE}"

--- a/openshift-ci/Dockerfile.bundle.master
+++ b/openshift-ci/Dockerfile.bundle.master
@@ -1,0 +1,31 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS stage
+
+LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
+LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
+LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
+LABEL operators.operatorframework.io.bundle.package.v1=ocs-operator
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+
+COPY deploy/bundle/manifests /manifests/
+COPY deploy/bundle/metadata/annotations.yaml /metadata/annotations.yaml
+
+COPY hack /hack/
+# the jq package is needed to query which container image represents the latest
+# master branch code for some OCS projects.
+RUN microdnf install -y jq
+RUN hack/generate-master-bundle.sh
+RUN rm -rf /hack/
+
+# These are three labels needed to control how the pipeline should handle this container image
+# This first label tells the pipeline that this is a bundle image and should be
+# delivered via an index image
+LABEL com.redhat.delivery.operator.bundle=true
+# This second label tells the pipeline which versions of OpenShift the operator supports.
+# This is used to control which index images should include this operator.
+LABEL com.redhat.openshift.versions="v4.5"
+# This third label tells the pipeline that this operator should *also* be supported on OCP 4.4 and
+# earlier.  It is used to control whether or not the pipeline should attempt to automatically
+# backport this content into the old appregistry format and upload it to the quay.io application
+# registry endpoints.
+LABEL com.redhat.delivery.backport=true


### PR DESCRIPTION
This change allows ci-operator to generate a bundle for
OCS-operator which pulls from the master branches of the
component projects of OCS.

Signed-off-by: egafford <egafford@redhat.com>