### PR TITLE
Explicit osd weight

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -156,6 +156,13 @@ type StorageDeviceSet struct {
 	// +optional
 	DeviceClass string `json:"deviceClass,omitempty"`
 
+	// InitialWeight is an optional explicit OSD weight value in TiB units.
+	// If non empty, it defines the 'CrushInitialWeight' value which is
+	// assigned to ceph OSD upon init
+	// +kubebuilder:validation:Pattern=`^([0-9]*[.])?[0-9]+(Ti[B])$`
+	// +optional
+	InitialWeight string `json:"initialWeight,omitempty"`
+
 	// TopologyKey is the Kubernetes topology label that the
 	// StorageClassDeviceSets will be distributed across. Ignored if
 	// Placement is set

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -1778,6 +1778,12 @@ spec:
                       - NVME
                       - nvme
                       type: string
+                    initialWeight:
+                      description: InitialWeight is an optional explicit OSD weight
+                        value in TiB units. If non empty, it defines the 'CrushInitialWeight'
+                        value which is assigned to ceph OSD upon init
+                      pattern: ^([0-9]*[.])?[0-9]+(Ti[B])$
+                      type: string
                     metadataPVCTemplate:
                       description: PersistentVolumeClaim is a user's request for and
                         claim to a persistent volume

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -625,6 +625,13 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 			annotations := map[string]string{
 				"crushDeviceClass": crushDeviceClass,
 			}
+			// Annotation crushInitialWeight is an optinal, explicit weight to set upon OSD's init (as float, in TiB units).
+			// ROOK & Ceph do not want any (optional) Ti[B] suffix, so trim it here.
+			// If not set, Ceph will define OSD's weight based on its capacity.
+			crushInitialWeight := strings.TrimSuffix(strings.TrimSuffix(ds.InitialWeight, "Ti"), "TiB")
+			if crushInitialWeight != "" {
+				annotations["crushInitialWeight"] = crushInitialWeight
+			}
 			ds.DataPVCTemplate.Annotations = annotations
 
 			set := rook.StorageClassDeviceSet{

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -1182,6 +1182,10 @@ spec:
                       - NVME
                       - nvme
                       type: string
+                    initialWeight:
+                      description: InitialWeight is an optional explicit OSD weight value in TiB units. If non empty, it defines the 'CrushInitialWeight' value which is assigned to ceph OSD upon init
+                      pattern: ^([0-9]*[.])?[0-9]+(Ti[B])$
+                      type: string
                     metadataPVCTemplate:
                       description: PersistentVolumeClaim is a user's request for and claim to a persistent volume
                       properties:

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -1778,6 +1778,12 @@ spec:
                       - NVME
                       - nvme
                       type: string
+                    initialWeight:
+                      description: InitialWeight is an optional explicit OSD weight
+                        value in TiB units. If non empty, it defines the 'CrushInitialWeight'
+                        value which is assigned to ceph OSD upon init
+                      pattern: ^([0-9]*[.])?[0-9]+(Ti[B])$
+                      type: string
                     metadataPVCTemplate:
                       description: PersistentVolumeClaim is a user's request for and
                         claim to a persistent volume


### PR DESCRIPTION
    Allow passing explicit InitialWeight
    
    Allow passing explicit CRUSH initial-weight upon OSD init, using
    annotations mechanism (same as DeviceType/DeviceClass). This may be
    useful for cases where user wants to have more fine-grained control on
    the overall load of specific devices. As an example, consider the
    (real-life) case of a PV which resides on a partition alongside OS
    partition. In such case, user can reduce I/O to the OSD over this PV be
    lowering its weight value.
    
    Issue: https://issues.redhat.com/browse/KNIP-1616
