### PR TITLE
must-gather: Don't download and install jq

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -99,11 +99,6 @@ for ns in $namespaces; do
         mkdir -p "${COMMAND_JSON_OUTPUT_DIR}"
         mkdir -p "${COMMAND_ERR_OUTPUT_DIR}"
 
-
-        # add jq command to the helper pod
-        timeout 120 oc -n "$ns" exec "${HOSTNAME}"-helper -- bash -c "wget 'http://stedolan.github.io/jq/download/linux64/jq' && chmod 755 jq"
-        timeout 120 oc -n "$ns" exec "${HOSTNAME}"-helper -- bash -c "mv jq /usr/bin/"
-
         pids_ceph=()
 
         # Collecting output of ceph osd config


### PR DESCRIPTION
jq command is now built with rook-ceph base image.
No need to download it while collecting must-gather.

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>

Fixes: https://github.com/openshift/ocs-operator/issues/1187