### PR TITLE
storagecluster: Increase mons db allocated space

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -333,7 +333,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 				StorageClassName: ds.DataPVCTemplate.Spec.StorageClassName,
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
-						corev1.ResourceStorage: resource.MustParse("10Gi"),
+						corev1.ResourceStorage: resource.MustParse("50Gi"),
 					},
 				},
 			},


### PR DESCRIPTION
recent cases of mons db require more space then 10G. Increase the space
to 50G.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1944580

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>