### PR TITLE
storagecluster: Fix Update in validateStorageClusterSpec

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -206,7 +206,7 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 		r.Log.Error(err, "Failed to validate version")
 		r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 		instance.Status.Phase = statusutil.PhaseError
-		if updateErr := r.Client.Update(context.TODO(), instance); updateErr != nil {
+		if updateErr := r.Client.Status().Update(context.TODO(), instance); updateErr != nil {
 			return updateErr
 		}
 		return err
@@ -217,7 +217,7 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 			r.Log.Error(err, "Failed to validate StorageDeviceSets")
 			r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 			instance.Status.Phase = statusutil.PhaseError
-			if updateErr := r.Client.Update(context.TODO(), instance); updateErr != nil {
+			if updateErr := r.Client.Status().Update(context.TODO(), instance); updateErr != nil {
 				return updateErr
 			}
 			return err
@@ -228,7 +228,7 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 		r.Log.Error(err, "Failed to validate ArbiterSpec")
 		r.recorder.Event(instance, statusutil.EventTypeWarning, statusutil.EventReasonValidationFailed, err.Error())
 		instance.Status.Phase = statusutil.PhaseError
-		if updateErr := r.Client.Update(context.TODO(), instance); updateErr != nil {
+		if updateErr := r.Client.Status().Update(context.TODO(), instance); updateErr != nil {
 			return updateErr
 		}
 		return err


### PR DESCRIPTION
r.Client.Update() does not update the status which was not showing the
correct phase of the storagecluster. Fix the same via start using the
r.Client.Status().Update() call instead.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1913357