### PR TITLE
Bug 1776876: [release-4.8] Add priority Class for the ceph resources

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -59,6 +59,12 @@ const (
 	clusterNetworkSelectorKey = "cluster"
 )
 
+const (
+	// PriorityClasses for cephCluster
+	systemNodeCritical    = "system-node-critical"
+	openshiftUserCritical = "openshift-user-critical"
+)
+
 func arbiterEnabled(sc *ocsv1.StorageCluster) bool {
 	return sc.Spec.Arbiter.Enable
 }
@@ -305,6 +311,13 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 				"all":     getPlacement(sc, "all"),
 				"mon":     getPlacement(sc, "mon"),
 				"arbiter": getPlacement(sc, "arbiter"),
+			},
+			PriorityClassNames: rook.PriorityClassNamesSpec{
+				"all":         openshiftUserCritical,
+				cephv1.KeyMds: openshiftUserCritical,
+				cephv1.KeyMgr: systemNodeCritical,
+				cephv1.KeyMon: systemNodeCritical,
+				cephv1.KeyOSD: systemNodeCritical,
 			},
 			Resources: newCephDaemonResources(sc.Spec.Resources),
 			ContinueUpgradeAfterChecksEvenIfNotHealthy: true,

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -313,8 +313,6 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 				"arbiter": getPlacement(sc, "arbiter"),
 			},
 			PriorityClassNames: rook.PriorityClassNamesSpec{
-				"all":         openshiftUserCritical,
-				cephv1.KeyMds: openshiftUserCritical,
 				cephv1.KeyMgr: systemNodeCritical,
 				cephv1.KeyMon: systemNodeCritical,
 				cephv1.KeyOSD: systemNodeCritical,

--- a/controllers/storagecluster/cephfilesystem.go
+++ b/controllers/storagecluster/cephfilesystem.go
@@ -40,6 +40,8 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initData *ocsv1.St
 					ActiveStandby: true,
 					Placement:     getPlacement(initData, "mds"),
 					Resources:     defaults.GetDaemonResources("mds", initData.Spec.Resources),
+					// set PriorityClassName for the MDS pods
+					PriorityClassName: openshiftUserCritical,
 				},
 			},
 		},

--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -154,6 +154,8 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 					Instances: gatewayInstances,
 					Placement: getPlacement(initData, "rgw"),
 					Resources: defaults.GetDaemonResources("rgw", initData.Spec.Resources),
+					// set PriorityClassName for the rgw pods
+					PriorityClassName: openshiftUserCritical,
 				},
 			},
 		},

--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -159,6 +159,8 @@ func newExternalGatewaySpec(rgwEndpoint string, reqLogger logr.Logger) (*cephv1.
 		return nil, err
 	}
 	gateWay.Port = int32(portInt64)
+	// set PriorityClassName for the rgw pods
+	gateWay.PriorityClassName = openshiftUserCritical
 	return &gateWay, nil
 }
 


### PR DESCRIPTION
Add default PriorityClasses support in the cephcluster CRD.

Use "systemNodeCritical" for the Mgr, Mon, Osd and
"openshiftUserCritical" for the Mds, rgw

Signed-off-by: Nitin Goyal nigoyal@redhat.com

Master PR's https://github.com/openshift/ocs-operator/pull/1166, https://github.com/openshift/ocs-operator/pull/1169