### PR TITLE
Re-Change job template name to its original one, 

### DIFF
--- a/controllers/storagecluster/job_templates.go
+++ b/controllers/storagecluster/job_templates.go
@@ -136,7 +136,7 @@ func newExtendClusterJob(sc *ocsv1.StorageCluster, jobTemplateName string, cephC
 			APIVersion: "batch/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        jobTemplateName,
+			Name:        jobTemplateName + "-job",
 			Namespace:   sc.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
@@ -253,7 +253,7 @@ func newosdCleanUpJob(sc *ocsv1.StorageCluster, jobTemplateName string, cephComm
 			APIVersion: "batch/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        jobTemplateName,
+			Name:        jobTemplateName + "-job",
 			Namespace:   sc.Namespace,
 			Labels:      labels,
 			Annotations: annotations,


### PR DESCRIPTION
Refer: https://bugzilla.redhat.com/show_bug.cgi?id=1966149

The osd removal job name on OCS4.7 and OCS4.8 is different.Thus this PR will set back the original name of the job