### PR TITLE
storagecluster: Change the phase when spec is not valid

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -205,6 +205,10 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 	if err := versionCheck(instance, r.Log); err != nil {
 		r.Log.Error(err, "Failed to validate version")
 		r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
+		instance.Status.Phase = statusutil.PhaseError
+		if updateErr := r.Client.Update(context.TODO(), instance); updateErr != nil {
+			return updateErr
+		}
 		return err
 	}
 
@@ -212,6 +216,10 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 		if err := r.validateStorageDeviceSets(instance); err != nil {
 			r.Log.Error(err, "Failed to validate StorageDeviceSets")
 			r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
+			instance.Status.Phase = statusutil.PhaseError
+			if updateErr := r.Client.Update(context.TODO(), instance); updateErr != nil {
+				return updateErr
+			}
 			return err
 		}
 	}
@@ -219,6 +227,10 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 	if err := validateArbiterSpec(instance, r.Log); err != nil {
 		r.Log.Error(err, "Failed to validate ArbiterSpec")
 		r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
+		instance.Status.Phase = statusutil.PhaseError
+		if updateErr := r.Client.Update(context.TODO(), instance); updateErr != nil {
+			return updateErr
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
As of now if spec is not valid we are logging error and recording events
and status.phase is still in the ready or progressing state. which gives
wrong indication to the user. From now onward we are changing the phase
of the storagecluster to get the user attention.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1913357#c16
cc: @raghavendra-talur 