### PR TITLE
must-gather: noobaa obc list command not working

### DIFF
--- a/must-gather/collection-scripts/gather_noobaa_resources
+++ b/must-gather/collection-scripts/gather_noobaa_resources
@@ -21,20 +21,20 @@ noobaa_resources+=(backingstore)
 noobaa_resources+=(bucketclass)
 
 noobaa_cli=()
-noobaa_cli+=("obc list")
 noobaa_cli+=("status")
+noobaa_cli+=("obc list")
 
 /templates/noobaa.template
 
 mkdir -p "${NOOBAA_COLLLECTION_PATH}/raw_output/}"
 
 # Run the Collection of Noobaa cli using must-gather
+# shellcheck disable=SC2086
 for cli in "${noobaa_cli[@]}"; do
     echo "collecting dump of ${cli}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
     COMMAND_OUTPUT_FILE="${NOOBAA_COLLLECTION_PATH}"/raw_output/${cli// /_}
-    { timeout 180 noobaa "${cli}" --namespace openshift-storage >> "${COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+    { timeout 180 noobaa ${cli} --namespace openshift-storage >> "${COMMAND_OUTPUT_FILE}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 done
-
 noobaa diagnose --dir "${NOOBAA_COLLLECTION_PATH}"/raw_output/ --namespace openshift-storage  >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
 
 # Run the Collection of NooBaa Resources using must-gather


### PR DESCRIPTION
added a workaround which fixes the issue where noobaa obc list command was not working. This is just a workaround and might be updated in the later releases.

Signed-off-by: RAJAT SINGH <rajasing@redhat.com>