### PR TITLE
Verify if the sub channel is valid with the package manifest

### DIFF
--- a/deploy/ocs-operator/manifests/provider-role.yaml
+++ b/deploy/ocs-operator/manifests/provider-role.yaml
@@ -67,6 +67,12 @@ rules:
       - get
       - list
   - apiGroups:
+      - packages.operators.coreos.com
+    resources:
+      - packagemanifests
+    verbs:
+      - get
+  - apiGroups:
       - ocs.openshift.io
     resources:
       - storageclusters

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -67,6 +67,12 @@ rules:
       - get
       - list
   - apiGroups:
+      - packages.operators.coreos.com
+    resources:
+      - packagemanifests
+    verbs:
+      - get
+  - apiGroups:
       - ocs.openshift.io
     resources:
       - storageclusters

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -16,6 +16,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
@@ -49,7 +50,9 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	klog "k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -72,6 +75,12 @@ const (
 	volumeReplicationClass5mSchedule = "5m"
 	mirroringTokenKey                = "rbdMirrorBootstrapPeerSecretName"
 	clientInfoRbdClientProfileKey    = "csiop-rbd-client-profile"
+)
+
+var (
+	knownOcsInstalledCsvName        string
+	knownOcsSubscriptionChannelName string
+	ocsSubChannelAndCsvMutex        sync.Mutex
 )
 
 type OCSProviderServer struct {
@@ -694,21 +703,86 @@ func (s *OCSProviderServer) getOCSSubscriptionChannel(ctx context.Context) (stri
 		klog.Info("unable to find ocs-operator subscription")
 		return "", nil
 	}
-	if subscription.Status.InstalledCSV == "" {
-		klog.Infof("Subscription %q does not have an installed CSV", subscription.Name)
-		return "", nil
+
+	ocsSubChannelAndCsvMutex.Lock()
+	defer ocsSubChannelAndCsvMutex.Unlock()
+
+	// If the installed CSV has changed then validate the current channel otherwise return the known valid channel
+	if subscription.Status.InstalledCSV != knownOcsInstalledCsvName {
+		ok, err := s.isSubscriptionChannelValid(ctx, subscription)
+		if err != nil || !ok {
+			return "", err
+		}
+		knownOcsInstalledCsvName = subscription.Status.InstalledCSV
+		knownOcsSubscriptionChannelName = subscription.Spec.Channel
+	}
+
+	return knownOcsSubscriptionChannelName, nil
+}
+
+func (s *OCSProviderServer) isSubscriptionChannelValid(ctx context.Context, subscription *opv1a1.Subscription) (bool, error) {
+	installedCSVName := subscription.Status.InstalledCSV
+	channelName := subscription.Spec.Channel
+
+	// Check if the installed CSV of the subscription is in Succeeded phase
+	if installedCSVName == "" {
+		klog.Infof("subscription %q does not have an installed CSV", subscription.Name)
+		return false, nil
 	}
 	csv := &opv1a1.ClusterServiceVersion{}
-	err = s.client.Get(ctx, client.ObjectKey{Name: subscription.Status.InstalledCSV, Namespace: s.namespace}, csv)
+	err := s.client.Get(ctx, client.ObjectKey{Name: installedCSVName, Namespace: s.namespace}, csv)
 	if err != nil {
-		klog.Errorf("failed to get installed CSV %q: %v", subscription.Status.InstalledCSV, err)
-		return "", err
+		klog.Errorf("failed to get installed CSV %q: %v", installedCSVName, err)
+		return false, err
 	}
 	if csv.Status.Phase != opv1a1.CSVPhaseSucceeded {
 		klog.Infof("installed CSV %q is in phase %q, not Succeeded", csv.Name, csv.Status.Phase)
-		return "", nil
+		return false, nil
 	}
-	return subscription.Spec.Channel, nil
+
+	// Check if the installed CSV is the expected one for the channel from the package manifest
+	packageManifest := &unstructured.Unstructured{}
+	packageManifest.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "packages.operators.coreos.com",
+		Version: "v1",
+		Kind:    "PackageManifest",
+	})
+	err = s.client.Get(ctx, client.ObjectKey{Name: subscription.Spec.Package, Namespace: s.namespace}, packageManifest)
+	if err != nil {
+		klog.Errorf("failed to get PackageManifest %q: %v", subscription.Spec.Package, err)
+		return false, err
+	}
+	channels, found, err := unstructured.NestedSlice(packageManifest.Object, "status", "channels")
+	if err != nil {
+		klog.Errorf("error getting channels from PackageManifest %q: %v", packageManifest.GetName(), err)
+		return false, err
+	}
+	if !found {
+		klog.Infof("channels not found in PackageManifest %q", packageManifest.GetName())
+		return false, nil
+	}
+	var expectedCSVName string
+	for _, ch := range channels {
+		chMap, ok := ch.(map[string]any)
+		if !ok {
+			continue
+		}
+		if chMap["name"].(string) == channelName {
+			expectedCSVName, ok = chMap["currentCSV"].(string)
+			if !ok {
+				klog.Infof("currentCSV not found or invalid in channel %s", channelName)
+				return false, nil
+			}
+			break
+		}
+	}
+	if installedCSVName != expectedCSVName {
+		klog.Infof("installed CSV %q does not match expected %q", installedCSVName, expectedCSVName)
+		return false, nil
+	}
+
+	klog.Infof("subscription for %q with channel %q is valid with installed CSV %q", subscription.Spec.Package, channelName, installedCSVName)
+	return true, nil
 }
 
 func isEncryptionInTransitEnabled(networkSpec *rookCephv1.NetworkSpec) bool {


### PR DESCRIPTION
To solve the upgrade deadlock issue due to early sending of sub channel we earlier introduced a check to verify if the sub installedCSV has succeeded. But there is a brief window where the sub channel has been updated but the sub installedCSV is not yet updated. In that window our check will pass and we will send the new channel even though the upgrade has not yet succeeded.

This commit adds a check to verify if the sub installedCSV is the expected one by matching it with the csv name from the package manifest's channel list. This helps us to avoid the earlier race condition. We are using the unstructured object to get the package manifest to avoid the added dependencies the import would bring.