### PR TITLE
controllers: update the correct values for ConsumerConfigMap

### DIFF
--- a/controllers/storagecluster/storageconsumer.go
+++ b/controllers/storagecluster/storageconsumer.go
@@ -101,6 +101,9 @@ func (s *storageConsumer) ensureCreated(r *StorageClusterReconciler, storageClus
 	consumerConfigMap.Name = localStorageConsumerConfigMapName
 	consumerConfigMap.Namespace = storageCluster.Namespace
 	if _, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, consumerConfigMap, func() error {
+		if err := controllerutil.SetControllerReference(storageCluster, consumerConfigMap, r.Scheme); err != nil {
+			return err
+		}
 		data := util.GetStorageConsumerDefaultResourceNames(
 			defaults.LocalStorageConsumerName,
 			string(storageConsumer.UID),


### PR DESCRIPTION
This PR prevents `storageconsumer_controller` from setting default values in `consumerConfigMap` for `cephfs-subvolumegroup`, to avoid inconsistent CR creation.

Resolves: [DFBUGS-2765](https://issues.redhat.com/browse/DFBUGS-2765)