### PR TITLE
must-gather: skip noobaa collection when storagecluster is not present

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -16,15 +16,16 @@ pre-install.sh
 # Call other gather scripts
 gather_namespaced_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
 gather_clusterscoped_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
-gather_noobaa_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
 
 storageClusterPresent=$(oc get storagecluster -n openshift-storage -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
 if [ "$(oc get storagecluster -n openshift-storage -o go-template='{{range .items}}{{.spec.externalStorage.enable}}{{"\n"}}{{end}}')" == true ]; then
-   echo "Skipping the ceph collection as External Storage is enabled" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+   echo "Skipping the ceph and nooobaa collection as External Storage is enabled" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
 elif [ -z "${storageClusterPresent}" ]; then
-    echo "Skipping ceph collection as Storage Cluster is not present" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    echo "Skipping ceph and nooobaa collection as Storage Cluster is not present" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
 else
+    echo "Collecting ceph and noobaa logs" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
     gather_ceph_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
+    gather_noobaa_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
 fi
 
 # Call post-uninstall.sh


### PR DESCRIPTION
now, the noobaa collection will only happen when the storagecluster will be present, otherwise, it would skip the noobaa collection

Signed-off-by: RAJAT SINGH <rajasing@redhat.com>