### PR TITLE
Skip adding key rotation disable annotation to unrelated storageClasses

### DIFF
--- a/controllers/storagecluster/external_resources.go
+++ b/controllers/storagecluster/external_resources.go
@@ -392,7 +392,6 @@ func (r *StorageClusterReconciler) createExternalStorageClusterResources(instanc
 						"rook-csi-rbd-node",
 						instance.Namespace,
 						"",
-						instance.GetAnnotations()[defaults.KeyRotationEnableAnnotation] == "false",
 					),
 					isClusterExternal: true,
 				}

--- a/controllers/util/storageclasses.go
+++ b/controllers/util/storageclasses.go
@@ -219,7 +219,6 @@ func NewDefaultNonResilientRbdStorageClass(
 	nodeSecret,
 	namespace,
 	storageId string,
-	disableKeyRotation bool,
 ) *storagev1.StorageClass {
 
 	sc := &storagev1.StorageClass{
@@ -247,10 +246,6 @@ func NewDefaultNonResilientRbdStorageClass(
 			"csi.storage.k8s.io/node-stage-secret-namespace":        namespace,
 			"csi.storage.k8s.io/controller-expand-secret-namespace": namespace,
 		},
-	}
-
-	if disableKeyRotation {
-		AddAnnotation(sc, defaults.KeyRotationEnableAnnotation, "false")
 	}
 	if storageId != "" {
 		AddLabel(sc, storageIdLabelKey, storageId)

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageclasses.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/storageclasses.go
@@ -219,7 +219,6 @@ func NewDefaultNonResilientRbdStorageClass(
 	nodeSecret,
 	namespace,
 	storageId string,
-	disableKeyRotation bool,
 ) *storagev1.StorageClass {
 
 	sc := &storagev1.StorageClass{
@@ -247,10 +246,6 @@ func NewDefaultNonResilientRbdStorageClass(
 			"csi.storage.k8s.io/node-stage-secret-namespace":        namespace,
 			"csi.storage.k8s.io/controller-expand-secret-namespace": namespace,
 		},
-	}
-
-	if disableKeyRotation {
-		AddAnnotation(sc, defaults.KeyRotationEnableAnnotation, "false")
 	}
 	if storageId != "" {
 		AddLabel(sc, storageIdLabelKey, storageId)

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -1433,7 +1433,6 @@ func (s *OCSProviderServer) appendStorageClassKubeResources(
 				consumerConfig.GetCsiRbdNodeCephUserName(),
 				consumer.Status.Client.OperatorNamespace,
 				rbdStorageId,
-				storageCluster.GetAnnotations()[defaults.KeyRotationEnableAnnotation] == "false",
 			)
 		}
 	}


### PR DESCRIPTION
The disable key rotation annotation only makes sense for encryption rbd storage classes. So the other storage classes should not be having this annotation.

Ref-https://issues.redhat.com/browse/DFBUGS-2630