### PR TITLE
GateWay spec's 'Instances' field should be minimum 1

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -161,6 +161,7 @@ func newExternalGatewaySpec(rgwEndpoint string, reqLogger logr.Logger) (*cephv1.
 	gateWay.Port = int32(portInt64)
 	// set PriorityClassName for the rgw pods
 	gateWay.PriorityClassName = openshiftUserCritical
+	gateWay.Instances = 1
 	return &gateWay, nil
 }
 


### PR DESCRIPTION
'Instances' field in GateWay spec needs to be atleast ONE.

External cluster creations are failing due to this with
following error in OCS Operator logs,

"error":"CephObjectStore.ceph.rook.io \"ocs-external-storagecluster-cephobjectstore\"
is invalid: spec.gateway.instances: Invalid value: 0: spec.gateway.instances in body
should be greater than or equal to 1"

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>