### PR TITLE
Enable Noobaa KMS configuration only when the cluster-wide encryption is enabled

### DIFF
--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -143,14 +143,16 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 		}
 	}
 
-	// Add KMS details to Noobaa spec, if available
-	// no need to pass any validation function,
-	// as validation already done during cephcluster creation time.
-	if kmsConfig, err := getKMSConfigMap(KMSConfigMapName, sc, r.Client); err != nil {
-		return err
-	} else if kmsConfig != nil {
-		nb.Spec.Security.KeyManagementService.ConnectionDetails = kmsConfig.Data
-		nb.Spec.Security.KeyManagementService.TokenSecretName = KMSTokenSecretName
+	// Add KMS details to Noobaa spec, only if
+	// cluster-wide encryption is enabled (ie; sc.Spec.Encryption.Enable is True)
+	// and KMS ConfigMap is available
+	if sc.Spec.Encryption.Enable {
+		if kmsConfig, err := getKMSConfigMap(KMSConfigMapName, sc, r.Client); err != nil {
+			return err
+		} else if kmsConfig != nil {
+			nb.Spec.Security.KeyManagementService.ConnectionDetails = kmsConfig.Data
+			nb.Spec.Security.KeyManagementService.TokenSecretName = KMSTokenSecretName
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Noobaa's root secret key, used for MCG encryption, should only  be
stored in to KMS server only if cluster wide encryption with StorageClass
encryption enabled.
Corrected the test cases accordingly.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>