### PR TITLE
Adding 'thick-provision' storageclass to External cluster

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -309,6 +309,10 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 				enableRookCSICephFS = true
 			} else if d.Name == cephRbdStorageClassName {
 				scc = newCephBlockPoolStorageClassConfiguration(instance, false)
+				// if RBD storageclass is present, we need to add thick provision
+				// storageclass as well into the 'availableSCCs' array
+				availableSCCs = append(availableSCCs,
+					newCephBlockPoolStorageClassConfiguration(instance, true))
 			} else if d.Name == cephRgwStorageClassName {
 				rgwEndpoint := d.Data[externalCephRgwEndpointKey]
 				if err := checkEndpointReachable(rgwEndpoint, 5*time.Second); err != nil {


### PR DESCRIPTION
Thick-provision storage class is required along with RBD storageclass.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>