### PR TITLE
fix ClusterObjectStoreState Alert empty spec

### DIFF
--- a/controllers/storagecluster/prometheus.go
+++ b/controllers/storagecluster/prometheus.go
@@ -79,10 +79,11 @@ func getPrometheusRuleSpecFrom(filePath string) (*monitoringv1.PrometheusRuleSpe
 	if err != nil {
 		return nil, fmt.Errorf("'%s' not readable", filePath)
 	}
-	ruleSpec := monitoringv1.PrometheusRuleSpec{}
-	if err := k8sYAML.NewYAMLOrJSONDecoder(bytes.NewBufferString(string(fileContent)), 1000).Decode(&ruleSpec); err != nil {
+	rule := monitoringv1.PrometheusRule{}
+	if err := k8sYAML.NewYAMLOrJSONDecoder(bytes.NewBufferString(string(fileContent)), 1000).Decode(&rule); err != nil {
 		return nil, err
 	}
+	ruleSpec := rule.Spec
 	return &ruleSpec, nil
 }
 


### PR DESCRIPTION
This commit fixes ClusterObjectStoreState alert spec being empty due to
which the rule was not being listed in the Prometheus Rules and alert
was not working. The reason alert spec is empty is because the function
getPrometheusRuleSpecFrom is returning empty object as the rule file
decoding is creating an object that matches the type struct
monitoringv1.PrometheusRule{} which does not match with the type of the
variable ruleSpec which is monitoringv1.PrometheusRuleS

Signed-off-by: Anmol Sachan <anmol13694@gmail.com>

Fix: https://bugzilla.redhat.com/show_bug.cgi?id=1948378