### PR TITLE
add OBC quota prometheus alerts

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules-external.yaml
+++ b/metrics/deploy/prometheus-ocs-rules-external.yaml
@@ -82,6 +82,62 @@ spec:
       for: 0s
       labels:
         severity: warning
+  - name: odf-obc-quota-alert.rules
+    rules:
+    - alert: ObcQuotaBytesAlert
+      annotations:
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80%
+          of the size limit set by the quota(bytes) and will become read-only on reaching
+          the quota limit. Increase the quota in the {{$labels.objectbucketclaim}}
+          OBC custom resource.
+        message: OBC has crossed 80% of the quota(bytes).
+        severity_level: warning
+        storage_type: RGW
+      expr: |
+        (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_used_bytes/ocs_objectbucket_max_bytes)) > 0.80
+      for: 10s
+      labels:
+        severity: warning
+    - alert: ObcQuotaObjectsAlert
+      annotations:
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80%
+          of the size limit set by the quota(objects) and will become read-only on
+          reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}}
+          OBC custom resource.
+        message: OBC has crossed 80% of the quota(object).
+        severity_level: warning
+        storage_type: RGW
+      expr: |
+        (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_objects_total/ocs_objectbucket_max_objects)) > 0.80
+      for: 10s
+      labels:
+        severity: warning
+    - alert: ObcQuotaBytesExhausedAlert
+      annotations:
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the
+          limit set by the quota(bytes) and will be read-only now. Increase the quota
+          in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
+        message: OBC reached quota(bytes) limit.
+        severity_level: error
+        storage_type: RGW
+      expr: |
+        (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_used_bytes/ocs_objectbucket_max_bytes)) >= 1
+      for: 0s
+      labels:
+        severity: critical
+    - alert: ObcQuotaObjectsExhausedAlert
+      annotations:
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the
+          limit set by the quota(objects) and will be read-only now. Increase the
+          quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
+        message: OBC reached quota(object) limit.
+        severity_level: error
+        storage_type: RGW
+      expr: |
+        (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_objects_total/ocs_objectbucket_max_objects)) >= 1
+      for: 0s
+      labels:
+        severity: critical
   - name: external-cluster-services-alert.rules
     rules:
     - alert: ClusterObjectStoreState

--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -135,6 +135,62 @@ spec:
       for: 10s
       labels:
         severity: critical
+  - name: odf-obc-quota-alert.rules
+    rules:
+    - alert: ObcQuotaBytesAlert
+      annotations:
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80%
+          of the size limit set by the quota(bytes) and will become read-only on reaching
+          the quota limit. Increase the quota in the {{$labels.objectbucketclaim}}
+          OBC custom resource.
+        message: OBC has crossed 80% of the quota(bytes).
+        severity_level: warning
+        storage_type: RGW
+      expr: |
+        (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_used_bytes/ocs_objectbucket_max_bytes)) > 0.80
+      for: 10s
+      labels:
+        severity: warning
+    - alert: ObcQuotaObjectsAlert
+      annotations:
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80%
+          of the size limit set by the quota(objects) and will become read-only on
+          reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}}
+          OBC custom resource.
+        message: OBC has crossed 80% of the quota(object).
+        severity_level: warning
+        storage_type: RGW
+      expr: |
+        (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_objects_total/ocs_objectbucket_max_objects)) > 0.80
+      for: 10s
+      labels:
+        severity: warning
+    - alert: ObcQuotaBytesExhausedAlert
+      annotations:
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the
+          limit set by the quota(bytes) and will be read-only now. Increase the quota
+          in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
+        message: OBC reached quota(bytes) limit.
+        severity_level: error
+        storage_type: RGW
+      expr: |
+        (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_used_bytes/ocs_objectbucket_max_bytes)) >= 1
+      for: 0s
+      labels:
+        severity: critical
+    - alert: ObcQuotaObjectsExhausedAlert
+      annotations:
+        description: ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the
+          limit set by the quota(objects) and will be read-only now. Increase the
+          quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.
+        message: OBC reached quota(object) limit.
+        severity_level: error
+        storage_type: RGW
+      expr: |
+        (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_objects_total/ocs_objectbucket_max_objects)) >= 1
+      for: 0s
+      labels:
+        severity: critical
   - name: cluster-services-alert.rules
     rules:
     - alert: ClusterObjectStoreState

--- a/metrics/mixin/alerts/alerts-external.libsonnet
+++ b/metrics/mixin/alerts/alerts-external.libsonnet
@@ -1,2 +1,3 @@
 (import 'cluster-resource-quota.libsonnet') +
+(import 'obc.libsonnet') +
 (import 'services-external.libsonnet')

--- a/metrics/mixin/alerts/alerts.libsonnet
+++ b/metrics/mixin/alerts/alerts.libsonnet
@@ -1,3 +1,4 @@
 (import 'cluster-resource-quota.libsonnet') +
 (import 'mirroring.libsonnet') +
+(import 'obc.libsonnet') +
 (import 'services.libsonnet')

--- a/metrics/mixin/alerts/obc.libsonnet
+++ b/metrics/mixin/alerts/obc.libsonnet
@@ -1,0 +1,76 @@
+
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'odf-obc-quota-alert.rules',
+        rules: [
+          {
+            alert: 'ObcQuotaBytesAlert',
+            expr: |||
+              (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_used_bytes/ocs_objectbucket_max_bytes)) > 0.80
+            ||| % $._config,
+            'for': $._config.odfObcQuotaAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'OBC has crossed 80% of the quota(bytes).',
+              description: 'ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80% of the size limit set by the quota(bytes) and will become read-only on reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource.',
+              storage_type: $._config.objectStorageType,
+              severity_level: 'warning',
+            },
+          },
+          {
+            alert: 'ObcQuotaObjectsAlert',
+            expr: |||
+              (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_objects_total/ocs_objectbucket_max_objects)) > 0.80
+            ||| % $._config,
+            'for': $._config.odfObcQuotaAlertTime,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'OBC has crossed 80% of the quota(object).',
+              description: 'ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed 80% of the size limit set by the quota(objects) and will become read-only on reaching the quota limit. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource.',
+              storage_type: $._config.objectStorageType,
+              severity_level: 'warning',
+            },
+          },
+          {
+            alert: 'ObcQuotaBytesExhausedAlert',
+            expr: |||
+              (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_used_bytes/ocs_objectbucket_max_bytes)) >= 1
+            ||| % $._config,
+            'for': $._config.odfObcQuotaCriticalAlertTime,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'OBC reached quota(bytes) limit.',
+              description: 'ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the limit set by the quota(bytes) and will be read-only now. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.',
+              storage_type: $._config.objectStorageType,
+              severity_level: 'error',
+            },
+          },
+          {
+            alert: 'ObcQuotaObjectsExhausedAlert',
+            expr: |||
+              (ocs_objectbucketclaim_info * on (namespace, objectbucket) group_left() (ocs_objectbucket_objects_total/ocs_objectbucket_max_objects)) >= 1
+            ||| % $._config,
+            'for': $._config.odfObcQuotaCriticalAlertTime,
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'OBC reached quota(object) limit.',
+              description: 'ObjectBucketClaim {{$labels.objectbucketclaim}} has crossed the limit set by the quota(objects) and will be read-only now. Increase the quota in the {{$labels.objectbucketclaim}} OBC custom resource immediately.',
+              storage_type: $._config.objectStorageType,
+              severity_level: 'error',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/metrics/mixin/config.libsonnet
+++ b/metrics/mixin/config.libsonnet
@@ -7,6 +7,8 @@
     clusterObjectStoreStateAlertTime: '15s',
     odfClusterResourceQuotaAlertTime: '0s',
     odfMirrorDaemonStatusAlertTime: '1m',
+    odfObcQuotaAlertTime: '10s',
+    odfObcQuotaCriticalAlertTime: '0s',
     odfPoolMirroringImageHealthWarningAlertTime: '1m',
     odfPoolMirroringImageHealthCriticalAlertTime: '10s',
 


### PR DESCRIPTION
This PR adds Prometheus alerts to notify the users when the OBC usage goes beyond 80%  and 100% of the limit(bytes/objects) set in the OBC definition.

Depends on: #1268 

Signed-off-by: Anmol Sachan anmol13694@gmail.com