### PR TITLE
set default secret engine for vault to kv

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -403,7 +403,7 @@ func newCephCluster(sc *ocsv1.StorageCluster, cephImage string, nodeCount int, s
 			kmsConfigMap.Data["KMS_PROVIDER"] = "vault"
 		}
 		if _, ok := kmsConfigMap.Data["VAULT_SECRET_ENGINE"]; !ok {
-			kmsConfigMap.Data["VAULT_SECRET_ENGINE"] = "transit"
+			kmsConfigMap.Data["VAULT_SECRET_ENGINE"] = "kv"
 		}
 		cephCluster.Spec.Security.KeyManagementService.ConnectionDetails = kmsConfigMap.Data
 		cephCluster.Spec.Security.KeyManagementService.TokenSecretName = KMSTokenSecretName


### PR DESCRIPTION
If there is no secret engine specified in the config map for vault configs,
by default OCS-Op was setting it to `transit` than `kv`.

Signed-off-by: Jiffin Tony Thottan <thottanjiffin@gmail.com>