### PR TITLE
Bug 1966149: [release-4.8] Re-Change the job template name back to its original one

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -753,7 +753,7 @@ func newExtendClusterJob(sc *ocsv1.StorageCluster, jobTemplateName string, cephC
 			APIVersion: "batch/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        jobTemplateName,
+			Name:        jobTemplateName + "-job",
 			Namespace:   sc.Namespace,
 			Labels:      labels,
 			Annotations: annotations,
@@ -870,7 +870,7 @@ func newosdCleanUpJob(sc *ocsv1.StorageCluster, jobTemplateName string, cephComm
 			APIVersion: "batch/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        jobTemplateName,
+			Name:        jobTemplateName + "-job",
 			Namespace:   sc.Namespace,
 			Labels:      labels,
 			Annotations: annotations,


### PR DESCRIPTION
Bug 1966149 : [ Re-Change the job template name back to its original one]
Since 4.8 does not have https://github.com/openshift/ocs-operator/pull/1153 ,  we cannot backport https://github.com/openshift/ocs-operator/pull/1198 alone , to 4.8 

This PR re-changes the job name to its original one w.r.t to the current code in release-4.8 branch

Signed-off-by: Prajith Kesava Prasad <pkesavap@redhat.com>