### PR TITLE
pass monitoring labels to CephCluster

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -320,6 +320,13 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 			},
 		},
 	}
+	if sc.Spec.Monitoring != nil && sc.Spec.Monitoring.Labels != nil {
+		label := rook.LabelsSpec{
+			cephv1.KeyMonitoring: sc.Spec.Monitoring.Labels,
+		}
+		cephCluster.Spec.Labels = label
+	}
+
 	monPVCTemplate := sc.Spec.MonPVCTemplate
 	monDataDirHostPath := sc.Spec.MonDataDirHostPath
 	// If the `monPVCTemplate` is provided, the mons will provisioned on the
@@ -422,6 +429,13 @@ func newExternalCephCluster(sc *ocsv1.StorageCluster, cephImage, monitoringIP, m
 			},
 			Monitoring: monitoringSpec,
 		},
+	}
+
+	if sc.Spec.Monitoring != nil && sc.Spec.Monitoring.Labels != nil {
+		label := rook.LabelsSpec{
+			cephv1.KeyMonitoring: sc.Spec.Monitoring.Labels,
+		}
+		externalCephCluster.Spec.Labels = label
 	}
 
 	return externalCephCluster


### PR DESCRIPTION
+ monitoring labels from StorageCluster spec is passed on to
CephCluster spec so that Rook can take care of injecting these
labels into the monitoring resources that it creates.

Follows up on #1129 .


Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>