### PR TITLE
test: fix verify-latest-csv

### DIFF
--- a/hack/verify-latest-csv.sh
+++ b/hack/verify-latest-csv.sh
@@ -18,8 +18,8 @@ if [[ -n "${NOT_FOUND}" ]];then
 	exit 1
 fi
 
-if [[ -n "$(git status --porcelain deploy/olm-catalog)" ]]; then
-	git diff -u deploy/olm-catalog
+if [[ -n "$(git status --porcelain deploy/csv-templates deploy/bundle config/crd/bases )" ]]; then
+	git diff -u deploy/csv-templates deploy/bundle config/crd/bases
 	echo "uncommitted CSV changes. run 'make gen-latest-csv' and commit results."
 	exit 1
 fi


### PR DESCRIPTION
This was checking generated csv files from before the move
to the sdk-version before 1.0.

This patch adjusts to the new locations.

Signed-off-by: Michael Adam <obnox@redhat.com>