### PR TITLE
Fix OBC StorageClass deletion during StorageCluster removal

### DIFF
--- a/controllers/storagecluster/uninstall_reconciler.go
+++ b/controllers/storagecluster/uninstall_reconciler.go
@@ -325,6 +325,7 @@ func (r *StorageClusterReconciler) deleteResources(sc *ocsv1.StorageCluster) (re
 		&storageClient{},
 		&storageConsumer{},
 		&ocsProviderServer{},
+		&obcStorageClasses{},
 		&ocsCephRGWRoutes{},
 		&ocsCephObjectStoreUsers{},
 		&ocsCephObjectStores{},


### PR DESCRIPTION
The OBC StorageClass `openshift-storage.noobaa.io` was not being deleted when the `StorageCluster` was removed. 
This fix updates the obcStorageClasses `ensureDeleted()` method to explicitly identify and delete StorageClasses with provisioner `openshift-storage.noobaa.io/obc`.
Also added obcStorageClasses to the list of resourceManagers for cleanup during StorageCluster uninstall.
