### PR TITLE
Fix external resources updation when json input change

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -104,7 +104,25 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 	var cephCluster *rookCephv1.CephCluster
 	// Define a new CephCluster object
 	if sc.Spec.ExternalStorage.Enable {
-		cephCluster = newExternalCephCluster(sc, r.images.Ceph, r.monitoringIP, r.monitoringPort)
+		extRArr, err := r.retrieveExternalSecretData(sc)
+		if err != nil {
+			r.Log.Error(err, "Could not retrieve the External Cluster details.",
+				"CephCluster", klog.KRef(sc.Namespace, sc.Name))
+			return err
+		}
+		endpointR, err := findNamedResourceFromArray(extRArr, "monitoring-endpoint")
+		if err != nil {
+			return err
+		}
+		monitoringIP := endpointR.Data["MonitoringEndpoint"]
+		monitoringPort := endpointR.Data["MonitoringPort"]
+		if err := verifyMonitoringEndpoints(monitoringIP, monitoringPort, r.Log); err != nil {
+			r.Log.Error(err, "Could not connect to the Monitoring Endpoints.",
+				"CephCluster", klog.KRef(sc.Namespace, sc.Name))
+			return err
+		}
+		r.Log.Info("Monitoring Information found. Monitoring will be enabled on the external cluster.", "CephCluster", klog.KRef(sc.Namespace, sc.Name))
+		cephCluster = newExternalCephCluster(sc, r.images.Ceph, monitoringIP, monitoringPort)
 	} else {
 		kmsConfigMap, err := getKMSConfigMap(KMSConfigMapName, sc, r.Client)
 		if err != nil {

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -476,7 +476,9 @@ func TestKMSConfigChanges(t *testing.T) {
 		{testLabel: "case 4", kmsProvider: "vault", kmsAddress: "http://unearchable.url.location:3366", failureExpected: true},
 	}
 	for _, kmsArgs := range validKMSArgs {
-		assertCephClusterKMSConfiguration(t, kmsArgs)
+		t.Run(kmsArgs.testLabel, func(t *testing.T) {
+			assertCephClusterKMSConfiguration(t, kmsArgs)
+		})
 	}
 }
 

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -501,7 +501,11 @@ func assertCephClusterKMSConfiguration(t *testing.T, kmsArgs struct {
 
 	// don't start dummy servers for invalid tests
 	if !kmsArgs.failureExpected {
-		startServerAt(kmsArgs.kmsAddress)
+		errChan := startServerAt(kmsArgs.kmsAddress)
+		go func() {
+			servErr := <-errChan
+			assert.NilError(t, servErr)
+		}()
 	}
 
 	var obj ocsCephCluster

--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -260,36 +260,16 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 		objectKey := types.NamespacedName{Name: d.Name, Namespace: instance.Namespace}
 		switch d.Kind {
 		case "CephCluster":
-			monitoringIP := d.Data["MonitoringEndpoint"]
-			if monitoringIP == "" {
-				err := fmt.Errorf(
-					"Monitoring Endpoint not present in the external cluster secret %s",
-					externalClusterDetailsSecret)
-				r.Log.Error(err, "Failed to get Monitoring IP.")
-				return err
-			}
-			// replace any comma in the monitoring ip string with space
-			// and then collect individual (non-empty) items' array
-			monIPArr := parseMonitoringIPs(monitoringIP)
-			monitoringPort := d.Data["MonitoringPort"]
-			if monitoringPort != "" {
-				var err error
-				for _, eachMonIP := range monIPArr {
-					err = checkEndpointReachable(net.JoinHostPort(eachMonIP, monitoringPort), 5*time.Second)
-					// if any one of the mon's IP:PORT combination is reachable,
-					// consider the whole set as valid
-					if err == nil {
-						break
-					}
-				}
-				if err != nil {
-					r.Log.Error(err, "Monitoring validation failed")
+			if d.Name == "monitoring-endpoint" {
+				monitoringIP := d.Data["MonitoringEndpoint"]
+				monitoringPort := d.Data["MonitoringPort"]
+				if err := verifyMonitoringEndpoints(monitoringIP, monitoringPort, r.Log); err != nil {
 					return err
 				}
+				r.monitoringIP = monitoringIP
 				r.monitoringPort = monitoringPort
+				r.Log.Info("Monitoring Information found. Monitoring will be enabled on the external cluster.", "StorageCluster", klog.KRef(instance.Namespace, instance.Name))
 			}
-			r.Log.Info("Monitoring Information found. Monitoring will be enabled on the external cluster.", "StorageCluster", klog.KRef(instance.Namespace, instance.Name))
-			r.monitoringIP = monitoringIP
 		case "ConfigMap":
 			cm := &corev1.ConfigMap{
 				ObjectMeta: objectMeta,
@@ -378,6 +358,35 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 		}
 	}
 	return nil
+}
+
+func verifyMonitoringEndpoints(monitoringIP, monitoringPort string,
+	log logr.Logger) (err error) {
+	if monitoringIP == "" {
+		err = fmt.Errorf(
+			"Monitoring Endpoint not present in the external cluster secret %s",
+			externalClusterDetailsSecret)
+		log.Error(err, "Failed to get Monitoring IP.")
+		return
+	}
+	if monitoringPort != "" {
+		// replace any comma in the monitoring ip string with space
+		// and then collect individual (non-empty) items' array
+		monIPArr := parseMonitoringIPs(monitoringIP)
+		for _, eachMonIP := range monIPArr {
+			err = checkEndpointReachable(net.JoinHostPort(eachMonIP, monitoringPort), 5*time.Second)
+			// if any one of the mon's IP:PORT combination is reachable,
+			// consider the whole set as valid
+			if err == nil {
+				break
+			}
+		}
+		if err != nil {
+			log.Error(err, "Monitoring validation failed")
+			return
+		}
+	}
+	return
 }
 
 // createExternalStorageClusterConfigMap creates configmap for external cluster

--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -64,6 +64,14 @@ var globalTestExternalResources = []ExternalResource{
 		},
 		Name: "ceph-rgw",
 	},
+	{
+		Kind: "CephCluster",
+		Data: map[string]string{
+			"MonitoringEndpoint": "127.0.0.1, localhost",
+			"MonitoringPort":     fmt.Sprintf("%d", generateRandomPort(19000, 29000)),
+		},
+		Name: "monitoring-endpoint",
+	},
 }
 
 func TestEnsureExternalStorageClusterResources(t *testing.T) {
@@ -142,6 +150,7 @@ func createExternalClusterReconcilerFromCustomResources(
 		monEndpointIP := extResource.Data["MonitoringEndpoint"]
 		monEndpointPort := extResource.Data["MonitoringPort"]
 		if monEndpointIP != "" && monEndpointPort != "" {
+			monEndpointIP = parseMonitoringIPs(monEndpointIP)[0]
 			startServerAt(net.JoinHostPort(monEndpointIP, monEndpointPort))
 		}
 	}
@@ -231,16 +240,6 @@ func assertExpectedExternalResources(t *testing.T, reconciler StorageClusterReco
 			}
 		}
 	}
-}
-
-// findNamedResourceFromArray retrieves the 'ExternalResource' with provided 'name'
-func findNamedResourceFromArray(extArr []ExternalResource, name string) (ExternalResource, error) {
-	for _, extR := range extArr {
-		if extR.Name == name {
-			return extR, nil
-		}
-	}
-	return ExternalResource{}, fmt.Errorf("Unable to retrieve %q external resource", name)
 }
 
 // removeNamedResourceFromArray removes the first resource with 'Name' == 'name'

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -78,8 +78,6 @@ type StorageClusterReconciler struct {
 	serverVersion     *version.Info
 	conditions        []conditionsv1.Condition
 	phase             string
-	monitoringIP      string
-	monitoringPort    string
 	nodeCount         int
 	platform          *Platform
 	images            ImageMap


### PR DESCRIPTION
This PR make sure that when JSON input is changed, corresponding external cluster resources also get updated.

This is on top of PR:https://github.com/openshift/ocs-operator/pull/1286 .