### PR TITLE
storagecluster: Add PriorityClasses support for all resources

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -313,8 +313,6 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 				"arbiter": getPlacement(sc, "arbiter"),
 			},
 			PriorityClassNames: rook.PriorityClassNamesSpec{
-				"all":         openshiftUserCritical,
-				cephv1.KeyMds: openshiftUserCritical,
 				cephv1.KeyMgr: systemNodeCritical,
 				cephv1.KeyMon: systemNodeCritical,
 				cephv1.KeyOSD: systemNodeCritical,

--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -40,6 +40,8 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initData *ocsv1.St
 					ActiveStandby: true,
 					Placement:     getPlacement(initData, "mds"),
 					Resources:     defaults.GetDaemonResources("mds", initData.Spec.Resources),
+					// set PriorityClassName for the MDS pods
+					PriorityClassName: openshiftUserCritical,
 				},
 			},
 		},

--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -154,6 +154,8 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 					Instances: gatewayInstances,
 					Placement: getPlacement(initData, "rgw"),
 					Resources: defaults.GetDaemonResources("rgw", initData.Spec.Resources),
+					// set PriorityClassName for the rgw pods
+					PriorityClassName: openshiftUserCritical,
 				},
 			},
 		},

--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -159,6 +159,8 @@ func newExternalGatewaySpec(rgwEndpoint string, reqLogger logr.Logger) (*cephv1.
 		return nil, err
 	}
 	gateWay.Port = int32(portInt64)
+	// set PriorityClassName for the rgw pods
+	gateWay.PriorityClassName = openshiftUserCritical
 	return &gateWay, nil
 }
 


### PR DESCRIPTION
Add default PriorityClasses support

Use "systemNodeCritical" for the Mgr, Mon, Osd and
"openshiftUserCritical" for the Mds and rgw

Signed-off-by: Nitin Goyal nigoyal@redhat.com

pending from https://github.com/openshift/ocs-operator/pull/1166

look at rook PR: rook/rook#3206 for more details