### PR TITLE
ceph: disable many objects warning

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -45,6 +45,7 @@ mon_osd_full_ratio = .85
 mon_osd_backfillfull_ratio = .8
 mon_osd_nearfull_ratio = .75
 mon_max_pg_per_osd = 600
+mon_pg_warn_max_object_skew = 0
 [osd]
 osd_memory_target_cgroup_limit_ratio = 0.5
 `


### PR DESCRIPTION
Adding "mon_pg_warn_max_object_skew = 0" to
the [global] section of the defaultRookConfigData var.

Signed-off-by: Mudit Agarwal <muagarwa@redhat.com>