### PR TITLE
mirroring: disable mirroring when secondary cluster is down

### DIFF
--- a/internal/controller/mirroring/mirroring_controller.go
+++ b/internal/controller/mirroring/mirroring_controller.go
@@ -21,17 +21,16 @@ import (
 	"reflect"
 	"slices"
 	"strconv"
-	"time"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
+	pb "github.com/red-hat-storage/ocs-operator/services/provider/api/v4"
 	providerClient "github.com/red-hat-storage/ocs-operator/services/provider/api/v4/client"
+	storageclusterctrl "github.com/red-hat-storage/ocs-operator/v4/internal/controller/storagecluster"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 
 	"github.com/go-logr/logr"
-	storageclusterctrl "github.com/red-hat-storage/ocs-operator/v4/internal/controller/storagecluster"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,7 +50,7 @@ import (
 
 const (
 	mirroringFinalizer              = "ocs.openshift.io/mirroring"
-	clientIDIndexName               = "clientID"
+	clientIDIndexName               = "index:clientID"
 	storageClusterPeerAnnotationKey = "ocs.openshift.io/storage-cluster-peer"
 )
 
@@ -92,7 +91,6 @@ func (r *MirroringReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("failed to set up FieldIndexer on StorageConsumer for clientID: %v", err)
 	}
 
-	// Reconcile the OperatorConfigMap object when the cluster's version object is updated
 	enqueueConfigMapRequest := handler.EnqueueRequestsFromMapFunc(
 		func(_ context.Context, obj client.Object) []reconcile.Request {
 			return []reconcile.Request{{
@@ -125,6 +123,16 @@ func (r *MirroringReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 	generationChangePredicate := builder.WithPredicates(predicate.GenerationChangedPredicate{})
+	storageClusterPeerStatusPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			oldObj := e.ObjectOld.(*ocsv1.StorageClusterPeer)
+			newObj := e.ObjectNew.(*ocsv1.StorageClusterPeer)
+			return !reflect.DeepEqual(oldObj.Status, newObj.Status)
+		},
+	}
 
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("MirroringController").
@@ -139,7 +147,10 @@ func (r *MirroringReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(
 			&ocsv1.StorageClusterPeer{},
 			enqueueConfigMapRequest,
-			generationChangePredicate,
+			builder.WithPredicates(
+				predicate.GenerationChangedPredicate{},
+				storageClusterPeerStatusPredicate,
+			),
 		).
 		Watches(
 			&ocsv1alpha1.StorageConsumer{},
@@ -214,9 +225,33 @@ func (r *MirroringReconciler) reconcilePhases(clientMappingConfig *corev1.Config
 		return ctrl.Result{}, err
 	}
 
-	shouldMirror := clientMappingConfig.DeletionTimestamp.IsZero() &&
-		clientMappingConfig.Data != nil &&
-		len(clientMappingConfig.Data) > 0
+	storageConsumerList := &ocsv1alpha1.StorageConsumerList{}
+	if err := r.list(storageConsumerList, client.InNamespace(clientMappingConfig.Namespace)); err != nil {
+		r.log.Error(err, "Failed to list StorageConsumers")
+		return ctrl.Result{}, err
+	}
+
+	remoteClientIds := []string{}
+	storageConsumerByName := map[string]*ocsv1alpha1.StorageConsumer{}
+	for i := range storageConsumerList.Items {
+		consumer := &storageConsumerList.Items[i]
+		storageConsumerByName[consumer.Name] = consumer
+		if cl := consumer.Status.Client; cl != nil && clientMappingConfig.Data[cl.ID] != "" {
+			remoteClientIds = append(remoteClientIds, clientMappingConfig.Data[cl.ID])
+		}
+	}
+
+	cephBlockPoolsList := &rookCephv1.CephBlockPoolList{}
+	if err := r.list(cephBlockPoolsList, client.InNamespace(clientMappingConfig.Namespace)); err != nil {
+		r.log.Error(err, "Failed to list CephBlockPools")
+		return ctrl.Result{}, err
+	}
+
+	remoteClientInfoById := map[string]*pb.ClientInfo{}
+	remoteBlockPoolInfoByName := map[string]*pb.BlockPoolInfo{}
+	errorOccurred := false
+
+	shouldMirror := clientMappingConfig.DeletionTimestamp.IsZero() && len(clientMappingConfig.Data) > 0
 
 	if shouldMirror {
 		if controllerutil.AddFinalizer(clientMappingConfig, mirroringFinalizer) {
@@ -231,48 +266,43 @@ func (r *MirroringReconciler) reconcilePhases(clientMappingConfig *corev1.Config
 				return ctrl.Result{}, fmt.Errorf("failed to update StorageClusterPeer: %v", err)
 			}
 		}
-	}
 
-	if storageClusterPeer.Status.State != ocsv1.StorageClusterPeerStatePeered ||
-		storageClusterPeer.Status.PeerInfo == nil ||
-		storageClusterPeer.Status.PeerInfo.StorageClusterUid == "" {
-		r.log.Info(
-			"waiting for StorageClusterPeer to be in Peered state",
-			"StorageClusterPeer",
-			storageClusterPeer.Name,
-		)
-		return ctrl.Result{RequeueAfter: 3 * time.Second}, nil
-	}
+		if storageClusterPeer.Status.State != ocsv1.StorageClusterPeerStatePeered ||
+			storageClusterPeer.Status.PeerInfo == nil ||
+			storageClusterPeer.Status.PeerInfo.StorageClusterUid == "" {
+			return ctrl.Result{}, fmt.Errorf("waiting for StorageClusterPeer %s to be in Peered state", storageClusterPeer.Name)
+		}
 
-	errorOccurred := false
+		ocsClient, err := providerClient.NewProviderClient(r.ctx, storageClusterPeer.Spec.ApiEndpoint, util.OcsClientTimeout)
+		if err != nil {
+			r.log.Error(err, "failed to create a new provider client")
+			return ctrl.Result{}, fmt.Errorf("failed to reconcile StorageClientMapping")
+		}
 
-	ocsClient, err := providerClient.NewProviderClient(r.ctx, storageClusterPeer.Spec.ApiEndpoint, util.OcsClientTimeout)
-	if err != nil {
-		r.log.Error(err, "failed to create a new provider client")
-		errorOccurred = true
-	} else if ocsClient != nil {
 		defer ocsClient.Close()
+
+		if errored := r.getBlockPoolsInfo(ocsClient, storageClusterPeer, cephBlockPoolsList, remoteBlockPoolInfoByName); errored {
+			errorOccurred = true
+		}
+
+		if errored := r.getStorageClientsInfo(ocsClient, storageClusterPeer, remoteClientIds, remoteClientInfoById); errored {
+			errorOccurred = true
+		}
 	}
 
 	if errored := r.reconcileRbdMirror(clientMappingConfig, shouldMirror); errored {
 		errorOccurred = true
 	}
 
-	if errored := r.reconcileBlockPoolMirroring(
-		ocsClient,
-		clientMappingConfig,
-		storageClusterPeer,
-		shouldMirror,
-	); errored {
+	if errored := r.reconcileBlockPoolMirroring(clientMappingConfig, cephBlockPoolsList, remoteBlockPoolInfoByName); errored {
 		errorOccurred = true
 	}
 
-	if errored := r.reconcileRadosNamespaceMirroring(
-		ocsClient,
-		clientMappingConfig,
-		storageClusterPeer,
-		shouldMirror,
-	); errored {
+	if errored := r.reconcileRadosNamespaceMirroring(clientMappingConfig, storageConsumerByName, remoteClientInfoById); errored {
+		errorOccurred = true
+	}
+
+	if errored := r.reconcileStorageConsumer(storageConsumerList, clientMappingConfig, remoteClientInfoById); errored {
 		errorOccurred = true
 	}
 
@@ -280,14 +310,14 @@ func (r *MirroringReconciler) reconcilePhases(clientMappingConfig *corev1.Config
 		if controllerutil.RemoveFinalizer(storageClusterPeer, mirroringFinalizer) {
 			r.log.Info("removing finalizer from StorageClusterPeer.")
 			if err := r.update(storageClusterPeer); err != nil {
-				r.log.Info("Failed to remove finalizer from StorageClusterPeer")
+				r.log.Error(err, "Failed to remove finalizer from StorageClusterPeer")
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from StorageClusterPeer: %v", err)
 			}
 		}
 		if controllerutil.RemoveFinalizer(clientMappingConfig, mirroringFinalizer) {
 			r.log.Info("removing finalizer from ConfigMap.")
 			if err := r.update(clientMappingConfig); err != nil {
-				r.log.Info("Failed to remove finalizer from ConfigMap")
+				r.log.Error(err, "Failed to remove finalizer from ConfigMap")
 				return ctrl.Result{}, fmt.Errorf("failed to remove finalizer from ConfigMap: %v", err)
 			}
 		}
@@ -298,6 +328,94 @@ func (r *MirroringReconciler) reconcilePhases(clientMappingConfig *corev1.Config
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (r *MirroringReconciler) getBlockPoolsInfo(
+	ocsClient *providerClient.OCSProviderClient,
+	storageClusterPeer *ocsv1.StorageClusterPeer,
+	cephBlockPoolsList *rookCephv1.CephBlockPoolList,
+	remoteBlockPoolInfoByName map[string]*pb.BlockPoolInfo,
+) bool {
+	blockPoolNames := []string{}
+	errorOccured := false
+	for i := range cephBlockPoolsList.Items {
+		cephBlockPool := &cephBlockPoolsList.Items[i]
+		labels := cephBlockPool.GetLabels()
+		forInternalUseOnly, _ := strconv.ParseBool(labels[util.ForInternalUseOnlyLabelKey])
+		forbidMirroring, _ := strconv.ParseBool(labels[util.ForbidMirroringLabel])
+		erasureCodedPool := !reflect.DeepEqual(cephBlockPool.Spec.ErasureCoded, rookCephv1.ErasureCodedSpec{})
+		if forInternalUseOnly || forbidMirroring || erasureCodedPool {
+			continue
+		}
+		blockPoolNames = append(blockPoolNames, cephBlockPool.Name)
+	}
+	// fetch BlockPoolsInfo
+	response, err := ocsClient.GetBlockPoolsInfo(
+		r.ctx,
+		storageClusterPeer.Status.PeerInfo.StorageClusterUid,
+		blockPoolNames,
+	)
+	if err != nil {
+		r.log.Error(err, "failed to get CephBlockPool(s) info from Peer")
+		return true
+	}
+
+	if response.Errors != nil {
+		for i := range response.Errors {
+			resp := response.Errors[i]
+			r.log.Error(
+				errors.New(resp.Message),
+				"failed to get BlockPoolsInfo",
+				"CephBlockPool",
+				resp.BlockPoolName,
+			)
+		}
+		errorOccured = true
+	}
+
+	for i := range response.BlockPoolsInfo {
+		remoteBlockPoolInfo := response.BlockPoolsInfo[i]
+		remoteBlockPoolInfoByName[remoteBlockPoolInfo.BlockPoolName] = remoteBlockPoolInfo
+	}
+
+	return errorOccured
+}
+
+func (r *MirroringReconciler) getStorageClientsInfo(
+	ocsClient *providerClient.OCSProviderClient,
+	storageClusterPeer *ocsv1.StorageClusterPeer,
+	remoteClientIds []string,
+	remoteClientIdByClientInfo map[string]*pb.ClientInfo,
+) bool {
+	errorOccured := false
+	response, err := ocsClient.GetStorageClientsInfo(
+		r.ctx,
+		storageClusterPeer.Status.PeerInfo.StorageClusterUid,
+		remoteClientIds,
+	)
+	if err != nil {
+		r.log.Error(err, "failed to get StorageClient(s) info from Peer")
+		return true
+	}
+
+	if response.Errors != nil {
+		for i := range response.Errors {
+			resp := response.Errors[i]
+			r.log.Error(
+				errors.New(resp.Message),
+				"failed to get StorageClientsInfo",
+				"StorageClient",
+				resp.ClientID,
+			)
+		}
+		errorOccured = true
+	}
+
+	for i := range response.ClientsInfo {
+		remoteClientIdByClientInfo[response.ClientsInfo[i].ClientID] = response.ClientsInfo[i]
+	}
+
+	return errorOccured
 }
 
 func (r *MirroringReconciler) reconcileRbdMirror(clientMappingConfig *corev1.ConfigMap, shouldMirror bool) bool {
@@ -313,11 +431,9 @@ func (r *MirroringReconciler) reconcileRbdMirror(clientMappingConfig *corev1.Con
 	} else if len(rbdMirrorList.Items) == 2 {
 		r.log.Error(fmt.Errorf("multiple RBDMirror present in the cluster"), "more than 1 CephRBDMirror present in the cluster")
 		return true
-	} else if len(rbdMirrorList.Items) == 1 {
-		if rbdMirrorList.Items[0].Name != util.CephRBDMirrorName {
-			r.log.Error(fmt.Errorf("RBDMirror name mismatch"), "RBDMirror with a different name is present in the cluster")
-			return true
-		}
+	} else if len(rbdMirrorList.Items) == 1 && rbdMirrorList.Items[0].Name != util.CephRBDMirrorName {
+		r.log.Error(fmt.Errorf("RBDMirror name mismatch"), "RBDMirror with a different name is present in the cluster")
+		return true
 	}
 
 	rbdMirror := &rookCephv1.CephRBDMirror{}
@@ -383,145 +499,76 @@ func (r *MirroringReconciler) reconcileRbdMirror(clientMappingConfig *corev1.Con
 }
 
 func (r *MirroringReconciler) reconcileBlockPoolMirroring(
-	ocsClient *providerClient.OCSProviderClient,
 	clientMappingConfig *corev1.ConfigMap,
-	storageClusterPeer *ocsv1.StorageClusterPeer,
-	shouldMirror bool,
+	cephBlockPoolsList *rookCephv1.CephBlockPoolList,
+	remoteBlockPoolInfoByName map[string]*pb.BlockPoolInfo,
 ) bool {
 	errorOccurred := false
 
-	cephBlockPoolsList := &rookCephv1.CephBlockPoolList{}
-	if err := r.list(
-		cephBlockPoolsList,
-		client.InNamespace(clientMappingConfig.Namespace),
-	); err != nil {
-		r.log.Error(err, "failed to list cephBlockPools")
-		return true
-	}
-
-	blockPoolByName := map[string]*rookCephv1.CephBlockPool{}
 	for i := range cephBlockPoolsList.Items {
 		cephBlockPool := &cephBlockPoolsList.Items[i]
+
 		labels := cephBlockPool.GetLabels()
 		forInternalUseOnly, _ := strconv.ParseBool(labels[util.ForInternalUseOnlyLabelKey])
 		forbidMirroring, _ := strconv.ParseBool(labels[util.ForbidMirroringLabel])
 		erasureCodedPool := !reflect.DeepEqual(cephBlockPool.Spec.ErasureCoded, rookCephv1.ErasureCodedSpec{})
-		if forInternalUseOnly || forbidMirroring || erasureCodedPool {
-			continue
-		}
-		blockPoolByName[cephBlockPool.Name] = cephBlockPool
-	}
+		blockPoolInfo := remoteBlockPoolInfoByName[cephBlockPool.Name]
 
-	if len(blockPoolByName) > 0 && ocsClient != nil {
-		// fetch BlockPoolsInfo
-		response, err := ocsClient.GetBlockPoolsInfo(
-			r.ctx,
-			storageClusterPeer.Status.PeerInfo.StorageClusterUid,
-			maps.Keys(blockPoolByName),
-		)
-		if err != nil {
-			r.log.Error(err, "failed to get CephBlockPool(s) info from Peer")
-			return true
-		}
-
-		if response.Errors != nil {
-			for i := range response.Errors {
-				resp := response.Errors[i]
-				r.log.Error(
-					errors.New(resp.Message),
-					"failed to get BlockPoolsInfo",
-					"CephBlockPool",
-					resp.BlockPoolName,
-				)
-			}
-			errorOccurred = true
-		}
-
-		if shouldMirror {
-			for i := range response.BlockPoolsInfo {
-				blockPoolName := response.BlockPoolsInfo[i].BlockPoolName
-				cephBlockPool := blockPoolByName[blockPoolName]
-
-				mirroringToken := response.BlockPoolsInfo[i].MirroringToken
-				secretName := GetMirroringSecretName(blockPoolName)
-				if mirroringToken != "" {
-					mirroringSecret := &corev1.Secret{}
-					mirroringSecret.Name = secretName
-					mirroringSecret.Namespace = clientMappingConfig.Namespace
-					_, err = ctrl.CreateOrUpdate(r.ctx, r.Client, mirroringSecret, func() error {
-						if err = r.own(clientMappingConfig, mirroringSecret); err != nil {
-							return err
-						}
-						mirroringSecret.Data = map[string][]byte{
-							"pool":  []byte(blockPoolName),
-							"token": []byte(mirroringToken),
-						}
-						return nil
-					})
-					if err != nil {
-						r.log.Error(err, "failed to create/update mirroring secret", "Secret", secretName)
-						errorOccurred = true
-						continue
-					}
-				} else {
-					// Mirroring Token is generated only after mirroring is enabled. If both sides reconcile at the
-					// same time the mirroring token won't be fetched. Hence, re-queuing to avoid this
-					r.log.Error(
-						fmt.Errorf("peer's CephBlockPool mirroring token is not generated"),
-						"Re-queuing as peer's CephBlockPool mirroring token is not generated",
-					)
-					errorOccurred = true
-				}
-
-				// We need to enable mirroring for the blockPool, else the mirroring secret will not be generated
-				_, err = controllerutil.CreateOrUpdate(r.ctx, r.Client, cephBlockPool, func() error {
-					util.AddAnnotation(
-						cephBlockPool,
-						util.BlockPoolMirroringTargetIDAnnotation,
-						response.BlockPoolsInfo[i].BlockPoolID,
-					)
-
-					cephBlockPool.Spec.Mirroring.Enabled = true
-					cephBlockPool.Spec.Mirroring.Mode = "init-only"
-					if mirroringToken != "" {
-						if cephBlockPool.Spec.Mirroring.Peers == nil {
-							cephBlockPool.Spec.Mirroring.Peers = &rookCephv1.MirroringPeerSpec{SecretNames: []string{}}
-						}
-						if !slices.Contains(cephBlockPool.Spec.Mirroring.Peers.SecretNames, secretName) {
-							cephBlockPool.Spec.Mirroring.Peers.SecretNames = append(
-								cephBlockPool.Spec.Mirroring.Peers.SecretNames, secretName)
-						}
-					}
-					return nil
-				})
-				if err != nil {
-					r.log.Error(
-						err,
-						"failed to update CephBlockPool for mirroring",
-						"CephBlockPool",
-						cephBlockPool.Name,
-					)
-					errorOccurred = true
-				}
-			}
+		if blockPoolInfo == nil || forbidMirroring || forInternalUseOnly || erasureCodedPool {
+			delete(cephBlockPool.GetLabels(), util.BlockPoolMirroringTargetIDAnnotation)
+			cephBlockPool.Spec.Mirroring = rookCephv1.MirroringSpec{}
 		} else {
-			for i := range response.BlockPoolsInfo {
-				blockPoolName := response.BlockPoolsInfo[i].BlockPoolName
-				cephBlockPool := blockPoolByName[blockPoolName]
-				_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, cephBlockPool, func() error {
-					cephBlockPool.Spec.Mirroring = rookCephv1.MirroringSpec{}
+			util.AddAnnotation(cephBlockPool, util.BlockPoolMirroringTargetIDAnnotation, blockPoolInfo.BlockPoolID)
+			cephBlockPool.Spec.Mirroring.Enabled = true
+			cephBlockPool.Spec.Mirroring.Mode = "init-only"
+
+			if blockPoolInfo.MirroringToken != "" {
+				mirroringSecret := &corev1.Secret{}
+				secretName := GetMirroringSecretName(cephBlockPool.Name)
+				mirroringSecret.Name = secretName
+				mirroringSecret.Namespace = clientMappingConfig.Namespace
+				_, err := ctrl.CreateOrUpdate(r.ctx, r.Client, mirroringSecret, func() error {
+					if err := r.own(clientMappingConfig, mirroringSecret); err != nil {
+						return err
+					}
+					mirroringSecret.Data = map[string][]byte{
+						"pool":  []byte(cephBlockPool.Name),
+						"token": []byte(blockPoolInfo.MirroringToken),
+					}
 					return nil
 				})
 				if err != nil {
-					r.log.Error(
-						err,
-						"failed to disable mirroring for CephBlockPool",
-						"CephBlockPool",
-						cephBlockPool.Name,
-					)
+					r.log.Error(err, "failed to create/update mirroring secret", "Secret", secretName)
 					errorOccurred = true
+					continue
 				}
+
+				if cephBlockPool.Spec.Mirroring.Peers == nil {
+					cephBlockPool.Spec.Mirroring.Peers = &rookCephv1.MirroringPeerSpec{SecretNames: []string{}}
+				}
+				if !slices.Contains(cephBlockPool.Spec.Mirroring.Peers.SecretNames, secretName) {
+					cephBlockPool.Spec.Mirroring.Peers.SecretNames = append(
+						cephBlockPool.Spec.Mirroring.Peers.SecretNames, secretName)
+				}
+			} else {
+				// Mirroring Token is generated only after mirroring is enabled. If both sides reconcile at the
+				// same time the mirroring token won't be fetched. Hence, re-queuing to avoid this
+				r.log.Error(
+					fmt.Errorf("peer's CephBlockPool mirroring token is not generated"),
+					"Re-queuing as peer's CephBlockPool mirroring token is not generated",
+				)
+				errorOccurred = true
 			}
+		}
+
+		if err := r.update(cephBlockPool); err != nil {
+			r.log.Error(
+				err,
+				"failed to update CephBlockPool for mirroring",
+				"CephBlockPool",
+				cephBlockPool.Name,
+			)
+			errorOccurred = true
 		}
 	}
 
@@ -529,126 +576,98 @@ func (r *MirroringReconciler) reconcileBlockPoolMirroring(
 }
 
 func (r *MirroringReconciler) reconcileRadosNamespaceMirroring(
-	ocsClient *providerClient.OCSProviderClient,
 	clientMappingConfig *corev1.ConfigMap,
-	storageClusterPeer *ocsv1.StorageClusterPeer,
-	shouldMirror bool,
+	storageConsumerByName map[string]*ocsv1alpha1.StorageConsumer,
+	remoteClientInfoById map[string]*pb.ClientInfo,
 ) bool {
-	/*
-		Algorithm:
-		make a list of peerClientIDs
-		send GetStorageClientsInfo with this Info
-		make a map of remoteNamespaceByClientID from response
-		list all radosNamespace and for each,
-			find out which consumer does it belong to
-			find the localClientID and use map to get radosnamespce
-			if radosnamespace is empty, disable mirroring
-			else enable mirroring
-	*/
 	errorOccurred := false
 
-	storageConsumerByName := map[string]*ocsv1alpha1.StorageConsumer{}
-	storageConsumerByRemoteClientID := map[string]*ocsv1alpha1.StorageConsumer{}
-
-	storageConsumerList := &ocsv1alpha1.StorageConsumerList{}
-	if err := r.List(r.ctx, storageConsumerList); err != nil {
-		r.log.Error(err, "failed to list storage consumers")
+	radosNamespaceList := &rookCephv1.CephBlockPoolRadosNamespaceList{}
+	if err := r.list(radosNamespaceList, client.InNamespace(clientMappingConfig.Namespace)); err != nil {
+		r.log.Error(err, "Failed to list CephBlockPools")
 		return true
 	}
 
-	for i := range storageConsumerList.Items {
-		consumer := &storageConsumerList.Items[i]
-		if cl := consumer.Status.Client; cl != nil && clientMappingConfig.Data[cl.ID] != "" {
-			storageConsumerByName[consumer.Name] = consumer
-			remoteClientID := clientMappingConfig.Data[cl.ID]
-			storageConsumerByRemoteClientID[remoteClientID] = consumer
+	for i := range radosNamespaceList.Items {
+		rns := &radosNamespaceList.Items[i]
+		consumerIndex := slices.IndexFunc(
+			rns.OwnerReferences,
+			func(ref metav1.OwnerReference) bool { return ref.Kind == "StorageConsumer" },
+		)
+		if consumerIndex == -1 {
+			continue
+		}
+		consumerOwner := &rns.OwnerReferences[consumerIndex]
+		consumer := storageConsumerByName[consumerOwner.Name]
+		remoteNamespace := ""
+		if consumer != nil && consumer.Status.Client != nil {
+			remoteClientId := clientMappingConfig.Data[consumer.Status.Client.ID]
+			if remoteClientInfo := remoteClientInfoById[remoteClientId]; remoteClientInfo != nil {
+				remoteNamespace = remoteClientInfo.RadosNamespace
+			}
+		}
+		_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, rns, func() error {
+			if remoteNamespace != "" {
+				rns.Spec.Mirroring = &rookCephv1.RadosNamespaceMirroring{
+					RemoteNamespace: ptr.To(remoteNamespace),
+					Mode:            "image",
+				}
+			} else {
+				rns.Spec.Mirroring = nil
+			}
+			return nil
+		})
+		if err != nil {
+			r.log.Error(
+				err,
+				"failed to update radosnamespace",
+				"CephBlockPoolRadosNamespace",
+				rns.Name,
+			)
+			errorOccurred = true
 		}
 	}
 
-	if len(storageConsumerByRemoteClientID) > 0 && ocsClient != nil {
-		response, err := ocsClient.GetStorageClientsInfo(
-			r.ctx,
-			storageClusterPeer.Status.PeerInfo.StorageClusterUid,
-			maps.Keys(storageConsumerByRemoteClientID),
-		)
-		if err != nil {
-			r.log.Error(err, "failed to get StorageClient(s) info from Peer")
-			return true
-		}
+	return errorOccurred
+}
 
-		if response.Errors != nil {
-			for i := range response.Errors {
-				resp := response.Errors[i]
-				r.log.Error(
-					errors.New(resp.Message),
-					"failed to get StorageClientsInfo",
-					"CephBlockPool",
-					resp.ClientID,
-				)
+func (r *MirroringReconciler) reconcileStorageConsumer(
+	storageConsumerList *ocsv1alpha1.StorageConsumerList,
+	clientMappingConfig *corev1.ConfigMap,
+	remoteClientInfoById map[string]*pb.ClientInfo,
+) bool {
+	errorOccurred := false
+
+	for i := range storageConsumerList.Items {
+		consumer := &storageConsumerList.Items[i]
+		var clientInfo *pb.ClientInfo
+		if cl := consumer.Status.Client; cl != nil {
+			if remoteClientId := clientMappingConfig.Data[cl.ID]; remoteClientId != "" {
+				clientInfo = remoteClientInfoById[remoteClientId]
 			}
-			errorOccurred = true
 		}
-
-		remoteNamespaceByClientID := map[string]string{}
-		for i := range response.ClientsInfo {
-			clientInfo := response.ClientsInfo[i]
-
-			consumer := storageConsumerByRemoteClientID[clientInfo.ClientID]
-			remoteNamespaceByClientID[consumer.Status.Client.ID] = clientInfo.RadosNamespace
+		updateRequired := false
+		if clientInfo == nil {
+			if _, hasAnnotation := consumer.GetAnnotations()[util.StorageConsumerMirroringInfoAnnotation]; hasAnnotation {
+				delete(consumer.GetAnnotations(), util.StorageConsumerMirroringInfoAnnotation)
+				updateRequired = true
+			}
+		} else {
 			marshaledClientInfo, err := json.Marshal(clientInfo)
 			if err != nil {
 				panic("failed to marshal")
 			}
-			util.AddAnnotation(consumer, util.StorageConsumerMirroringInfoAnnotation, string(marshaledClientInfo))
+			if util.AddAnnotation(consumer, util.StorageConsumerMirroringInfoAnnotation, string(marshaledClientInfo)) {
+				updateRequired = true
+			}
+		}
+		if updateRequired {
 			if err := r.update(consumer); err != nil {
 				r.log.Error(
 					err,
 					"failed to update StorageConsumer with mirroring info annotation",
 					"StorageConsumer",
 					client.ObjectKeyFromObject(consumer),
-				)
-				errorOccurred = true
-			}
-		}
-
-		radosNamespaceList := &rookCephv1.CephBlockPoolRadosNamespaceList{}
-		if err = r.list(radosNamespaceList, client.InNamespace(storageClusterPeer.Namespace)); err != nil {
-			r.log.Error(err, "failed to list CephBlockPoolRadosNamespace(s)")
-			return true
-		}
-
-		for i := range radosNamespaceList.Items {
-			rns := &radosNamespaceList.Items[i]
-			consumerIndex := slices.IndexFunc(
-				rns.OwnerReferences,
-				func(ref metav1.OwnerReference) bool { return ref.Kind == "StorageConsumer" },
-			)
-			if consumerIndex == -1 {
-				continue
-			}
-			consumerOwner := &rns.OwnerReferences[consumerIndex]
-			consumer := storageConsumerByName[consumerOwner.Name]
-			if consumer == nil || consumer.Status.Client == nil {
-				continue
-			}
-			remoteNamespace := remoteNamespaceByClientID[consumer.Status.Client.ID]
-			_, err = controllerutil.CreateOrUpdate(r.ctx, r.Client, rns, func() error {
-				if remoteNamespace != "" && shouldMirror {
-					rns.Spec.Mirroring = &rookCephv1.RadosNamespaceMirroring{
-						RemoteNamespace: ptr.To(remoteNamespace),
-						Mode:            "image",
-					}
-				} else {
-					rns.Spec.Mirroring = nil
-				}
-				return nil
-			})
-			if err != nil {
-				r.log.Error(
-					err,
-					"failed to update radosnamespace",
-					"CephBlockPoolRadosNamespace",
-					rns.Name,
 				)
 				errorOccurred = true
 			}

--- a/pkg/util/k8sutil.go
+++ b/pkg/util/k8sutil.go
@@ -56,9 +56,9 @@ const (
 	DisableCSIDriverKey         = "ROOK_CSI_DISABLE_DRIVER"
 
 	// This is the name for the FieldIndex
-	OwnerUIDIndexName   = "ownerUID"
-	AnnotationIndexName = "annotation"
-	ObjectUidIndexName  = "objectUID"
+	OwnerUIDIndexName   = "index:ownerUID"
+	AnnotationIndexName = "index:annotation"
+	ObjectUidIndexName  = "index:objectUID"
 
 	OdfInfoNamespacedNameClaimName = "odfinfo.odf.openshift.io"
 


### PR DESCRIPTION
Refactor the mirroring controller to disable mirroring on cephblockpool and rns when the secondary cluster is down.

1. Create a desired state from the entries in the storage-client-mapping. This includes fetching the information from the peer cluster and creating a state out of it.
2. Reconcile the storagecosumer, blockpools, radosnamespaces, and rbdmirror.

Fixes: [DFBUGS-2957](https://issues.redhat.com/browse/DFBUGS-2957), [DFBUGS-3638](https://issues.redhat.com/browse/DFBUGS-3638)