### PR TITLE
Thick Provision SC Parameters has to be updated

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -303,16 +303,19 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 				return err
 			}
 		case "StorageClass":
-			var scc StorageClassConfiguration
+			// sccArr will contain all the SC Configs
+			var sccArr []StorageClassConfiguration
 			if d.Name == cephFsStorageClassName {
-				scc = newCephFilesystemStorageClassConfiguration(instance)
+				sccArr = append(sccArr,
+					newCephFilesystemStorageClassConfiguration(instance))
 				enableRookCSICephFS = true
 			} else if d.Name == cephRbdStorageClassName {
-				scc = newCephBlockPoolStorageClassConfiguration(instance, false)
-				// if RBD storageclass is present, we need to add thick provision
-				// storageclass as well into the 'availableSCCs' array
-				availableSCCs = append(availableSCCs,
-					newCephBlockPoolStorageClassConfiguration(instance, true))
+				// if RBD storageclass is present, we need to add
+				// a thick provision storageclass as well
+				sccArr = append(sccArr,
+					newCephBlockPoolStorageClassConfiguration(instance, false),
+					newCephBlockPoolStorageClassConfiguration(instance, true),
+				)
 			} else if d.Name == cephRgwStorageClassName {
 				rgwEndpoint := d.Data[externalCephRgwEndpointKey]
 				if err := checkEndpointReachable(rgwEndpoint, 5*time.Second); err != nil {
@@ -329,14 +332,21 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 				// https://github.com/rook/rook/issues/6165
 				delete(d.Data, externalCephRgwEndpointKey)
 
-				scc = newCephOBCStorageClassConfiguration(instance)
+				sccArr = append(sccArr,
+					newCephOBCStorageClassConfiguration(instance))
 			}
-			// now sc is pointing to appropriate StorageClass,
-			// whose parameters have to be updated
-			for k, v := range d.Data {
-				scc.storageClass.Parameters[k] = v
+			// most cases, 'sccArr' will be a singleton array,
+			// only in case of 'ceph-rbd' SC name, we create
+			// both thin and thick provision SCs.
+			for _, scc := range sccArr {
+				// now 'scc' is pointing to
+				// appropriate StorageClass Configuration,
+				// whose SC parameters have to be updated
+				for k, v := range d.Data {
+					scc.storageClass.Parameters[k] = v
+				}
+				availableSCCs = append(availableSCCs, scc)
 			}
-			availableSCCs = append(availableSCCs, scc)
 		}
 	}
 	// creating only the available storageClasses


### PR DESCRIPTION
Whenever a 'ceph-rbd' SC name is found, we have to create both thin and
thick provision RBD StorageClasses and for both the SC-s' parameters has
to be modified according to the 'data' passed from the input secret.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>