### PR TITLE
OCS: Upgrade rbac manifests to use api v1

### DIFF
--- a/deploy/bundle/manifests/exporter-role.yaml
+++ b/deploy/bundle/manifests/exporter-role.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-metrics-exporter
 rules:

--- a/deploy/bundle/manifests/exporter-role_binding.yaml
+++ b/deploy/bundle/manifests/exporter-role_binding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-metrics-exporter
 roleRef:

--- a/deploy/bundle/manifests/exporter-service-role.yaml
+++ b/deploy/bundle/manifests/exporter-service-role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-metrics-svc
 rules:

--- a/deploy/bundle/manifests/exporter-service-role_binding.yaml
+++ b/deploy/bundle/manifests/exporter-service-role_binding.yaml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-metrics-svc
 roleRef:

--- a/deploy/bundle/manifests/noobaa-metrics-role.yaml
+++ b/deploy/bundle/manifests/noobaa-metrics-role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: noobaa-metrics
 rules:

--- a/deploy/bundle/manifests/noobaa-metrics-role_binding.yaml
+++ b/deploy/bundle/manifests/noobaa-metrics-role_binding.yaml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: noobaa-metrics
 roleRef:

--- a/deploy/bundle/manifests/rook-metrics-role.yaml
+++ b/deploy/bundle/manifests/rook-metrics-role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-metrics
 rules:

--- a/deploy/bundle/manifests/rook-metrics-role_binding.yaml
+++ b/deploy/bundle/manifests/rook-metrics-role_binding.yaml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-metrics
 roleRef:

--- a/deploy/bundle/manifests/rook-monitor-role.yaml
+++ b/deploy/bundle/manifests/rook-monitor-role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-monitor
 rules:

--- a/deploy/bundle/manifests/rook-monitor-role_binding.yaml
+++ b/deploy/bundle/manifests/rook-monitor-role_binding.yaml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-monitor
 roleRef:

--- a/rbac/exporter-role.yaml
+++ b/rbac/exporter-role.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-metrics-exporter
 rules:

--- a/rbac/exporter-role_binding.yaml
+++ b/rbac/exporter-role_binding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-metrics-exporter
 roleRef:

--- a/rbac/exporter-service-role.yaml
+++ b/rbac/exporter-service-role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-metrics-svc
 rules:

--- a/rbac/exporter-service-role_binding.yaml
+++ b/rbac/exporter-service-role_binding.yaml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ocs-metrics-svc
 roleRef:

--- a/rbac/noobaa-metrics-role.yaml
+++ b/rbac/noobaa-metrics-role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: noobaa-metrics
 rules:

--- a/rbac/noobaa-metrics-role_binding.yaml
+++ b/rbac/noobaa-metrics-role_binding.yaml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: noobaa-metrics
 roleRef:

--- a/rbac/rook-metrics-role.yaml
+++ b/rbac/rook-metrics-role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-metrics
 rules:

--- a/rbac/rook-metrics-role_binding.yaml
+++ b/rbac/rook-metrics-role_binding.yaml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-metrics
 roleRef:

--- a/rbac/rook-monitor-role.yaml
+++ b/rbac/rook-monitor-role.yaml
@@ -1,5 +1,5 @@
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-monitor
 rules:

--- a/rbac/rook-monitor-role_binding.yaml
+++ b/rbac/rook-monitor-role_binding.yaml
@@ -1,5 +1,5 @@
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rook-ceph-monitor
 roleRef:


### PR DESCRIPTION
Update rbac manifests to use the rbac.authorization.k8s.io/v1 API version