### PR TITLE
[WIP] Changing the way external endpoint IP/Port being propagated

### DIFF
--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -72,17 +72,15 @@ type ImageMap struct {
 //nolint
 type StorageClusterReconciler struct {
 	client.Client
-	Log            logr.Logger
-	Scheme         *runtime.Scheme
-	serverVersion  *version.Info
-	conditions     []conditionsv1.Condition
-	phase          string
-	monitoringIP   string
-	monitoringPort string
-	nodeCount      int
-	platform       *Platform
-	images         ImageMap
-	recorder       *util.EventReporter
+	Log           logr.Logger
+	Scheme        *runtime.Scheme
+	serverVersion *version.Info
+	conditions    []conditionsv1.Condition
+	phase         string
+	nodeCount     int
+	platform      *Platform
+	images        ImageMap
+	recorder      *util.EventReporter
 }
 
 // SetupWithManager sets up a controller with manager


### PR DESCRIPTION
Previously external cluster's monitoring endpoints were attached to
Reconcile object's variables and passed to other parts of the code.

Now, we are creating an external endpoint configmap which holds the
monitoring endpoint details. Resources (like CephCluster) which requires
these endpoint details, can access it through the endpoint configmap.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>