### PR TITLE
deps: update Golang to 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/ocs-operator
 
-go 1.15
+go 1.16
 
 require (
 	github.com/RHsyseng/operator-utils v1.4.2


### PR DESCRIPTION
Go 1.16 is not available in upstream builder images.
Dockerfile needs to be updated once it is available.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>