### PR TITLE
Bug 1942354: [release-4.6]  hack/source-manifests: Do not use quotes

### DIFF
--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -41,9 +41,11 @@ mkdir -p $OUTDIR_TOOLS
 noobaa_dump_crds_cmd="crd yaml"
 noobaa_dump_csv_cmd="olm csv yaml"
 echo "Dumping Noobaa csv using command: $IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_csv_cmd"
-($IMAGE_RUN_CMD "$NOOBAA_IMAGE" "$noobaa_dump_csv_cmd") > $NOOBAA_CSV
+# shellcheck disable=SC2086
+($IMAGE_RUN_CMD "$NOOBAA_IMAGE" $noobaa_dump_csv_cmd) > $NOOBAA_CSV
+# shellcheck disable=SC2086
 echo "Dumping Noobaa crds using command: $IMAGE_RUN_CMD $NOOBAA_IMAGE $noobaa_dump_crds_cmd"
-($IMAGE_RUN_CMD "$NOOBAA_IMAGE" "$noobaa_dump_crds_cmd") > $OUTDIR_CRDS/noobaa-crd.yaml
+($IMAGE_RUN_CMD "$NOOBAA_IMAGE" $noobaa_dump_crds_cmd) > $OUTDIR_CRDS/noobaa-crd.yaml
 
 # ==== DUMP ROOK YAMLS ====
 rook_template_dir="/etc/ceph-csv-templates"


### PR DESCRIPTION
We cannot use quotes around the noobaa dump csv cmd (olm csv yaml)
because otherwise, these will be treated as a single argument instead of
three arguments and the csv generation fails.

The same goes for the noobaa crds.

Signed-off-by: Boris Ranto <branto@redhat.com>
(cherry picked from commit ddb49afd2c480a3bdede1b725a3b15c4df49038a)