### PR TITLE
topology: fix crash in determinePlacementRack

### DIFF
--- a/controllers/storagecluster/topology.go
+++ b/controllers/storagecluster/topology.go
@@ -96,13 +96,11 @@ func determinePlacementRack(
 	rackList := []string{}
 
 	if len(nodeRacks.Labels) < minRacks {
-		for i := len(nodeRacks.Labels); i < minRacks; i++ {
-			for j := 0; j <= i; j++ {
-				newRack := fmt.Sprintf("rack%d", j)
-				if _, ok := nodeRacks.Labels[newRack]; !ok {
-					nodeRacks.Labels[newRack] = ocsv1.TopologyLabelValues{}
-					break
-				}
+		for i := 0; i < minRacks; i++ {
+			newRack := fmt.Sprintf("rack%d", i)
+			if _, ok := nodeRacks.Labels[newRack]; !ok {
+				nodeRacks.Labels[newRack] = ocsv1.TopologyLabelValues{}
+				break
 			}
 		}
 	}
@@ -152,6 +150,18 @@ func determinePlacementRack(
 			}
 			if validRack {
 				rackList = append(rackList, rack)
+			}
+		}
+		if len(rackList) == 0 {
+			//Create a new rack because EBS volumes cannot move to a different
+			// AZ
+			for i := len(nodeRacks.Labels); ; i++ {
+				newRack := fmt.Sprintf("rack%d", i)
+				if _, ok := nodeRacks.Labels[newRack]; !ok {
+					nodeRacks.Labels[newRack] = ocsv1.TopologyLabelValues{}
+					rackList = append(rackList, newRack)
+					break
+				}
 			}
 		}
 	} else {

--- a/controllers/storagecluster/topology_test.go
+++ b/controllers/storagecluster/topology_test.go
@@ -16,6 +16,7 @@ import (
 
 var rack0 = "rack0"
 var rack1 = "rack1"
+var rack2 = "rack2"
 
 var workerAffinityNode = corev1.Node{
 	ObjectMeta: metav1.ObjectMeta{
@@ -904,6 +905,74 @@ func TestDeterminePlacementRack(t *testing.T) {
 				},
 			},
 			expectedRack: "rack2",
+		},
+		{
+			label: "Case 4", // `rack3` should be placement rack as`node4` is in a different zone`
+			nodeList: &corev1.NodeList{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "NodeList",
+				},
+				Items: []corev1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "Node1",
+							Labels: map[string]string{
+								defaults.RackTopologyKey: "rack0",
+								zoneTopologyLabel:        "zone1",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "Node2",
+							Labels: map[string]string{
+								defaults.RackTopologyKey: "rack1",
+								zoneTopologyLabel:        "zone1",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "Node3",
+							Labels: map[string]string{
+								defaults.RackTopologyKey: "rack2",
+								zoneTopologyLabel:        "zone1",
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "Node4",
+							Labels: map[string]string{
+								zoneTopologyLabel: "zone2",
+							},
+						},
+					},
+				},
+			},
+			node: corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "Node4",
+					Labels: map[string]string{
+						zoneTopologyLabel: "zone2",
+					},
+				},
+			},
+			minRacks: 3,
+			nodeRacks: &api.NodeTopologyMap{
+				Labels: map[string]api.TopologyLabelValues{
+					rack0: []string{
+						"Node1",
+					},
+					rack1: []string{
+						"Node2",
+					},
+					rack2: []string{
+						"Node3",
+					},
+				},
+			},
+			expectedRack: "rack3",
 		},
 	}
 


### PR DESCRIPTION
Add a new rack for a node if there are no empty racks and none
of the nodes in the existing racks belong to the same zone as the new
node.

Signed-off-by: N Balachandran <nibalach@redhat.com>