### PR TITLE
Check Replica-1 volumeClaimTemplate & Resources spec is not empty before applying it

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -994,7 +994,8 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster) []rookCephv1.StorageCla
 			} else {
 				ds.Count = sc.Spec.ManagedResources.CephNonResilientPools.Count
 			}
-			if sc.Spec.ManagedResources.CephNonResilientPools.Resources != nil {
+			if sc.Spec.ManagedResources.CephNonResilientPools.Resources != nil &&
+				!reflect.DeepEqual(*sc.Spec.ManagedResources.CephNonResilientPools.Resources, corev1.ResourceRequirements{}) {
 				ds.Resources = *sc.Spec.ManagedResources.CephNonResilientPools.Resources
 			} else {
 				ds.Resources = defaults.GetProfileDaemonResources("osd", sc)
@@ -1005,7 +1006,8 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster) []rookCephv1.StorageCla
 			annotations := map[string]string{
 				"crushDeviceClass": failureDomainValue,
 			}
-			if sc.Spec.ManagedResources.CephNonResilientPools.VolumeClaimTemplate != nil {
+			if sc.Spec.ManagedResources.CephNonResilientPools.VolumeClaimTemplate != nil &&
+				!reflect.DeepEqual(*sc.Spec.ManagedResources.CephNonResilientPools.VolumeClaimTemplate, corev1.PersistentVolumeClaim{}) {
 				ds.VolumeClaimTemplates = []rookCephv1.VolumeClaimTemplate{{
 					ObjectMeta: sc.Spec.ManagedResources.CephNonResilientPools.VolumeClaimTemplate.ObjectMeta,
 					Spec:       sc.Spec.ManagedResources.CephNonResilientPools.VolumeClaimTemplate.Spec,


### PR DESCRIPTION
From 4.18 to 4.19 There was a API change which converted the sc.Spec.managedResources.cephNonResilientPools.VolumeClaimTemplate & sc.Spec.ManagedResources.CephNonResilientPools.Resources fields from a struct to a pointer to struct. Accordingly the code was modified. But when someone upgrades from 4.18 to 4.19 the empty struct created
during 4.18 stays. Which negates the nil check being done on 4.19. So operator believes there is some spec given to it & applies it while in reality it's an empty struct. To fix this along with a nil check we need to do a not empty check before applying the values.