### PR TITLE
Storagecluster: generate mgr spec in a function

### DIFF
--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -59,6 +59,16 @@ var (
 				corev1.ResourceMemory: resource.MustParse("3Gi"),
 			},
 		},
+		"mgr-sidecar": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("40Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+		},
 		"noobaa-core": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("1"),

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -312,7 +312,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 				cephv1.KeyMon: systemNodeCritical,
 				cephv1.KeyOSD: systemNodeCritical,
 			},
-			Resources: newCephDaemonResources(sc.Spec.Resources),
+			Resources: newCephDaemonResources(sc),
 			ContinueUpgradeAfterChecksEvenIfNotHealthy: true,
 			LogCollector: cephv1.LogCollectorSpec{
 				Enabled:     true,
@@ -675,7 +675,9 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 	return storageClassDeviceSets
 }
 
-func newCephDaemonResources(custom map[string]corev1.ResourceRequirements) map[string]corev1.ResourceRequirements {
+func newCephDaemonResources(sc *ocsv1.StorageCluster) map[string]corev1.ResourceRequirements {
+
+	custom := sc.Spec.Resources
 	resources := map[string]corev1.ResourceRequirements{
 		"mon": defaults.DaemonResources["mon"],
 		"mgr": defaults.DaemonResources["mgr"],

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -791,6 +791,10 @@ func generateMgrSpec(sc *ocsv1.StorageCluster) cephv1.MgrSpec {
 		},
 	}
 
+	if arbiterEnabled(sc) {
+		spec.Count = 2
+	}
+
 	return spec
 }
 

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -684,6 +684,9 @@ func newCephDaemonResources(sc *ocsv1.StorageCluster) map[string]corev1.Resource
 		"mds": defaults.DaemonResources["mds"],
 		"rgw": defaults.DaemonResources["rgw"],
 	}
+	if arbiterEnabled(sc) {
+		resources["mgr-sidecar"] = defaults.DaemonResources["mgr-sidecar"]
+	}
 
 	for k := range custom {
 		if r, ok := custom[k]; ok {

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -280,13 +280,8 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 				Image:            cephImage,
 				AllowUnsupported: allowUnsupportedCephVersion(),
 			},
-			Mon: generateMonSpec(sc, nodeCount),
-			Mgr: cephv1.MgrSpec{
-				Modules: []cephv1.Module{
-					{Name: "pg_autoscaler", Enabled: true},
-					{Name: "balancer", Enabled: true},
-				},
-			},
+			Mon:             generateMonSpec(sc, nodeCount),
+			Mgr:             generateMgrSpec(sc),
 			DataDirHostPath: "/var/lib/rook",
 			DisruptionManagement: cephv1.DisruptionManagementSpec{
 				ManagePodBudgets:                 true,
@@ -786,6 +781,17 @@ func generateMonSpec(sc *ocsv1.StorageCluster, nodeCount int) cephv1.MonSpec {
 		Count:                getMonCount(nodeCount, false),
 		AllowMultiplePerNode: false,
 	}
+}
+
+func generateMgrSpec(sc *ocsv1.StorageCluster) cephv1.MgrSpec {
+	spec := cephv1.MgrSpec{
+		Modules: []cephv1.Module{
+			{Name: "pg_autoscaler", Enabled: true},
+			{Name: "balancer", Enabled: true},
+		},
+	}
+
+	return spec
 }
 
 func getCephObjectStoreGatewayInstances(sc *ocsv1.StorageCluster) int32 {

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -675,6 +675,24 @@ func TestNewCephDaemonResources(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "When nothing is passed to StorageCluster.Spec.Resources (Defaults) and arbiter is enabled",
+			spec: &api.StorageCluster{
+				Spec: api.StorageClusterSpec{
+					Resources: map[string]corev1.ResourceRequirements{},
+					Arbiter: api.ArbiterSpec{
+						Enable: true,
+					},
+				},
+			},
+			expected: map[string]corev1.ResourceRequirements{
+				"mon":         defaults.DaemonResources["mon"],
+				"mgr":         defaults.DaemonResources["mgr"],
+				"mds":         defaults.DaemonResources["mds"],
+				"rgw":         defaults.DaemonResources["rgw"],
+				"mgr-sidecar": defaults.DaemonResources["mgr-sidecar"],
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -588,13 +588,17 @@ func TestStorageClassDeviceSetCreationForArbiter(t *testing.T) {
 func TestNewCephDaemonResources(t *testing.T) {
 
 	cases := []struct {
-		name      string
-		resources map[string]corev1.ResourceRequirements
-		expected  map[string]corev1.ResourceRequirements
+		name     string
+		spec     *api.StorageCluster
+		expected map[string]corev1.ResourceRequirements
 	}{
 		{
-			name:      "When nothing is passed to StorageCluster.Spec.Resources (Defaults)",
-			resources: map[string]corev1.ResourceRequirements{},
+			name: "When nothing is passed to StorageCluster.Spec.Resources (Defaults)",
+			spec: &api.StorageCluster{
+				Spec: api.StorageClusterSpec{
+					Resources: map[string]corev1.ResourceRequirements{},
+				},
+			},
 			expected: map[string]corev1.ResourceRequirements{
 				"mon": defaults.DaemonResources["mon"],
 				"mgr": defaults.DaemonResources["mgr"],
@@ -604,15 +608,19 @@ func TestNewCephDaemonResources(t *testing.T) {
 		},
 		{
 			name: "Overriding defaults",
-			resources: map[string]corev1.ResourceRequirements{
-				"mds": {
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("6"),
-						corev1.ResourceMemory: resource.MustParse("16Gi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("6"),
-						corev1.ResourceMemory: resource.MustParse("16Gi"),
+			spec: &api.StorageCluster{
+				Spec: api.StorageClusterSpec{
+					Resources: map[string]corev1.ResourceRequirements{
+						"mds": {
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("6"),
+								corev1.ResourceMemory: resource.MustParse("16Gi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("6"),
+								corev1.ResourceMemory: resource.MustParse("16Gi"),
+							},
+						},
 					},
 				},
 			},
@@ -634,15 +642,19 @@ func TestNewCephDaemonResources(t *testing.T) {
 		},
 		{
 			name: "Passing a new key",
-			resources: map[string]corev1.ResourceRequirements{
-				"crashcollector": {
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("6"),
-						corev1.ResourceMemory: resource.MustParse("16Gi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("6"),
-						corev1.ResourceMemory: resource.MustParse("16Gi"),
+			spec: &api.StorageCluster{
+				Spec: api.StorageClusterSpec{
+					Resources: map[string]corev1.ResourceRequirements{
+						"crashcollector": {
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("6"),
+								corev1.ResourceMemory: resource.MustParse("16Gi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("6"),
+								corev1.ResourceMemory: resource.MustParse("16Gi"),
+							},
+						},
 					},
 				},
 			},
@@ -666,7 +678,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		got := newCephDaemonResources(c.resources)
+		got := newCephDaemonResources(c.spec)
 		assert.Equalf(t, len(c.expected), len(got), c.name)
 		assert.Equalf(t, c.expected, got, c.name)
 	}


### PR DESCRIPTION
This also updates the count of MGRs that are created for an arbiter
deployment to 2.

Signed-off-by: Raghavendra Talur <raghavendra.talur@gmail.com>