### PR TITLE
fix merge strategy for newCephDaemonResources

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -682,11 +682,13 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster, serverVersion *version.
 
 func newCephDaemonResources(custom map[string]corev1.ResourceRequirements) map[string]corev1.ResourceRequirements {
 	resources := map[string]corev1.ResourceRequirements{
-		"mon": defaults.GetDaemonResources("mon", custom),
-		"mgr": defaults.GetDaemonResources("mgr", custom),
+		"mon": defaults.DaemonResources["mon"],
+		"mgr": defaults.DaemonResources["mgr"],
+		"mds": defaults.DaemonResources["mds"],
+		"rgw": defaults.DaemonResources["rgw"],
 	}
 
-	for k := range resources {
+	for k := range custom {
 		if r, ok := custom[k]; ok {
 			resources[k] = r
 		}


### PR DESCRIPTION
newCephDaemonResources was taking custom resource requirements
for multiple daemons but only returning resource requirements
of ceph-mgr and mon.

This patch changes it to take all custom resource requirements
and merge it with the defaults. If key exists, it's value will
be overwritten and if it doesn't exist, it will be appended.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>