### PR TITLE
Update, Organize & Improve the README

### DIFF
--- a/deploy/storagecluster.yaml
+++ b/deploy/storagecluster.yaml
@@ -1,0 +1,20 @@
+apiVersion: ocs.openshift.io/v1
+kind: StorageCluster
+metadata:
+  name: ocs-storagecluster
+  namespace: openshift-storage
+spec:
+  storageDeviceSets:
+    - name: gp3-csi
+      dataPVCTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: "256Gi"
+          storageClassName: gp3-csi
+          volumeMode: Block
+      count: 1
+      replica: 3
+      portable: true


### PR DESCRIPTION
Changed the structure of the README to make it more organized Removed unnecessary sections and texts
The installation section now refers to only the make install command and no longer mentions catalog based installation
Added a section on how to access the live PROW CI cluster