### PR TITLE
Add RBAC for creating service monitors from mgr sidecar

### DIFF
--- a/deploy/bundle/manifests/rook-monitor-mgr-role.yaml
+++ b/deploy/bundle/manifests/rook-monitor-mgr-role.yaml
@@ -1,0 +1,14 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitor-mgr
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - list
+  - create
+  - update

--- a/deploy/bundle/manifests/rook-monitor-mgr-role_binding.yaml
+++ b/deploy/bundle/manifests/rook-monitor-mgr-role_binding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitor-mgr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-monitor-mgr
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-mgr
+  namespace: openshift-storage

--- a/rbac/rook-monitor-mgr-role.yaml
+++ b/rbac/rook-monitor-mgr-role.yaml
@@ -1,0 +1,14 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitor-mgr
+rules:
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - list
+  - create
+  - update

--- a/rbac/rook-monitor-mgr-role_binding.yaml
+++ b/rbac/rook-monitor-mgr-role_binding.yaml
@@ -1,0 +1,12 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rook-ceph-monitor-mgr
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-monitor-mgr
+subjects:
+- kind: ServiceAccount
+  name: rook-ceph-mgr
+  namespace: openshift-storage


### PR DESCRIPTION
Stretch clusters have two mgrs, each with a sidecar for updating the services and service monitor if the active mgr changes in Ceph. The mgr pod needs access to update the service monitor.

In order for the monitoring RBAC to be picked up, it needs to be added to the OCS operator in this folder:
https://github.com/openshift/ocs-operator/tree/master/rbac

This corresponds to the RBAC that was added upstream in this PR: https://github.com/rook/rook/pull/8118


