### PR TITLE
add permissions for ocs-metrics-exporter

### DIFF
--- a/deploy/bundle/manifests/exporter-role.yaml
+++ b/deploy/bundle/manifests/exporter-role.yaml
@@ -21,3 +21,17 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+  - objectbucket.io
+  resources:
+  - objectbuckets
+  verbs:
+    - get
+    - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+    - get
+    - list

--- a/metrics/deploy/rbac.yaml
+++ b/metrics/deploy/rbac.yaml
@@ -26,6 +26,20 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+  - objectbucket.io
+  resources:
+  - objectbuckets
+  verbs:
+    - get
+    - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+    - get
+    - list
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/rbac/exporter-role.yaml
+++ b/rbac/exporter-role.yaml
@@ -21,3 +21,17 @@ rules:
     - get
     - list
     - watch
+- apiGroups:
+  - objectbucket.io
+  resources:
+  - objectbuckets
+  verbs:
+    - get
+    - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+    - get
+    - list


### PR DESCRIPTION
The ocs-metrics-exporter service misses permissions to access the
secrets and objectbuckets, hence it was not able to metrics.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>