### PR TITLE
must-gather: collect ceph CR's logs when external cluster is deployed

### DIFF
--- a/must-gather/collection-scripts/gather
+++ b/must-gather/collection-scripts/gather
@@ -19,13 +19,15 @@ gather_clusterscoped_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
 gather_noobaa_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
 
 storageClusterPresent=$(oc get storagecluster -n openshift-storage -o go-template='{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
+externalStorageClusterPresent=$(oc get storagecluster -n openshift-storage -o go-template='{{range .items}}{{.spec.externalStorage.enable}}{{"\n"}}{{end}}')
 
-if [ "$(oc get storagecluster -n openshift-storage -o go-template='{{range .items}}{{.spec.externalStorage.enable}}{{"\n"}}{{end}}')" == true ]; then
-    echo "Skipping the ceph collection as External Storage is enabled" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+if [ "${externalStorageClusterPresent}" == true ]; then
+    echo "Collecting limited ceph logs since external cluster is present" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    gather_common_ceph_resources "${BASE_COLLECTION_PATH}" "${SINCE_TIME}"
 elif [ -z "${storageClusterPresent}" ]; then
     echo "Skipping ceph collection as Storage Cluster is not present" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
 else
-    echo "Collecting ceph logs" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
+    echo "Collecting entire ceph logs" | tee -a "${BASE_COLLECTION_PATH}"/gather-debug.log
     gather_ceph_resources ${BASE_COLLECTION_PATH} "${SINCE_TIME}"
 fi
 

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+gather_common_ceph_resources "${BASE_COLLECTION_PATH}" "${SINCE_TIME}"
+
 # Expect base collection path as an argument
 BASE_COLLECTION_PATH=$1
 
@@ -15,10 +18,7 @@ CEPH_COLLECTION_PATH="${BASE_COLLECTION_PATH}/ceph"
 # Ceph resources
 ceph_resources=()
 ceph_resources+=(cephblockpools)
-ceph_resources+=(cephclusters)
 ceph_resources+=(cephfilesystems)
-ceph_resources+=(cephobjectstores)
-ceph_resources+=(cephobjectstoreusers)
 
 # Ceph commands
 ceph_commands=()

--- a/must-gather/collection-scripts/gather_common_ceph_resources
+++ b/must-gather/collection-scripts/gather_common_ceph_resources
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Expect base collection path as an argument
+BASE_COLLECTION_PATH=$1
+
+# Expect time option as an argument
+SINCE_TIME=$2
+
+# Use PWD as base path if no argument is passed
+if [ "${BASE_COLLECTION_PATH}" = "" ]; then
+    BASE_COLLECTION_PATH=$(pwd)
+fi
+
+CEPH_COLLECTION_PATH="${BASE_COLLECTION_PATH}/ceph"
+
+# common Ceph resources
+common_ceph_resources=()
+common_ceph_resources+=(cephobjectstores)
+common_ceph_resources+=(cephobjectstoreusers)
+common_ceph_resources+=(cephclusters)
+
+for resource in "${common_ceph_resources[@]}"; do
+    echo "collecting dump ${resource}" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
+    { oc adm --dest-dir="${CEPH_COLLECTION_PATH}" inspect "${resource}" --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+done
+cat "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
+rm -rf "${BASE_COLLECTION_PATH}/"gather-ceph-debug.log >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1


### PR DESCRIPTION
Currently for External mode, the must-gather skips the whole ceph collection
and therefore some resources which are applicable for external mode are absent
in the logs. Those resources are
* cephobjectstores
* cephobjectstoreusers
* cephclusters

Signed-off-by: RAJAT SINGH <rajasing@redhat.com>