### PR TITLE
Bump ocs-operator to v4.9.0

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
       ]
     capabilities: Deep Insights
     categories: Storage
-    containerImage: quay.io/ocs-dev/ocs-operator:4.8.0
+    containerImage: quay.io/ocs-dev/ocs-operator:4.9.0
     description: Red Hat OpenShift Container Storage provides hyperconverged storage for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/export-script: |-
       JycnCkNvcHlyaWdodCAyMDIwIFRoZSBSb29rIEF1dGhvcnMuIEFsbCByaWdodHMgcmVzZXJ2ZWQu
@@ -991,7 +991,7 @@ metadata:
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None", "VSphere", "OpenStack", "oVirt"]'
     external.features.ocs.openshift.io/validation: '{"secrets":["rook-ceph-operator-creds", "rook-csi-rbd-node", "rook-csi-rbd-provisioner"], "configMaps": ["rook-ceph-mon-endpoints", "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}'
     features.ocs.openshift.io/enabled: '["kms", "arbiter", "flexible-scaling", "multus", "thick-provision", "pool-management", "namespace-store"]'
-    olm.skipRange: '>=0.0.1 <4.8.0'
+    olm.skipRange: '>=0.0.1 <4.9.0'
     operatorframework.io/initialization-resource: "\n    {\n        \"apiVersion\": \"ocs.openshift.io/v1\",\n        \"kind\": \"StorageCluster\",\n        \"metadata\": {\n            \"name\": \"example-storagecluster\",\n            \"namespace\": \"openshift-storage\"\n        },\n        \"spec\": {\n            \"manageNodes\": false,\n            \"monPVCTemplate\": {\n                \"spec\": {\n                    \"accessModes\": [\n                        \"ReadWriteOnce\"\n                    ],\n                    \"resources\": {\n                        \"requests\": {\n                            \"storage\": \"10Gi\"\n                        }\n                    },\n                    \"storageClassName\": \"gp2\"\n                }\n            },\n            \"storageDeviceSets\": [\n                {\n                    \"count\": 3,\n                    \"dataPVCTemplate\": {\n                        \"spec\": {\n                            \"accessModes\": [\n                                \"ReadWriteOnce\"\n                            ],\n                            \"resources\": {\n                                \"requests\": {\n                                    \"storage\": \"1Ti\"\n                                }\n                            },\n                            \"storageClassName\": \"gp2\",\n                            \"volumeMode\": \"Block\"\n                        }\n                    },\n                    \"name\": \"example-deviceset\",\n                    \"placement\": {},\n                    \"portable\": true,\n                    \"resources\": {}\n                }\n            ]\n        }\n    }\n\t"
     operatorframework.io/suggested-namespace: openshift-storage
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
@@ -1003,7 +1003,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
-  name: ocs-operator.v4.8.0
+  name: ocs-operator.v4.9.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -3073,4 +3073,4 @@ spec:
     name: noobaa-db
   - image: quay.io/ocs-dev/ocs-must-gather:latest
     name: ocs-must-gather
-  version: 4.8.0
+  version: 4.9.0

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -63,7 +63,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-  name: ocs-operator.v4.8.0
+  name: ocs-operator.v4.9.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -299,4 +299,4 @@ spec:
   provider:
     name: '""'
     url: '""'
-  version: 4.8.0
+  version: 4.9.0

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -10,7 +10,7 @@ GOOS="${GOOS:-linux}"
 GOARCH="${GOARCH:-amd64}"
 
 # Current DEV version of the CSV
-DEFAULT_CSV_VERSION="4.8.0"
+DEFAULT_CSV_VERSION="4.9.0"
 CSV_VERSION="${CSV_VERSION:-${DEFAULT_CSV_VERSION}}"
 
 OUTDIR="build/_output"

--- a/hack/generate-master-appregistry.sh
+++ b/hack/generate-master-appregistry.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-CSV_VERSION=4.8.0
+CSV_VERSION=4.9.0
 source hack/generate-appregistry.sh
 
 CSV_FILE=build/_output/appregistry/olm-catalog/ocs-operator/${CSV_VERSION}/ocs-operator.v${CSV_VERSION}.clusterserviceversion.yaml

--- a/hack/generate-master-bundle.sh
+++ b/hack/generate-master-bundle.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-CSV_VERSION=4.8.0
+CSV_VERSION=4.9.0
 source hack/common.sh
 
 CSV_FILE=/manifests/ocs-operator.clusterserviceversion.yaml

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	// Version of the operator
-	Version = "4.8.0"
+	Version = "4.9.0"
 )


### PR DESCRIPTION
This also resolves the fact that both `master` and `release-4.8` CI are pushing to `quay.io/ocs-dev/ocs-*:latest`.