### PR TITLE
storagecluster: move cephCluster deletion at the end

### DIFF
--- a/controllers/storagecluster/uninstall_reconciler.go
+++ b/controllers/storagecluster/uninstall_reconciler.go
@@ -284,7 +284,6 @@ func (r *StorageClusterReconciler) deleteResources(sc *ocsv1.StorageCluster) err
 
 	objs := []resourceManager{
 		&ocsNoobaaSystem{},
-		&ocsCephCluster{},
 		&ocsCephRGWRoutes{},
 		&ocsCephObjectStoreUsers{},
 		&ocsCephObjectStores{},
@@ -292,6 +291,7 @@ func (r *StorageClusterReconciler) deleteResources(sc *ocsv1.StorageCluster) err
 		&ocsCephBlockPools{},
 		&ocsSnapshotClass{},
 		&ocsStorageClass{},
+		&ocsCephCluster{},
 	}
 
 	for _, obj := range objs {


### PR DESCRIPTION
with the new uninstall behaviour of the rook we should delete
cephCluster at the end after all related resources are deleted.

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>

cc @raghavendra-talur @BlaineEXE 