### PR TITLE
provider: donot send the topology resposne if replica-1 is disabled

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -396,8 +396,10 @@ func (s *OCSProviderServer) GetDesiredClientState(ctx context.Context, req *pb.G
 		}
 
 		topologyKey := consumer.GetAnnotations()[util.AnnotationNonResilientPoolsTopologyKey]
-		response.RbdDriverRequirements = &pb.RbdDriverRequirements{
-			TopologyDomainLables: []string{topologyKey},
+		if topologyKey != "" {
+			response.RbdDriverRequirements = &pb.RbdDriverRequirements{
+				TopologyDomainLables: []string{topologyKey},
+			}
 		}
 
 		desiredClientConfigHash := getDesiredClientConfigHash(


### PR DESCRIPTION
if the topology is empty we were still sending the response, and by this the client is treating the empty value as of slice length 1.
By which we were adding a empty annotation in the storageclient