### PR TITLE
ocs: replace avoid with skip where possible

### DIFF
--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -24,17 +24,17 @@ func (obj *ocsCephObjectStores) ensureCreated(r *StorageClusterReconciler, insta
 		return nil
 	}
 
-	avoid, err := r.PlatformsShouldAvoidObjectStore()
+	skip, err := r.PlatformsShouldSkipObjectStore()
 	if err != nil {
 		return err
 	}
 
-	if avoid {
+	if skip {
 		platform, err := r.platform.GetPlatform(r.Client)
 		if err != nil {
 			return err
 		}
-		r.Log.Info("Platform is set to avoid object store. Not creating a CephObjectStore.", "Platform", platform)
+		r.Log.Info("Platform is set to skip object store. Not creating a CephObjectStore.", "Platform", platform)
 		return nil
 	}
 

--- a/controllers/storagecluster/cephobjectstores_test.go
+++ b/controllers/storagecluster/cephobjectstores_test.go
@@ -48,9 +48,9 @@ func assertCephObjectStores(t *testing.T, reconciler StorageClusterReconciler, c
 	err = reconciler.Client.Get(context.TODO(), request.NamespacedName, actualCos)
 	// for any cloud platform, 'cephobjectstore' should not be created
 	// 'Get' should have thrown an error
-	avoid, avoidErr := reconciler.PlatformsShouldAvoidObjectStore()
-	assert.NoError(t, avoidErr)
-	if avoid {
+	skip, skipErr := reconciler.PlatformsShouldSkipObjectStore()
+	assert.NoError(t, skipErr)
+	if skip {
 		assert.Error(t, err)
 	} else {
 		assert.NoError(t, err)

--- a/controllers/storagecluster/cephobjectstoreusers.go
+++ b/controllers/storagecluster/cephobjectstoreusers.go
@@ -47,17 +47,17 @@ func (obj *ocsCephObjectStoreUsers) ensureCreated(r *StorageClusterReconciler, i
 	if reconcileStrategy == ReconcileStrategyIgnore {
 		return nil
 	}
-	avoid, err := r.PlatformsShouldAvoidObjectStore()
+	skip, err := r.PlatformsShouldSkipObjectStore()
 	if err != nil {
 		return err
 	}
 
-	if avoid {
+	if skip {
 		platform, err := r.platform.GetPlatform(r.Client)
 		if err != nil {
 			return err
 		}
-		r.Log.Info("Platform is set to avoid object store. Not creating a CephObjectStore.", "Platform", platform)
+		r.Log.Info("Platform is set to skip object store. Not creating a CephObjectStoreUser.", "Platform", platform)
 		return nil
 	}
 

--- a/controllers/storagecluster/cephobjectstoreusers_test.go
+++ b/controllers/storagecluster/cephobjectstoreusers_test.go
@@ -48,7 +48,7 @@ func assertCephObjectStoreUsers(t *testing.T, reconciler StorageClusterReconcile
 	}
 	request.Name = "ocsinit-cephobjectstoreuser"
 	err = reconciler.Client.Get(context.TODO(), request.NamespacedName, actualCosu)
-	if avoidObjectStore(reconciler.platform.platform) {
+	if skipObjectStore(reconciler.platform.platform) {
 		assert.Error(t, err)
 	} else {
 		assert.NoError(t, err)

--- a/controllers/storagecluster/initialization_reconciler_test.go
+++ b/controllers/storagecluster/initialization_reconciler_test.go
@@ -80,9 +80,9 @@ func createUpdateRuntimeObjects(t *testing.T, cp *Platform, r StorageClusterReco
 	}
 	updateRTObjects := []client.Object{csfs, csrbd, cfs, cbp}
 
-	avoid, err := r.PlatformsShouldAvoidObjectStore()
+	skip, err := r.PlatformsShouldSkipObjectStore()
 	assert.NoError(t, err)
-	if !avoid {
+	if !skip {
 		csobc := &storagev1.StorageClass{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "ocsinit-ceph-rgw",

--- a/controllers/storagecluster/platform_detection.go
+++ b/controllers/storagecluster/platform_detection.go
@@ -22,8 +22,8 @@ const (
 	IBMCloudCosPlatformType configv1.PlatformType = "IBMCloudCosPlatform"
 )
 
-// AvoidObjectStorePlatforms is a list of all PlatformTypes where CephObjectStores will not be deployed.
-var AvoidObjectStorePlatforms = []configv1.PlatformType{
+// SkipObjectStorePlatforms is a list of all PlatformTypes where CephObjectStores will not be deployed.
+var SkipObjectStorePlatforms = []configv1.PlatformType{
 	configv1.AWSPlatformType,
 	configv1.GCPPlatformType,
 	configv1.AzurePlatformType,
@@ -76,8 +76,8 @@ func (p *Platform) getPlatform(c client.Client) (configv1.PlatformType, error) {
 	return p.platform, nil
 }
 
-func avoidObjectStore(p configv1.PlatformType) bool {
-	for _, platform := range AvoidObjectStorePlatforms {
+func skipObjectStore(p configv1.PlatformType) bool {
+	for _, platform := range SkipObjectStorePlatforms {
 		if p == platform {
 			return true
 		}
@@ -135,17 +135,17 @@ func (r *StorageClusterReconciler) DevicesDefaultToFastForThisPlatform() (bool, 
 	return false, nil
 }
 
-// PlatformsShouldAvoidObjectStore determines whether an object store should be created
+// PlatformsShouldSkipObjectStore determines whether an object store should be created
 // for the platform.
-func (r *StorageClusterReconciler) PlatformsShouldAvoidObjectStore() (bool, error) {
+func (r *StorageClusterReconciler) PlatformsShouldSkipObjectStore() (bool, error) {
 	// Call GetPlatform to get platform
 	platform, err := r.platform.GetPlatform(r.Client)
 	if err != nil {
 		return false, err
 	}
 
-	// Call avoidObjectStore to avoid creation of objectstores
-	if avoidObjectStore(platform) {
+	// Call skipObjectStore to skip creation of objectstores
+	if skipObjectStore(platform) {
 		return true, nil
 	}
 

--- a/controllers/storagecluster/routes.go
+++ b/controllers/storagecluster/routes.go
@@ -22,16 +22,16 @@ func (obj *ocsCephRGWRoutes) ensureCreated(r *StorageClusterReconciler, instance
 	if reconcileStrategy == ReconcileStrategyIgnore {
 		return nil
 	}
-	avoid, err := r.PlatformsShouldAvoidObjectStore()
+	skip, err := r.PlatformsShouldSkipObjectStore()
 	if err != nil {
 		return err
 	}
-	if avoid {
+	if skip {
 		platform, err := r.platform.GetPlatform(r.Client)
 		if err != nil {
 			return err
 		}
-		r.Log.Info("Platform is set to avoid Ceph RGW Route. Not creating a Ceph RGW Route.", "platform", platform)
+		r.Log.Info("Platform is set to skip Ceph RGW Route. Not creating a Ceph RGW Route.", "platform", platform)
 		return nil
 	}
 

--- a/controllers/storagecluster/routes_test.go
+++ b/controllers/storagecluster/routes_test.go
@@ -54,7 +54,7 @@ func assertCephRGWRoutes(t *testing.T, reconciler StorageClusterReconciler, cr *
 	err = reconciler.Client.Get(context.TODO(), request.NamespacedName, actualCos)
 	// for any cloud platform, 'route' should not be created
 	// 'Get' should have thrown an error
-	if avoidObjectStore(reconciler.platform.platform) {
+	if skipObjectStore(reconciler.platform.platform) {
 		assert.Error(t, err)
 	} else {
 		assert.NoError(t, err)

--- a/controllers/storagecluster/storageclasses.go
+++ b/controllers/storagecluster/storageclasses.go
@@ -236,8 +236,8 @@ func (r *StorageClusterReconciler) newStorageClassConfigurations(initData *ocsv1
 	// a. either 'externalStorage' is enabled
 	// OR
 	// b. current platform is not a cloud-based platform
-	avoid, err := r.PlatformsShouldAvoidObjectStore()
-	if initData.Spec.ExternalStorage.Enable || err == nil && !avoid {
+	skip, err := r.PlatformsShouldSkipObjectStore()
+	if initData.Spec.ExternalStorage.Enable || err == nil && !skip {
 		ret = append(ret, newCephOBCStorageClassConfiguration(initData))
 	}
 	return ret, nil

--- a/controllers/storagecluster/storageclasses_test.go
+++ b/controllers/storagecluster/storageclasses_test.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var allPlatforms = append(AvoidObjectStorePlatforms,
+var allPlatforms = append(SkipObjectStorePlatforms,
 	configv1.NonePlatformType, configv1.PlatformType("NonCloudPlatform"), configv1.IBMCloudPlatformType)
 
 func TestStorageClasses(t *testing.T) {
@@ -41,9 +41,9 @@ func assertStorageClasses(t *testing.T, reconciler StorageClusterReconciler, cr 
 
 	// on a cloud platform, 'Get' should throw an error,
 	// as RGW StorageClass won't be created
-	avoid, avoidErr := reconciler.PlatformsShouldAvoidObjectStore()
-	assert.NoError(t, avoidErr)
-	if avoid {
+	skip, skipErr := reconciler.PlatformsShouldSkipObjectStore()
+	assert.NoError(t, skipErr)
+	if skip {
 		// we should be expecting only 3 StorageClasses
 		assert.Equal(t, len(expected), 3)
 	} else {
@@ -55,7 +55,7 @@ func assertStorageClasses(t *testing.T, reconciler StorageClusterReconciler, cr 
 		scName := scConfig.storageClass.Name
 		request.Name = scName
 		err := reconciler.Client.Get(context.TODO(), request.NamespacedName, actual[scName])
-		if avoid && scName == scNameRgw {
+		if skip && scName == scNameRgw {
 			assert.Error(t, err)
 		} else {
 			assert.NoError(t, err)


### PR DESCRIPTION
Replace "avoid" with "skip" in functions and variables whenever
it better clarifies what the code is doing.

Signed-off-by: N Balachandran <nibalach@redhat.com>