### PR TITLE
Update csv annotation with mcg-standalone feature

### DIFF
--- a/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/bundle/manifests/ocs-operator.clusterserviceversion.yaml
@@ -1093,7 +1093,7 @@ metadata:
       "rook-csi-rbd-node", "rook-csi-rbd-provisioner"], "configMaps": ["rook-ceph-mon-endpoints",
       "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}'
     features.ocs.openshift.io/enabled: '["kms", "arbiter", "flexible-scaling", "multus",
-      "thick-provision", "pool-management", "namespace-store"]'
+      "thick-provision", "pool-management", "namespace-store", "mcg-standalone"]'
     olm.skipRange: '>=0.0.1 <4.9.0'
     operatorframework.io/initialization-resource: "\n    {\n        \"apiVersion\":
       \"ocs.openshift.io/v1\",\n        \"kind\": \"StorageCluster\",\n        \"metadata\":

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -667,7 +667,7 @@ The NooBaa operator deploys and manages the [NooBaa][2] Multi-Cloud Gateway on O
 	// Feature gating for Console. The array values are unique identifiers provided by the console.
 	// This can be used to enable/disable console support for any supported feature
 	// Example: "features.ocs.openshift.io/enabled": `["external", "foo1", "foo2", ...]`
-	ocsCSV.Annotations["features.ocs.openshift.io/enabled"] = `["kms", "arbiter", "flexible-scaling", "multus", "thick-provision", "pool-management", "namespace-store"]`
+	ocsCSV.Annotations["features.ocs.openshift.io/enabled"] = `["kms", "arbiter", "flexible-scaling", "multus", "thick-provision", "pool-management", "namespace-store", "mcg-standalone"]`
 	// Used by UI to validate user uploaded metdata
 	// Metadata is used to connect to an external cluster
 	ocsCSV.Annotations["external.features.ocs.openshift.io/validation"] = `{"secrets":["rook-ceph-operator-creds", "rook-csi-rbd-node", "rook-csi-rbd-provisioner"], "configMaps": ["rook-ceph-mon-endpoints", "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}`


### PR DESCRIPTION
Added "mcg-standalone" in the supported features l;ist of operator csv.
This is required so we can have control over the enablement of OCS features in OCP console

Implements https://issues.redhat.com/browse/RHSTOR-2129

Signed-off-by: Afreen Rahman <afrahman@redhat.com>