### PR TITLE
Use .ci-operator.yaml file for OpenShift CI builds

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: rhel-8-release-golang-1.16-openshift-4.8


### PR DESCRIPTION
See docs:
https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>