### PR TITLE
Update OCS operator version at build time

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -12,6 +12,7 @@ GOARCH="${GOARCH:-amd64}"
 # Current DEV version of the CSV
 DEFAULT_CSV_VERSION="4.9.0"
 CSV_VERSION="${CSV_VERSION:-${DEFAULT_CSV_VERSION}}"
+VERSION="${VERSION:-${CSV_VERSION}}"
 
 OUTDIR="build/_output"
 OUTDIR_BIN="build/_output/bin"

--- a/hack/go-build.sh
+++ b/hack/go-build.sh
@@ -5,5 +5,9 @@ set -e
 source hack/common.sh
 
 mkdir -p ${OUTDIR_BIN}
-go build -tags 'netgo osusergo' -ldflags="-s -w -X github.com/openshift/ocs-operator/controllers/defaults.IsUnsupportedCephVersionAllowed=${OCS_ALLOW_UNSUPPORTED_CEPH_VERSION}" -o ${OUTDIR_BIN}/ocs-operator ./main.go
-go build -tags 'netgo osusergo' -ldflags="-s -w -X github.com/openshift/ocs-operator/controllers/defaults.IsUnsupportedCephVersionAllowed=${OCS_ALLOW_UNSUPPORTED_CEPH_VERSION}" -o ${OUTDIR_BIN}/metrics-exporter ./metrics/main.go
+
+LDFLAGS="-s -w -X github.com/openshift/ocs-operator/controllers/defaults.IsUnsupportedCephVersionAllowed=${OCS_ALLOW_UNSUPPORTED_CEPH_VERSION} \
+	-X github.com/openshift/ocs-operator/version.Version=${VERSION}"
+
+go build -tags 'netgo osusergo' -ldflags="${LDFLAGS}" -o ${OUTDIR_BIN}/ocs-operator ./main.go
+go build -tags 'netgo osusergo' -ldflags="${LDFLAGS}" -o ${OUTDIR_BIN}/metrics-exporter ./metrics/main.go


### PR DESCRIPTION
Synchronizes the `version.Version` to `$CSV_VERSION`'s value at build-time.