### PR TITLE
Fix  server listen flake forever

### DIFF
--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -501,7 +501,7 @@ func assertCephClusterKMSConfiguration(t *testing.T, kmsArgs struct {
 
 	// don't start dummy servers for invalid tests
 	if !kmsArgs.failureExpected {
-		startServerAt(kmsArgs.kmsAddress)
+		startServerAt(t, kmsArgs.kmsAddress)
 	}
 
 	var obj ocsCephCluster

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -501,11 +501,7 @@ func assertCephClusterKMSConfiguration(t *testing.T, kmsArgs struct {
 
 	// don't start dummy servers for invalid tests
 	if !kmsArgs.failureExpected {
-		errChan := startServerAt(kmsArgs.kmsAddress)
-		go func() {
-			servErr := <-errChan
-			assert.NilError(t, servErr)
-		}()
+		startServerAt(kmsArgs.kmsAddress)
 	}
 
 	var obj ocsCephCluster

--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -307,19 +307,21 @@ func TestOptionalExternalStorageClusterResources(t *testing.T) {
 	}
 
 	for _, testParam := range optionalTestParams {
-		extResources := removeNamedResourceFromArray(globalTestExternalResources, testParam.resourceToBeRemoved)
-		reconciler := createExternalClusterReconcilerFromCustomResources(t, extResources)
-		result, err := reconciler.Reconcile(context.TODO(), request)
-		assert.NoError(t, err)
-		assert.Equal(t, reconcile.Result{}, result)
-		// rest of the resources should be available
-		assertExpectedExternalResources(t, reconciler)
-		// make sure we are missing the provided resource
-		assertMissingExternalResource(t, reconciler, testParam.resourceToBeRemoved)
-		// make sure that we have expected rook ceph config value
-		assertRookCephOperatorConfigValue(t, reconciler, testParam.expectedRookCephConfigVal)
-		// make sure about the availability of 'CephObjectStore' according to the resource removed
-		assertCephObjectStore(t, reconciler, testParam.resourceToBeRemoved)
+		t.Run(testParam.label, func(t *testing.T) {
+			extResources := removeNamedResourceFromArray(globalTestExternalResources, testParam.resourceToBeRemoved)
+			reconciler := createExternalClusterReconcilerFromCustomResources(t, extResources)
+			result, err := reconciler.Reconcile(context.TODO(), request)
+			assert.NoError(t, err)
+			assert.Equal(t, reconcile.Result{}, result)
+			// rest of the resources should be available
+			assertExpectedExternalResources(t, reconciler)
+			// make sure we are missing the provided resource
+			assertMissingExternalResource(t, reconciler, testParam.resourceToBeRemoved)
+			// make sure that we have expected rook ceph config value
+			assertRookCephOperatorConfigValue(t, reconciler, testParam.expectedRookCephConfigVal)
+			// make sure about the availability of 'CephObjectStore' according to the resource removed
+			assertCephObjectStore(t, reconciler, testParam.resourceToBeRemoved)
+		})
 	}
 }
 
@@ -539,17 +541,19 @@ func TestExternalMonitoringResources(t *testing.T) {
 	}
 
 	for _, extR := range monAddedExternalResources {
-		extRArr := updateNamedResourceInArray(globalTestExternalResources, extR.ExternalResource)
+		t.Run(extR.Label, func(t *testing.T) {
+			extRArr := updateNamedResourceInArray(globalTestExternalResources, extR.ExternalResource)
 
-		reconciler := createExternalClusterReconcilerFromCustomResources(t, extRArr)
-		result, err := reconciler.Reconcile(context.TODO(), request)
-		if extR.ReconcileExpectedToFail && err != nil {
-			continue
-		}
-		if ok := assert.NoError(t, err); !ok {
-			t.Fatalf("Reconcile Error: %v", err)
-		}
-		assert.Equal(t, reconcile.Result{}, result)
-		assertExpectedExternalResources(t, reconciler)
+			reconciler := createExternalClusterReconcilerFromCustomResources(t, extRArr)
+			result, err := reconciler.Reconcile(context.TODO(), request)
+			if extR.ReconcileExpectedToFail && err != nil {
+				return
+			}
+			if ok := assert.NoError(t, err); !ok {
+				t.Fatalf("Reconcile Error: %v", err)
+			}
+			assert.Equal(t, reconcile.Result{}, result)
+			assertExpectedExternalResources(t, reconciler)
+		})
 	}
 }

--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -143,14 +143,16 @@ func createExternalClusterReconcilerFromCustomResources(
 		},
 	}
 	if extResource, err := findNamedResourceFromArray(extResources, "ceph-rgw"); err == nil {
-		startServerAt(extResource.Data["endpoint"])
+		servEndpoint := extResource.Data["endpoint"]
+		startServerAt(t, servEndpoint)
 	}
 	if extResource, err := findNamedResourceFromArray(extResources, "monitoring-endpoint"); err == nil {
 		monEndpointIP := extResource.Data["MonitoringEndpoint"]
 		monEndpointPort := extResource.Data["MonitoringPort"]
 		if monEndpointIP != "" && monEndpointPort != "" {
 			monEndpointIP = parseMonitoringIPs(monEndpointIP)[0]
-			startServerAt(net.JoinHostPort(monEndpointIP, monEndpointPort))
+			servEndpoint := net.JoinHostPort(monEndpointIP, monEndpointPort)
+			startServerAt(t, servEndpoint)
 		}
 	}
 	externalSecret, err := createExternalCephClusterSecret(extResources)
@@ -434,7 +436,7 @@ func assertReconciliationOfExternalResource(t *testing.T, reconciler StorageClus
 	// change 'rgw-endpoint'
 	rgwRsrc.Data[externalCephRgwEndpointKey] = fmt.Sprintf("localhost:%d", generateRandomPort(20000, 30000))
 	// start a dummy / local server at the endpoint
-	startServerAt(rgwRsrc.Data[externalCephRgwEndpointKey])
+	startServerAt(t, rgwRsrc.Data[externalCephRgwEndpointKey])
 	extRsrcs = updateNamedResourceInArray(extRsrcs, rgwRsrc)
 	// create and update external secret with new changes
 	extSecret, err := createExternalCephClusterSecret(extRsrcs)

--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"regexp"
 	"strconv"
 	"testing"
 	"time"
@@ -268,30 +267,6 @@ func updateNamedResourceInArray(extArr []ExternalResource, extRsrc ExternalResou
 	}
 	extArr = append(extArr, extRsrc)
 	return extArr
-}
-
-func startServerAt(endpoint string) <-chan error {
-	var doneChan = make(chan error)
-	go func(doneChan chan<- error, endpoint string) {
-		defer close(doneChan)
-		rxp := regexp.MustCompile(`^http[s]?://`)
-		// remove any http or https protocols from the endpoint string
-		endpoint = rxp.ReplaceAllString(endpoint, "")
-		ln, err := net.Listen("tcp4", endpoint)
-		if err != nil {
-			doneChan <- err
-			return
-		}
-		defer ln.Close()
-		conn, err := ln.Accept()
-		if err != nil {
-			doneChan <- err
-			return
-		}
-		defer conn.Close()
-		doneChan <- nil
-	}(doneChan, endpoint)
-	return doneChan
 }
 
 func generateRandomPort(minPort, maxPort int) int {

--- a/controllers/storagecluster/external_resources_test.go
+++ b/controllers/storagecluster/external_resources_test.go
@@ -290,11 +290,20 @@ func TestOptionalExternalStorageClusterResources(t *testing.T) {
 	}
 
 	optionalTestParams := []struct {
+		label                     string
 		resourceToBeRemoved       string
 		expectedRookCephConfigVal string
 	}{
-		{resourceToBeRemoved: "ceph-rgw", expectedRookCephConfigVal: "true"},
-		{resourceToBeRemoved: "cephfs", expectedRookCephConfigVal: "false"},
+		{
+			label:                     "RemoveRGW",
+			resourceToBeRemoved:       "ceph-rgw",
+			expectedRookCephConfigVal: "true",
+		},
+		{
+			label:                     "RemoveCephFS",
+			resourceToBeRemoved:       "cephfs",
+			expectedRookCephConfigVal: "false",
+		},
 	}
 
 	for _, testParam := range optionalTestParams {
@@ -494,7 +503,7 @@ func TestExternalMonitoringResources(t *testing.T) {
 				},
 				Name: "monitoring-endpoint",
 			},
-			Label:                   "A passing case, with valid args",
+			Label:                   "ValidEndpointAndPort",
 			ReconcileExpectedToFail: false,
 		},
 		{
@@ -505,7 +514,7 @@ func TestExternalMonitoringResources(t *testing.T) {
 				},
 				Name: "monitoring-endpoint",
 			},
-			Label:                   "Another passing case, without an explicit port, in which rook will provide a default port number",
+			Label:                   "ValidEndpointWithoutPort",
 			ReconcileExpectedToFail: false,
 		},
 		{
@@ -517,7 +526,7 @@ func TestExternalMonitoringResources(t *testing.T) {
 				},
 				Name: "monitoring-endpoint",
 			},
-			Label:                   "A failing case, which has an invalid port",
+			Label:                   "InvalidPort",
 			ReconcileExpectedToFail: true,
 		},
 	}

--- a/controllers/storagecluster/noobaa_system_reconciler_test.go
+++ b/controllers/storagecluster/noobaa_system_reconciler_test.go
@@ -453,7 +453,7 @@ func assertNoobaaKMSConfiguration(t *testing.T, kmsArgs struct {
 	reconciler.initializeImagesStatus(cr)
 	// start a dummy server, if we are not expecting any errors
 	if !kmsArgs.failureExpected {
-		startServerAt(kmsArgs.kmsAddress)
+		startServerAt(t, kmsArgs.kmsAddress)
 	}
 
 	var obj ocsCephCluster

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -1162,14 +1162,16 @@ func NewListenServer(endpoint string) (*ListenServer, error) {
 	ls.DoneChan = make(chan error)
 
 	go func(doneChan chan<- error, ln net.Listener) {
+		var err error
 		defer close(doneChan)
-		conn, err := ln.Accept()
-		if err != nil {
-			doneChan <- err
-			return
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				break
+			}
+			conn.Close()
 		}
-		defer conn.Close()
-		doneChan <- nil
+		doneChan <- err
 	}(ls.DoneChan, ls.Listener)
 
 	go func() {

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -1169,15 +1169,15 @@ func NewListenServer(endpoint string) (*ListenServer, error) {
 
 }
 
-func startServerAt(endpoint string) <-chan error {
+func startServerAt(t *testing.T, endpoint string) <-chan error {
 	ls, err := NewListenServer(endpoint)
 	if err != nil {
 		return nil
 	}
+	t.Cleanup(func() { ls.Listener.Close() })
 
 	go func(doneChan chan<- error, ln net.Listener) {
 		defer close(doneChan)
-		defer ln.Close()
 		conn, err := ln.Accept()
 		if err != nil {
 			doneChan <- err


### PR DESCRIPTION
A test flake where sometimes a test would fail due to a mock server not being present has plagued us for far too long. This PR refactors the `startServerAt()` function to properly start and stop a dummy listening server. It also updates the relevant test functions to use `t.Run()` to make sure we are not reusing mock servers between test cases.