### PR TITLE
Skip Rados Namespace creation for Erasure Coded pools as not supported

### DIFF
--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -20,6 +20,7 @@ import (
 	"cmp"
 	"context"
 	"fmt"
+	"reflect"
 	"slices"
 	"strconv"
 	"strings"
@@ -527,6 +528,11 @@ func (r *StorageConsumerReconciler) reconcileCephRadosNamespace(
 		bp := &blockPools.Items[idx]
 		// a new radosnamespace is not required for internal pools
 		if forInternalUseOnly, _ := strconv.ParseBool(bp.GetLabels()[util.ForInternalUseOnlyLabelKey]); forInternalUseOnly {
+			continue
+		}
+
+		// For erasure coded block pools creating rados namespaces is not supported
+		if !reflect.DeepEqual(bp.Spec.ErasureCoded, rookCephv1.ErasureCodedSpec{}) {
 			continue
 		}
 


### PR DESCRIPTION
Trying to create RNS for Erasure Coded pools is not supported and returns the error "failed to add namespace: (95) Operation not supported: exit status 95". We are aiming to achieve the isolation of data based on the rados namespace created for for the replicated metadata pool for Erasure Coded Usage.
Ref-https://issues.redhat.com/browse/RHSTOR-1958