### PR TITLE
Bug 1962281:  Update the ocs-osd-removal template description #1215

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -657,9 +657,10 @@ func osdCleanUpTemplate(sc *ocsv1.StorageCluster) *openshiftv1.Template {
 				Description: `
 The parameter OSD IDs needs a comma-separated list of numerical FAILED_OSD_IDs 
 when a single job removes multiple OSDs. 
-If the expected comma-separated format is not used, 
-or an ID cannot be converted to an int, 
-or if an OSD ID is not found, errors will be generated in the log and no OSDs would be removed.`,
+OSD removal is an advanced use case.
+In the event of errors or invalid user inputs,
+the Job will attempt to remove as many OSDs as can be processed and complete without returning an error condition.
+Users should always check for errors and success in the log of the finished OSD removal Job.`,
 			},
 		},
 		Objects: []runtime.RawExtension{


### PR DESCRIPTION
Reference https://bugzilla.redhat.com/show_bug.cgi?id=1962281
The status of "ocs-osd-removal-job pod" turns completed although removal
job failed to remove osds successfully.
In some cases user might enter wrong input to the FAILED_OSD_IDS
template parameter.
This commit updates the template description to notify the user to always
read the job logs to check whether osds successfully removed or not.

Signed-off-by: Servesha Dudhgaonkar <sdudhgao@redhat.com>
(cherry picked from commit 92df1c3044538ef6152650757c0efbf1e4ad3048)