### PR TITLE
Allow passing explicit PrimaryAffinity

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -163,6 +163,15 @@ type StorageDeviceSet struct {
 	// +optional
 	InitialWeight string `json:"initialWeight,omitempty"`
 
+	// PrimaryAffinity is an optional OSD primary-affinity value within the
+	// range [0,1). This value influence the way Ceph's CRUSH selection of
+	// primary OSDs. Lower value reduce performance bottlenecks (especially
+	// on read operations). If not set, default value is 1.
+	// https://docs.ceph.com/en/latest/rados/operations/crush-map/#primary-affinity
+	// +kubebuilder:validation:Pattern=`^0.[0-9]+$`
+	// +optional
+	PrimaryAffinity string `json:"primaryAffinity,omitempty"`
+
 	// TopologyKey is the Kubernetes topology label that the
 	// StorageClassDeviceSets will be distributed across. Ignored if
 	// Placement is set

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -3561,6 +3561,14 @@ spec:
                             type: object
                           type: array
                       type: object
+                    primaryAffinity:
+                      description: PrimaryAffinity is an optional OSD primary-affinity
+                        value within the range [0,1). This value influence the way
+                        Ceph's CRUSH selection of primary OSDs. Lower value reduce
+                        performance bottlenecks (especially on read operations). If
+                        not set, default value is 1. https://docs.ceph.com/en/latest/rados/operations/crush-map/#primary-affinity
+                      pattern: ^0.[0-9]+$
+                      type: string
                     replica:
                       description: Replica is the number of StorageClassDeviceSets
                         for this StorageDeviceSet

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -643,6 +643,11 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 			if crushInitialWeight != "" {
 				annotations["crushInitialWeight"] = crushInitialWeight
 			}
+			// Annotation crushPrimaryAffinity is an optinal, explicit primary-affinity value within the range [0,1) to
+			// set upon OSD's deployment. If not set, Ceph sets default value to 1
+			if ds.PrimaryAffinity != "" {
+				annotations["crushPrimaryAffinity"] = ds.PrimaryAffinity
+			}
 			ds.DataPVCTemplate.Annotations = annotations
 
 			set := rook.StorageClassDeviceSet{

--- a/deploy/bundle/manifests/storagecluster.crd.yaml
+++ b/deploy/bundle/manifests/storagecluster.crd.yaml
@@ -2170,6 +2170,10 @@ spec:
                             type: object
                           type: array
                       type: object
+                    primaryAffinity:
+                      description: PrimaryAffinity is an optional OSD primary-affinity value within the range [0,1). This value influence the way Ceph's CRUSH selection of primary OSDs. Lower value reduce performance bottlenecks (especially on read operations). If not set, default value is 1. https://docs.ceph.com/en/latest/rados/operations/crush-map/#primary-affinity
+                      pattern: ^0.[0-9]+$
+                      type: string
                     replica:
                       description: Replica is the number of StorageClassDeviceSets for this StorageDeviceSet
                       minimum: 1

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -3561,6 +3561,14 @@ spec:
                             type: object
                           type: array
                       type: object
+                    primaryAffinity:
+                      description: PrimaryAffinity is an optional OSD primary-affinity
+                        value within the range [0,1). This value influence the way
+                        Ceph's CRUSH selection of primary OSDs. Lower value reduce
+                        performance bottlenecks (especially on read operations). If
+                        not set, default value is 1. https://docs.ceph.com/en/latest/rados/operations/crush-map/#primary-affinity
+                      pattern: ^0.[0-9]+$
+                      type: string
                     replica:
                       description: Replica is the number of StorageClassDeviceSets
                         for this StorageDeviceSet


### PR DESCRIPTION
Allow passing explicit primary-affinity upon OSD's deployment using
annotations mechanism (same as DeviceClass/InitialWeight). This may be
useful for cases where user wants to have more fine-grained control on
the overall (read) load of specific devices. Valid values are within
range [0, 1) (where 1 is the default).

As an example, consider the (real-life) case of a PV which resides on a
partition alongside OS partition. In such case, user can reduce I/O load
of this specific OSD by choosing explicit primary-affinity value.

Issue: https://issues.redhat.com/browse/KNIP-1616
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1924946

Signed-off-by: Shachar Sharon <ssharon@redhat.com>