### PR TITLE
Allow passing explicit DeviceClass

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -150,6 +150,12 @@ type StorageDeviceSet struct {
 	// +optional
 	DeviceType string `json:"deviceType,omitempty"`
 
+	// DeviceClass is an optional, fine-grained property of DeviceType.
+	// If non empty, it defines the 'crushDeviceClass' value as used by ceph's
+	// CRUSH map.
+	// +optional
+	DeviceClass string `json:"deviceClass,omitempty"`
+
 	// TopologyKey is the Kubernetes topology label that the
 	// StorageClassDeviceSets will be distributed across. Ignored if
 	// Placement is set

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -1760,6 +1760,11 @@ spec:
                               type: string
                           type: object
                       type: object
+                    deviceClass:
+                      description: DeviceClass is an optional, fine-grained property
+                        of DeviceType. If non empty, it defines the 'crushDeviceClass'
+                        value as used by ceph's CRUSH map.
+                      type: string
                     deviceType:
                       description: DeviceType is the value of device type in this
                         StorageDeviceSet. It can have one of the three values (SSD,

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -618,8 +618,12 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 			}
 
 			// Annotation crushDeviceClass ensures osd with different CRUSH device class than the one detected by Ceph
+			crushDeviceClass := ds.DeviceType
+			if ds.DeviceClass != "" {
+				crushDeviceClass = ds.DeviceClass
+			}
 			annotations := map[string]string{
-				"crushDeviceClass": ds.DeviceType,
+				"crushDeviceClass": crushDeviceClass,
 			}
 			ds.DataPVCTemplate.Annotations = annotations
 

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -1168,6 +1168,9 @@ spec:
                               type: string
                           type: object
                       type: object
+                    deviceClass:
+                      description: DeviceClass is an optional, fine-grained property of DeviceType. If non empty, it defines the 'crushDeviceClass' value as used by ceph's CRUSH map.
+                      type: string
                     deviceType:
                       description: DeviceType is the value of device type in this StorageDeviceSet. It can have one of the three values (SSD, HDD, NVMe)
                       enum:

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -1760,6 +1760,11 @@ spec:
                               type: string
                           type: object
                       type: object
+                    deviceClass:
+                      description: DeviceClass is an optional, fine-grained property
+                        of DeviceType. If non empty, it defines the 'crushDeviceClass'
+                        value as used by ceph's CRUSH map.
+                      type: string
                     deviceType:
                       description: DeviceType is the value of device type in this
                         StorageDeviceSet. It can have one of the three values (SSD,


### PR DESCRIPTION
For cases where we want to associate OSD and pools with devices on
specific nodes with specific devices, we need a more fine-grained level
of device-type, which is passed on to rook as CRUSH-device-class.

As an example, consider cluster with ssd devices from two different
vendors, where user would want to have different pools, one for each
sub-device type. When combined with node-labeling and this patch, the
task becomes trivial.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>