### PR TITLE
do not pass labels as map of single empty string

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -437,7 +437,6 @@ func (r *StorageClusterReconciler) reconcilePhases(
 		if instance.Spec.Monitoring == nil {
 			instance.Spec.Monitoring = &ocsv1.MonitoringSpec{
 				ReconcileStrategy: string(ReconcileStrategyUnknown),
-				Labels:            map[string]string{"": ""},
 			}
 		}
 		if err := r.enableMetricsExporter(instance); err != nil {


### PR DESCRIPTION
Commit 3fc88d52 ("merge user provided labels with existing ones") passes
'Labels' as map of single entry, with empty string. This, in turn,
causes deployment failure on AWS cluster, with the following message:

failed to create metrics exporter service
openshift-storage/ocs-metrics-exporter. Service \"ocs-metrics-exporter\" is
invalid: [metadata.labels: Invalid value: \"\": name part must be non-empty

Fixed by setting empty Labels map for the default case of Spec.Monitoring

Signed-off-by: Shachar Sharon <ssharon@redhat.com>