### PR TITLE
[WIP] Changing the way external endpoint IP/Port being propagated

### DIFF
--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -64,6 +64,14 @@ var globalTestExternalResources = []ExternalResource{
 		},
 		Name: "ceph-rgw",
 	},
+	{
+		Kind: "CephCluster",
+		Data: map[string]string{
+			"MonitoringEndpoint": "127.0.0.1, localhost",
+			"MonitoringPort":     fmt.Sprintf("%d", generateRandomPort(19000, 29000)),
+		},
+		Name: "monitoring-endpoint",
+	},
 }
 
 func TestEnsureExternalStorageClusterResources(t *testing.T) {
@@ -142,6 +150,7 @@ func createExternalClusterReconcilerFromCustomResources(
 		monEndpointIP := extResource.Data["MonitoringEndpoint"]
 		monEndpointPort := extResource.Data["MonitoringPort"]
 		if monEndpointIP != "" && monEndpointPort != "" {
+			monEndpointIP = parseMonitoringIPs(monEndpointIP)[0]
 			startServerAt(net.JoinHostPort(monEndpointIP, monEndpointPort))
 		}
 	}
@@ -231,16 +240,6 @@ func assertExpectedExternalResources(t *testing.T, reconciler StorageClusterReco
 			}
 		}
 	}
-}
-
-// findNamedResourceFromArray retrieves the 'ExternalResource' with provided 'name'
-func findNamedResourceFromArray(extArr []ExternalResource, name string) (ExternalResource, error) {
-	for _, extR := range extArr {
-		if extR.Name == name {
-			return extR, nil
-		}
-	}
-	return ExternalResource{}, fmt.Errorf("Unable to retrieve %q external resource", name)
 }
 
 // removeNamedResourceFromArray removes the first resource with 'Name' == 'name'

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -72,17 +72,15 @@ type ImageMap struct {
 //nolint
 type StorageClusterReconciler struct {
 	client.Client
-	Log            logr.Logger
-	Scheme         *runtime.Scheme
-	serverVersion  *version.Info
-	conditions     []conditionsv1.Condition
-	phase          string
-	monitoringIP   string
-	monitoringPort string
-	nodeCount      int
-	platform       *Platform
-	images         ImageMap
-	recorder       *util.EventReporter
+	Log           logr.Logger
+	Scheme        *runtime.Scheme
+	serverVersion *version.Info
+	conditions    []conditionsv1.Condition
+	phase         string
+	nodeCount     int
+	platform      *Platform
+	images        ImageMap
+	recorder      *util.EventReporter
 }
 
 // SetupWithManager sets up a controller with manager


### PR DESCRIPTION
Previously external cluster's monitoring endpoints were attached to
Reconcile object's variables and passed to other parts of the code.

Now, we are retrieving the Monitoring endpoint details, directly from
the external cluster secret, while creating the CephCluster and do all
the verifications.

Signed-off-by: Arun Kumar Mohan <amohan@redhat.com>