### PR TITLE
Set the operator readiness state to true on StorageCluster removal

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -311,6 +311,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 			}
 		}
 		r.Log.Info("Object is terminated, skipping reconciliation")
+		ReadinessSet()
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION

The removal of a failed StorageCluster leaves the OCS operator in the
Not Ready state. We now set the readiness state on SC termination.

Signed-off-by: N Balachandran <nibalach@redhat.com>