### PR TITLE
hack/source-manifests: Update noobaa cmd

### DIFF
--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -34,7 +34,7 @@ mkdir -p $OUTDIR_TOOLS
 # ==== DUMP NOOBAA YAMLS ====
 function dump_noobaa_csv() {
 	noobaa_dump_crds_cmd="crd yaml"
-	noobaa_dump_csv_cmd="olm csv yaml"
+	noobaa_dump_csv_cmd="olm csv"
 	noobaa_crds_outdir="$OUTDIR_CRDS/noobaa"
 	rm -rf $NOOBAA_CSV
 	rm -rf $noobaa_crds_outdir


### PR DESCRIPTION
Noobaa operator no longer accepts `olm csv yaml` command for dumping the
noobaa CSV. It is just `olm csv`, now. The new command still works in
older noobaa operators (4.8 at least), only the support for the yaml
suffix was dropped in 4.9.

Signed-off-by: Boris Ranto <branto@redhat.com>