### PR TITLE
Set Maintenance Mode only if RDR is configured & rbd-mirror CR is absent

### DIFF
--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -359,3 +359,10 @@ func mutate(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) 
 	}
 	return nil
 }
+
+// If the storage-client-mapping configMap is present, then the cluster is configured for RDR otherwise not
+func IsClusterConfiguredForRDR(ctx context.Context, kubeClient client.Client, namespace string) bool {
+	cm := &corev1.ConfigMap{}
+	err := kubeClient.Get(ctx, types.NamespacedName{Name: StorageClientMappingConfigName, Namespace: namespace}, cm)
+	return err == nil
+}

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
@@ -359,3 +359,10 @@ func mutate(f controllerutil.MutateFn, key client.ObjectKey, obj client.Object) 
 	}
 	return nil
 }
+
+// If the storage-client-mapping configMap is present, then the cluster is configured for RDR otherwise not
+func IsClusterConfiguredForRDR(ctx context.Context, kubeClient client.Client, namespace string) bool {
+	cm := &corev1.ConfigMap{}
+	err := kubeClient.Get(ctx, types.NamespacedName{Name: StorageClientMappingConfigName, Namespace: namespace}, cm)
+	return err == nil
+}

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -968,15 +968,18 @@ func (s *OCSProviderServer) GetBlockPoolsInfo(ctx context.Context, req *pb.Block
 }
 
 func (s *OCSProviderServer) isSystemInMaintenanceMode(ctx context.Context) (bool, error) {
-	// found - false, not found - true
-	cephRBDMirrors := &rookCephv1.CephRBDMirror{}
-	cephRBDMirrors.Name = util.CephRBDMirrorName
-	cephRBDMirrors.Namespace = s.namespace
-	err := s.client.Get(ctx, client.ObjectKeyFromObject(cephRBDMirrors), cephRBDMirrors)
-	if client.IgnoreNotFound(err) != nil {
-		return false, err
+	// if cluster is configured for RDR & cephRBDMirror CR is not found, then system is in maintenance mode
+	if util.IsClusterConfiguredForRDR(ctx, s.client, s.namespace) {
+		cephRBDMirrors := &rookCephv1.CephRBDMirror{}
+		cephRBDMirrors.Name = util.CephRBDMirrorName
+		cephRBDMirrors.Namespace = s.namespace
+		err := s.client.Get(ctx, client.ObjectKeyFromObject(cephRBDMirrors), cephRBDMirrors)
+		if client.IgnoreNotFound(err) != nil {
+			return false, err
+		}
+		return kerrors.IsNotFound(err), nil
 	}
-	return kerrors.IsNotFound(err), nil
+	return false, nil
 }
 
 func (s *OCSProviderServer) isConsumerMirrorEnabled(ctx context.Context, consumer *ocsv1alpha1.StorageConsumer) (bool, error) {


### PR DESCRIPTION
Until now we were setting maintenance mode based on only the absence of the rbd-mirror CR only, due to which maintenance mode was getting set always even in non rdr cluster. To solve this we are now checking if the cluster is configured for RDR & if the rbd-mirror CR is absent.
Ref-https://issues.redhat.com/browse/DFBUGS-2315