### PR TITLE
hack: fix new shellcheck issue SC2269

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -13,7 +13,6 @@ GOARCH="${GOARCH:-amd64}"
 DEFAULT_CSV_VERSION="4.8.0"
 CSV_VERSION="${CSV_VERSION:-${DEFAULT_CSV_VERSION}}"
 
-IMAGE_BUILD_CMD="${IMAGE_BUILD_CMD}"
 if [ -z "$IMAGE_BUILD_CMD" ]; then
     IMAGE_BUILD_CMD=$(command -v docker || echo "")
 fi


### PR DESCRIPTION
It seems the latest stable shellcheck update has uncovered another issue

SC2269: This variable is assigned to itself, so the assignment does nothing.

Signed-off-by: Michael Adam <obnox@redhat.com>