### PR TITLE
Fix the check for provider not upgradable check

### DIFF
--- a/controllers/storagecluster/reconcile.go
+++ b/controllers/storagecluster/reconcile.go
@@ -950,7 +950,7 @@ func getUnsupportedClientsCount(r *StorageClusterReconciler, namespace string) (
 		if scList.Items[idx].Status.Client != nil {
 			clientVersion, err := semver.Make(scList.Items[idx].Status.Client.OperatorVersion)
 			if err == nil {
-				if providerVersion.Major != clientVersion.Major || providerVersion.Minor <= clientVersion.Minor {
+				if providerVersion.Major != clientVersion.Major || providerVersion.Minor > clientVersion.Minor {
 					count++
 				}
 			} else {


### PR DESCRIPTION
We want to not block provider upgrade when the client is by anyway ahead of the provider. But our earlier fix broke the check as even provider & client on the same version are now not upgradable. Now to simplify the logic we do a negation of the allowed conditions (provider should be equal to or less than client) for deciding if the provider is not upgradable.