### PR TITLE
Fix ocs performance latency recording rules

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -15,13 +15,13 @@ spec:
         \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by
         (instance,device) \n    (1,\n      (\n        rate(node_disk_read_time_seconds_total[1m])
         / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      )\n    )\n)\n"
-      record: 'record: cluster:ceph_disk_latency_read:join_ceph_node_disk_rate1m'
+      record: cluster:ceph_disk_latency_read:join_ceph_node_disk_rate1m
     - expr: "sum by (namespace, managedBy) (\n    topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"},
         \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\",
         \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by
         (instance,device) \n    (1,\n      (\n        rate(node_disk_write_time_seconds_total[1m])
         / (clamp_min(rate(node_disk_writes_completed_total[1m]), 1))\n      )\n    )\n)\n"
-      record: 'record: cluster:ceph_disk_latency_write:join_ceph_node_disk_rate1m'
+      record: cluster:ceph_disk_latency_write:join_ceph_node_disk_rate1m
   - name: external-cluster-services-alert.rules
     rules:
     - alert: ClusterObjectStoreState

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -15,13 +15,13 @@ spec:
         \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by
         (instance,device) \n    (1,\n      (\n        rate(node_disk_read_time_seconds_total[1m])
         / (clamp_min(rate(node_disk_reads_completed_total[1m]), 1))\n      )\n    )\n)\n"
-      record: 'record: cluster:ceph_disk_latency_read:join_ceph_node_disk_rate1m'
+      record: cluster:ceph_disk_latency_read:join_ceph_node_disk_rate1m
     - expr: "sum by (namespace, managedBy) (\n    topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job=\"rook-ceph-mgr\"},
         \"instance\", \"$1\", \"exported_instance\", \"(.*)\"), \"device\", \"$1\",
         \"device\", \"/dev/(.*)\")) \n  * on(instance, device) group_left topk by
         (instance,device) \n    (1,\n      (\n        rate(node_disk_write_time_seconds_total[1m])
         / (clamp_min(rate(node_disk_writes_completed_total[1m]), 1))\n      )\n    )\n)\n"
-      record: 'record: cluster:ceph_disk_latency_write:join_ceph_node_disk_rate1m'
+      record: cluster:ceph_disk_latency_write:join_ceph_node_disk_rate1m
   - name: cluster-services-alert.rules
     rules:
     - alert: ClusterObjectStoreState

--- a/metrics/mixin/rules/rules.libsonnet
+++ b/metrics/mixin/rules/rules.libsonnet
@@ -5,7 +5,7 @@
         name: 'ocs_performance.rules',
         rules: [
           {
-            record: 'record: cluster:ceph_disk_latency_read:join_ceph_node_disk_rate1m',
+            record: 'cluster:ceph_disk_latency_read:join_ceph_node_disk_rate1m',
             expr: |||
               sum by (namespace, managedBy) (
                   topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job="rook-ceph-mgr"}, "instance", "$1", "exported_instance", "(.*)"), "device", "$1", "device", "/dev/(.*)")) 
@@ -19,7 +19,7 @@
             ||| % $._config,
           },
           {
-            record: 'record: cluster:ceph_disk_latency_write:join_ceph_node_disk_rate1m',
+            record: 'cluster:ceph_disk_latency_write:join_ceph_node_disk_rate1m',
             expr: |||
               sum by (namespace, managedBy) (
                   topk by (ceph_daemon) (1, label_replace(label_replace(ceph_disk_occupation{job="rook-ceph-mgr"}, "instance", "$1", "exported_instance", "(.*)"), "device", "$1", "device", "/dev/(.*)")) 


### PR DESCRIPTION
This PR fixes the typos in the ocs performance recording rules for the cluster latency.

Signed-off-by: Anmol Sachan <anmol13694@gmail.com>


Tested the rules on the cluster: 
![Screenshot from 2021-08-09 21-19-24](https://user-images.githubusercontent.com/8753636/128736584-de6ce351-cfa1-4f0c-b612-409a4aa68839.png)


