### PR TITLE
must-gather: collect logs for RegionalDR

### DIFF
--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -140,6 +140,11 @@ for ns in $namespaces; do
         # Collecting rbd mirroring info for ceph rbd volumes
         printf "collecting rbd mirroring info for ceph rbd volumes \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
         COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/rbd_vol_and_mirror_info
+        # Checking snapshot schedule status
+        { printf "checking snapshot schedule status \n" >> "${COMMAND_OUTPUT_FILE}"; }
+        printf "collecting snapshot schedule status \n" | tee -a "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule status --format=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-status-debug.log 2>&1 &
+        pids_ceph+=($!)
         # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n openshift-storage -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
         for bp in $blockpools; do

--- a/must-gather/collection-scripts/gather_ceph_resources
+++ b/must-gather/collection-scripts/gather_ceph_resources
@@ -128,21 +128,40 @@ for ns in $namespaces; do
         # Inspecting ceph block pools for ceph rbd
         blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n openshift-storage -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
         for bp in $blockpools; do
-            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule list --pool=$bp" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-list-"${bp}"-debug.log 2>&1 &
-            pids_ceph+=($!)
-            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool status $bp --format=json" >> "${JSON_COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-status-"${bp}"-debug.log 2>&1 &
-            pids_ceph+=($!)
-            { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool info $bp --format=json" >> "${JSON_COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-info-"${bp}"-debug.log 2>&1 &
-            pids_ceph+=($!)
             images=$(timeout 60 oc -n openshift-storage exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $bp")
             for image in $images; do
                 { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd info $image --pool $bp" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-image-"${image}"-debug.log 2>&1 &
                 pids_ceph+=($!)
                 { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd snap ls --all $image --pool $bp" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-snap-"${image}"-debug.log 2>&1 &
                 pids_ceph+=($!)
-                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror image status $bp/$image --format=json" >> "${JSON_COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-image-status-"${bp}"-"${image}"-debug.log 2>&1 &
-                pids_ceph+=($!)
             done
+        done
+
+        # Collecting rbd mirroring info for ceph rbd volumes
+        printf "collecting rbd mirroring info for ceph rbd volumes \n" | tee -a  "${BASE_COLLECTION_PATH}"/gather-ceph-debug.log
+        COMMAND_OUTPUT_FILE=${COMMAND_OUTPUT_DIR}/rbd_vol_and_mirror_info
+        # Inspecting ceph block pools for ceph rbd
+        blockpools=$(timeout 60 oc get cephblockpools.ceph.rook.io -n openshift-storage -o jsonpath="{range .items[*]}{@.metadata.name}{'\n'}{end}")
+        for bp in $blockpools; do
+            # Check if mirroring is enabled here.
+            isEnabled=$(timeout 60 oc -n openshift-storage exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool info $bp --format=json | jq --raw-output '.mode'")
+            if [ "${isEnabled}" != "disabled" ]; then
+                { printf "Mirroring is enabled on: %s\n" "${bp}" >> "${COMMAND_OUTPUT_FILE}"; }
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror snapshot schedule list --pool=$bp --fromat=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-snap-schedule-list-"${bp}"-debug.log 2>&1 &
+                pids_ceph+=($!)
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool status $bp --format=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-status-"${bp}"-debug.log 2>&1 &
+                pids_ceph+=($!)
+                { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror pool info $bp --format=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-pool-info-"${bp}"-debug.log 2>&1 &
+                pids_ceph+=($!)
+                images=$(timeout 60 oc -n openshift-storage exec "${HOSTNAME}"-helper -- bash -c "rbd ls -p $bp")
+                for image in $images; do
+                    { printf "Printing information for image: %s\n" "${image}" >> "${COMMAND_OUTPUT_FILE}"; }
+                    { timeout 120 oc -n "${ns}" exec "${HOSTNAME}"-helper -- bash -c "rbd mirror image status $bp/$image --format=json" >> "${COMMAND_OUTPUT_FILE}"; } >> "${COMMAND_ERR_OUTPUT_DIR}"/gather-rbd-mirror-image-status-"${bp}"-"${image}"-debug.log 2>&1 &
+                    pids_ceph+=($!)
+                done
+            else
+                { printf "Mirroring is disabled on: %s\n" "${bp}" >> "${COMMAND_OUTPUT_FILE}"; }
+            fi
         done
 
         # Collecting snapshot information for ceph subvolumes

--- a/must-gather/collection-scripts/gather_clusterscoped_resources
+++ b/must-gather/collection-scripts/gather_clusterscoped_resources
@@ -23,6 +23,7 @@ commands_get+=("infrastructures.config")
 commands_get+=("clusterrole")
 commands_get+=("clusterrolebinding")
 commands_get+=("scc")
+commands_get+=("volumereplicationclass")
 
 # collect yaml output of OC commands
 oc_yamls=()
@@ -35,6 +36,7 @@ oc_yamls+=("infrastructures.config")
 oc_yamls+=("clusterrole")
 oc_yamls+=("clusterrolebinding")
 oc_yamls+=("scc")
+oc_yamls+=("volumereplicationclass")
 
 # collect describe output of OC commands
 commands_desc=()

--- a/must-gather/collection-scripts/gather_namespaced_resources
+++ b/must-gather/collection-scripts/gather_namespaced_resources
@@ -43,8 +43,6 @@ commands_get+=("rolebinding")
 commands_get+=("volumesnapshot -A")
 commands_get+=("volumesnapshotclass")
 commands_get+=("volumesnapshotcontent")
-commands_get+=("volumereplication")
-commands_get+=("volumereplicationclass")
 
 # collect oc output of OC desc commands
 commands_desc=()
@@ -61,8 +59,6 @@ oc_yamls+=("installplan")
 oc_yamls+=("volumesnapshot -A")
 oc_yamls+=("volumesnapshotclass")
 oc_yamls+=("volumesnapshotcontent")
-oc_yamls+=("volumereplication")
-oc_yamls+=("volumereplicationclass")
 
 echo "collecting dump of namespace" | tee -a  "${BASE_COLLECTION_PATH}"/gather-debug.log
 oc adm --dest-dir="${BASE_COLLECTION_PATH}" inspect ns/"${INSTALL_NAMESPACE}" --"${SINCE_TIME}" >> "${BASE_COLLECTION_PATH}"/gather-debug.log 2>&1
@@ -113,3 +109,8 @@ echo "collecting dump of oc get pvc all namespaces" | tee -a  "${BASE_COLLECTION
 echo "collecting dump of oc get obc all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
 { oc get obc --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/obc_all_namespaces"
 { oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect obc --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1
+
+# For VolumeReplication of all namespaces
+echo "collecting dump of oc get volumereplication all namespaces" | tee -a  "${BASE_COLLECTION_PATH}/gather-debug.log"
+{ oc get volumereplication --all-namespaces; } >> "${BASE_COLLECTION_PATH}/namespaces/all/vr_all_namespaces"
+{ oc adm --dest-dir="${BASE_COLLECTION_PATH}/namespaces/all/" inspect volumereplication --all-namespaces --"${SINCE_TIME}"; } >> "${BASE_COLLECTION_PATH}/gather-debug.log" 2>&1


### PR DESCRIPTION
This PR adds the following changes.
1. separate mirroring info from snapshot info
2. adds mirror snapshot schedule list
3. checks if mirroring is enabled in CBP
4. collect logs for VR in all namespaces.

Signed-off-by: yati1998 <ypadia@redhat.com>