### PR TITLE
Use Topology Spread Constraints and improve placement configuration flow

### DIFF
--- a/controllers/defaults/placements.go
+++ b/controllers/defaults/placements.go
@@ -109,6 +109,12 @@ var (
 			NodeAffinity: DefaultNodeAffinity,
 		},
 
+		"toolbox": {
+			Tolerations: []corev1.Toleration{
+				getOcsToleration(),
+			},
+			NodeAffinity: DefaultNodeAffinity,
+		},
 
 		APIServerKey: {
 			Tolerations: []corev1.Toleration{

--- a/controllers/defaults/placements.go
+++ b/controllers/defaults/placements.go
@@ -23,6 +23,12 @@ var (
 	DefaultNodeAffinity = &corev1.NodeAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: getOcsNodeSelector(),
 	}
+	// MasterNodeToleration is a toleration for master node scheduling
+	MasterNodeToleration = corev1.Toleration{
+		Key:      "node-role.kubernetes.io/master",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
 	// DaemonPlacements map contains the default placement configs for the
 	// various OCS daemons
 	DaemonPlacements = map[string]rookCephv1.Placement{

--- a/controllers/defaults/placements.go
+++ b/controllers/defaults/placements.go
@@ -30,6 +30,7 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
+			NodeAffinity: DefaultNodeAffinity,
 		},
 
 		"mon": {
@@ -53,7 +54,7 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
-			PodAntiAffinity: &corev1.PodAntiAffinity{
+			NodeAffinity: DefaultNodeAffinity,
 			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 				// leave the label value empty as it will be updated with the objectStore name later in getPlacement()
 				getTopologySpreadConstraint(1, "rook_object_store", []string{}, corev1.DoNotSchedule),
@@ -64,7 +65,7 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
-			PodAntiAffinity: &corev1.PodAntiAffinity{
+			NodeAffinity: DefaultNodeAffinity,
 			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 				// leave the label value empty as it will be updated with the filesystem name later in getPlacement()
 				getTopologySpreadConstraint(1, "rook_file_system", []string{}, corev1.DoNotSchedule),
@@ -75,6 +76,7 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
+			NodeAffinity: DefaultNodeAffinity,
 			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 				// leave the label value empty as it will be updated with the nfs name later in getPlacement()
 				getTopologySpreadConstraint(1, "ceph_nfs", []string{}, corev1.DoNotSchedule),
@@ -85,6 +87,7 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
+			NodeAffinity: DefaultNodeAffinity,
 		},
 
 		"noobaa-standalone": {
@@ -97,7 +100,9 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
+			NodeAffinity: DefaultNodeAffinity,
 		},
+
 
 		APIServerKey: {
 			Tolerations: []corev1.Toleration{

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -556,11 +556,16 @@ func newCephCluster(r *StorageClusterReconciler, sc *ocsv1.StorageCluster, kmsCo
 				BackfillFullRatio:            getBackfillFullRatio(sc.Spec.ManagedResources.CephCluster.BackfillFullRatio),
 				FullRatio:                    getFullRatio(sc.Spec.ManagedResources.CephCluster.FullRatio),
 			},
-			Placement: rookCephv1.PlacementSpec{
-				"all":     getPlacement(sc, "all"),
-				"mon":     getPlacement(sc, "mon"),
-				"arbiter": getPlacement(sc, "arbiter"),
-			},
+			Placement: func() rookCephv1.PlacementSpec {
+				placement := rookCephv1.PlacementSpec{
+					"all": getPlacement(sc, "all"),
+					"mon": getPlacement(sc, "mon"),
+				}
+				if arbiterEnabled(sc) {
+					placement["arbiter"] = getPlacement(sc, "arbiter")
+				}
+				return placement
+			}(),
 			PriorityClassNames: rookCephv1.PriorityClassNamesSpec{
 				rookCephv1.KeyMgr:            systemNodeCritical,
 				rookCephv1.KeyMon:            systemNodeCritical,

--- a/controllers/storagecluster/cephtoolbox.go
+++ b/controllers/storagecluster/cephtoolbox.go
@@ -9,10 +9,8 @@ import (
 
 	nadclientset "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
-	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,15 +33,7 @@ func (r *StorageClusterReconciler) ensureToolsDeployment(sc *ocsv1.StorageCluste
 	var isFound bool
 	namespace := sc.Namespace
 
-	tolerations := []corev1.Toleration{{
-		Key:      defaults.NodeTolerationKey,
-		Operator: corev1.TolerationOpEqual,
-		Value:    "true",
-		Effect:   corev1.TaintEffectNoSchedule,
-	}}
-
-	tolerations = append(tolerations, getPlacement(sc, "toolbox").Tolerations...)
-
+	tolerations := getPlacement(sc, "toolbox").Tolerations
 	nodeAffinity := getPlacement(sc, "toolbox").NodeAffinity
 
 	toolsDeployment := sc.NewToolsDeployment(tolerations, nodeAffinity)

--- a/controllers/storagecluster/initialization_reconciler_test.go
+++ b/controllers/storagecluster/initialization_reconciler_test.go
@@ -147,10 +147,10 @@ var (
 )
 
 func createDefaultStorageCluster() *api.StorageCluster {
-	return createStorageCluster("ocsinit", "zone", []string{"zone1", "zone2", "zone3"})
+	return createStorageCluster("ocsinit", "zone", "topology.kubernetes.io/zone", []string{"zone1", "zone2", "zone3"})
 }
 
-func createStorageCluster(scName, failureDomainName string,
+func createStorageCluster(scName, failureDomainName string, failureDomainKey string,
 	zoneTopologyLabels []string) *api.StorageCluster {
 	cr := &api.StorageCluster{
 		ObjectMeta: metav1.ObjectMeta{
@@ -170,7 +170,8 @@ func createStorageCluster(scName, failureDomainName string,
 			},
 		},
 		Status: api.StorageClusterStatus{
-			FailureDomain: failureDomainName,
+			FailureDomain:    failureDomainName,
+			FailureDomainKey: failureDomainKey,
 			NodeTopologies: &api.NodeTopologyMap{
 				Labels: map[string]api.TopologyLabelValues{
 					zoneTopologyLabel: zoneTopologyLabels,

--- a/controllers/storagecluster/placement.go
+++ b/controllers/storagecluster/placement.go
@@ -32,16 +32,6 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookCephv1.Placeme
 		return placement
 	}
 
-	// If no placement is specified for the given component and the
-	// StorageCluster has no label selector, set the default node
-	// affinity.
-	if placement.NodeAffinity == nil && sc.Spec.LabelSelector == nil {
-		// Don't add node affinity again for these rook-ceph daemons as it is already added via the "all" key
-		if component != "mgr" && component != "mon" && component != "osd" && component != "osd-prepare" {
-			placement.NodeAffinity = defaults.DefaultNodeAffinity
-		}
-	}
-
 	// If the StorageCluster specifies a label selector, append it to the
 	// node affinity, creating it if it doesn't exist.
 	if sc.Spec.LabelSelector != nil {

--- a/controllers/storagecluster/placement_test.go
+++ b/controllers/storagecluster/placement_test.go
@@ -5,7 +5,6 @@ import (
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
-	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
 
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
@@ -13,140 +12,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	WorkerAffinityKey = "node-role.kubernetes.io/worker"
-	MasterAffinityKey = "node-role.kubernetes.io/master"
-)
-
-var masterLabelSelector = metav1.LabelSelector{
-	MatchExpressions: []metav1.LabelSelectorRequirement{
-		{
-			Key:      MasterAffinityKey,
-			Operator: metav1.LabelSelectorOpExists,
-		},
-	},
-}
-var masterSelectorRequirement = corev1.NodeSelectorRequirement{
-	Key:      MasterAffinityKey,
-	Operator: corev1.NodeSelectorOpExists,
-}
-
-var workerLabelSelector = metav1.LabelSelector{
-	MatchExpressions: []metav1.LabelSelectorRequirement{
-		{
-			Key:      WorkerAffinityKey,
-			Operator: metav1.LabelSelectorOpExists,
-		},
-	},
-}
-var workerSelectorRequirement = corev1.NodeSelectorRequirement{
-	Key:      WorkerAffinityKey,
-	Operator: corev1.NodeSelectorOpExists,
-}
-var workerNodeSelector = corev1.NodeSelector{
-	NodeSelectorTerms: []corev1.NodeSelectorTerm{
-		{
-			MatchExpressions: []corev1.NodeSelectorRequirement{
-				workerSelectorRequirement,
-			},
-		},
-	},
-}
-var workerNodeAffinity = corev1.NodeAffinity{
-	RequiredDuringSchedulingIgnoredDuringExecution: &workerNodeSelector,
-}
-var workerPlacements = map[rookCephv1.KeyType]rookCephv1.Placement{
-	"all": {
-		NodeAffinity: &workerNodeAffinity,
-	},
-	"mds": {
-		NodeAffinity: &workerNodeAffinity,
-	},
-	"mon": {
-		NodeAffinity: &workerNodeAffinity,
-	},
-}
-
-var emptyLabelSelector = metav1.LabelSelector{
-	MatchExpressions: []metav1.LabelSelectorRequirement{},
-}
-var emptyPlacements = map[rookCephv1.KeyType]rookCephv1.Placement{
-	"all": {},
-	"mds": {},
-	"mon": {},
-}
-
-var customMDSPlacement = rookCephv1.Placement{
-	PodAntiAffinity: &corev1.PodAntiAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-			{
-				LabelSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{
-							Key:      "app",
-							Operator: metav1.LabelSelectorOpIn,
-							Values:   []string{"rook-ceph-mds"},
-						},
-					},
-				},
-				TopologyKey: "topology.rook.io/rack",
-			},
-		},
-		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-			{
-				PodAffinityTerm: corev1.PodAffinityTerm{
-					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      "app",
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{"rook-ceph-mds"},
-							},
-						},
-					},
-					TopologyKey: "topology.rook.io/rack",
-				},
-				Weight: 100,
-			},
-		},
-	},
-}
-
-var customMONPlacement = rookCephv1.Placement{
-	PodAntiAffinity: &corev1.PodAntiAffinity{
-		RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-			{
-				LabelSelector: &metav1.LabelSelector{
-					MatchExpressions: []metav1.LabelSelectorRequirement{
-						{
-							Key:      "app",
-							Operator: metav1.LabelSelectorOpIn,
-							Values:   []string{"rook-ceph-mon"},
-						},
-					},
-				},
-				TopologyKey: "topology.rook.io/rack",
-			},
-		},
-		PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-			{
-				PodAffinityTerm: corev1.PodAffinityTerm{
-					LabelSelector: &metav1.LabelSelector{
-						MatchExpressions: []metav1.LabelSelectorRequirement{
-							{
-								Key:      "app",
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{"rook-ceph-mon"},
-							},
-						},
-					},
-					TopologyKey: "topology.rook.io/rack",
-				},
-				Weight: 100,
-			},
-		},
-	},
-}
 
 func getOcsToleration() corev1.Toleration {
 	toleration := corev1.Toleration{
@@ -159,130 +24,90 @@ func getOcsToleration() corev1.Toleration {
 }
 
 func TestGetPlacement(t *testing.T) {
-	cases := []struct {
-		label              string
-		storageCluster     *ocsv1.StorageCluster
-		placements         rookCephv1.PlacementSpec
-		labelSelector      *metav1.LabelSelector
-		expectedPlacements rookCephv1.PlacementSpec
-		topologyMap        *ocsv1.NodeTopologyMap
+	// Common storage cluster for all test cases
+	baseStorageCluster := &ocsv1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-cluster",
+		},
+		Status: ocsv1.StorageClusterStatus{
+			FailureDomainKey: "topology.kubernetes.io/zone",
+		},
+	}
+
+	testCases := []struct {
+		name      string
+		specified rookCephv1.Placement
+		component string
+		expected  rookCephv1.Placement
 	}{
 		{
-			label:          "Case 1: Defaults are preserved i.e no placement and no label selector",
-			storageCluster: mockStorageCluster.DeepCopy(),
-			placements:     rookCephv1.PlacementSpec{},
-			labelSelector:  nil,
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					NodeAffinity: defaults.DefaultNodeAffinity,
-					Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
-				},
-				"mon": {
-					PodAntiAffinity: defaults.DaemonPlacements["mon"].PodAntiAffinity,
-				},
-				"mds": {
-					NodeAffinity:    defaults.DefaultNodeAffinity,
-					PodAntiAffinity: defaults.DaemonPlacements["mds"].PodAntiAffinity,
-					Tolerations:     defaults.DaemonPlacements["mds"].Tolerations,
-				},
-			},
-		},
-		{
-			label:          "Case 2: The configured Placements override the defaults",
-			storageCluster: mockStorageCluster.DeepCopy(),
-			placements:     emptyPlacements,
-			labelSelector:  nil,
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					NodeAffinity: defaults.DefaultNodeAffinity,
-				},
-				"mon": {},
-				"mds": {
-					NodeAffinity: defaults.DefaultNodeAffinity,
-				},
-			},
-		},
-		{
-			label:          "Case 3: LabelSelector to modify the default Placements correctly",
-			storageCluster: mockStorageCluster.DeepCopy(),
-			placements:     rookCephv1.PlacementSpec{},
-			labelSelector:  &workerLabelSelector,
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					NodeAffinity: &workerNodeAffinity,
-					Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
-				},
-				"mon": {
-					NodeAffinity:    &workerNodeAffinity,
-					PodAntiAffinity: defaults.DaemonPlacements["mon"].PodAntiAffinity,
-				},
-				"mds": {
-					NodeAffinity:    &workerNodeAffinity,
-					PodAntiAffinity: defaults.DaemonPlacements["mds"].PodAntiAffinity,
-					Tolerations:     defaults.DaemonPlacements["mds"].Tolerations,
-				},
-			},
-		},
-		{
-			label:          "Case 4: LabelSelector modifies an empty NodeAffinity",
-			storageCluster: mockStorageCluster.DeepCopy(),
-			placements:     emptyPlacements,
-			labelSelector:  &workerLabelSelector,
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					NodeAffinity: &workerNodeAffinity,
-				},
-				"mon": {
-					NodeAffinity: &workerNodeAffinity,
-				},
-				"mds": {
-					NodeAffinity: &workerNodeAffinity,
-				},
-			},
-		},
-		{
-			label:          "Case 5: LabelSelector modifies a configured NodeAffinity",
-			storageCluster: mockStorageCluster.DeepCopy(),
-			placements:     workerPlacements,
-			labelSelector:  &masterLabelSelector,
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					NodeAffinity: &corev1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			name:      "default placement for mon component",
+			component: "mon",
+			expected: rookCephv1.Placement{
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "topology.kubernetes.io/zone",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
 								{
-									MatchExpressions: []corev1.NodeSelectorRequirement{
-										workerSelectorRequirement,
-										masterSelectorRequirement,
-									},
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"rook-ceph-mon"},
 								},
 							},
 						},
 					},
 				},
-				"mon": {
-					NodeAffinity: &corev1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			},
+		},
+		{
+			name:      "default placement for arbiter component",
+			component: "arbiter",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					defaults.MasterNodeToleration,
+				},
+			},
+		},
+		{
+			name:      "default placement for osd component",
+			component: "osd",
+			expected: rookCephv1.Placement{
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.ScheduleAnyway,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
 								{
-									MatchExpressions: []corev1.NodeSelectorRequirement{
-										workerSelectorRequirement,
-										masterSelectorRequirement,
-									},
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"rook-ceph-osd"},
 								},
 							},
 						},
 					},
 				},
-				"mds": {
-					NodeAffinity: &corev1.NodeAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-							NodeSelectorTerms: []corev1.NodeSelectorTerm{
+			},
+		},
+		{
+			name:      "default placement for osd-prepare component",
+			component: "osd-prepare",
+			expected: rookCephv1.Placement{
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.ScheduleAnyway,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
 								{
-									MatchExpressions: []corev1.NodeSelectorRequirement{
-										workerSelectorRequirement,
-										masterSelectorRequirement,
-									},
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"rook-ceph-osd", "rook-ceph-osd-prepare"},
 								},
 							},
 						},
@@ -291,231 +116,599 @@ func TestGetPlacement(t *testing.T) {
 			},
 		},
 		{
-			label:          "Case 6: Empty LabelSelector sets no NodeAffinity",
-			storageCluster: mockStorageCluster.DeepCopy(),
-			placements:     rookCephv1.PlacementSpec{},
-			labelSelector:  &emptyLabelSelector,
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					Tolerations: defaults.DaemonPlacements["all"].Tolerations,
+			name:      "default placement for rgw component with topology key update",
+			component: "rgw",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
 				},
-				"mon": {
-					PodAntiAffinity: defaults.DaemonPlacements["mon"].PodAntiAffinity,
-				},
-				"mds": {
-					PodAntiAffinity: defaults.DaemonPlacements["mds"].PodAntiAffinity,
-					Tolerations:     defaults.DaemonPlacements["mds"].Tolerations,
-				},
-			},
-		},
-		{
-			label:          "Case 7: Custom placement is applied without failure",
-			storageCluster: mockStorageCluster.DeepCopy(),
-			placements: rookCephv1.PlacementSpec{
-				"mds": customMDSPlacement,
-				"mon": customMONPlacement,
-			},
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					NodeAffinity: defaults.DefaultNodeAffinity,
-					Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
-				},
-				"mon": {
-					PodAntiAffinity: customMONPlacement.PodAntiAffinity,
-				},
-				"mds": {
-					NodeAffinity:    defaults.DefaultNodeAffinity,
-					PodAntiAffinity: customMDSPlacement.PodAntiAffinity,
-				},
-			},
-		},
-		{
-			label:          "Case 8: Custom placement is modified by labelSelector",
-			storageCluster: mockStorageCluster.DeepCopy(),
-			placements: rookCephv1.PlacementSpec{
-				"mds": customMDSPlacement,
-				"mon": customMONPlacement,
-			},
-			labelSelector: &workerLabelSelector,
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					NodeAffinity: &workerNodeAffinity,
-					Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
-				},
-				"mon": {
-					NodeAffinity:    &workerNodeAffinity,
-					PodAntiAffinity: customMONPlacement.PodAntiAffinity,
-				},
-				"mds": {
-					NodeAffinity:    &workerNodeAffinity,
-					PodAntiAffinity: customMDSPlacement.PodAntiAffinity,
-				},
-			},
-		},
-		{
-			label:          "Case 9: NodeTopologyMap modifies default mon placement",
-			storageCluster: mockStorageCluster.DeepCopy(),
-			placements:     rookCephv1.PlacementSpec{},
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					NodeAffinity: defaults.DefaultNodeAffinity,
-					Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
-				},
-				"mds": {
-					NodeAffinity: defaults.DefaultNodeAffinity,
-					Tolerations:  defaults.DaemonPlacements["mds"].Tolerations,
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-							{
-								LabelSelector: &metav1.LabelSelector{
-									MatchExpressions: []metav1.LabelSelectorRequirement{
-										{
-											Key:      "rook_file_system",
-											Operator: metav1.LabelSelectorOpIn,
-											Values:   []string{"storage-test-cephfilesystem"},
-										},
-									},
+				NodeAffinity: defaults.DefaultNodeAffinity,
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "topology.kubernetes.io/zone",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "rook_object_store",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-cluster-cephobjectstore"},
 								},
-								TopologyKey: corev1.LabelZoneFailureDomainStable,
 							},
 						},
 					},
 				},
+			},
+		},
+		{
+			name:      "default placement for mds component with topology key update",
+			component: "mds",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+				NodeAffinity: defaults.DefaultNodeAffinity,
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "topology.kubernetes.io/zone",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "rook_file_system",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-cluster-cephfilesystem"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "default placement for nfs component with topology key update",
+			component: "nfs",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+				NodeAffinity: defaults.DefaultNodeAffinity,
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "topology.kubernetes.io/zone",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "ceph_nfs",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-cluster-cephnfs"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:      "default placement for rbd-mirror component",
+			component: "rbd-mirror",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+				NodeAffinity: defaults.DefaultNodeAffinity,
+			},
+		},
+		{
+			name:      "default placement for toolbox component",
+			component: "toolbox",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+				NodeAffinity: defaults.DefaultNodeAffinity,
+			},
+		},
+		{
+			name:      "default placement for noobaa-core component",
+			component: "noobaa-core",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+				NodeAffinity: defaults.DefaultNodeAffinity,
+			},
+		},
 
-				"mon": {
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-							{
+		{
+			name:      "default placement for api-server component",
+			component: "api-server",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+			},
+		},
+		{
+			name:      "default placement for metrics-exporter component",
+			component: "metrics-exporter",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+			},
+		},
+		{
+			name: "mon with custom tolerations",
+			specified: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "custom-toleration",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+			component: "mon",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "custom-toleration",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				},
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "topology.kubernetes.io/zone",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"rook-ceph-mon"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "osd with custom topology spread constraints",
+			specified: rookCephv1.Placement{
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.ScheduleAnyway,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"rook-ceph-osd"},
+								},
+							},
+						},
+					},
+					{
+						MaxSkew:           2,
+						TopologyKey:       "topology.kubernetes.io/zone",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"custom-osd-app"},
+								},
+							},
+						},
+					},
+				},
+			},
+			component: "osd",
+			expected: rookCephv1.Placement{
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: corev1.ScheduleAnyway,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"rook-ceph-osd"},
+								},
+							},
+						},
+					},
+					{
+						MaxSkew:           2,
+						TopologyKey:       "topology.kubernetes.io/zone",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"custom-osd-app"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "rgw with custom pod affinity",
+			specified: rookCephv1.Placement{
+				PodAffinity: &corev1.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						{
+							Weight: 100,
+							PodAffinityTerm: corev1.PodAffinityTerm{
 								LabelSelector: &metav1.LabelSelector{
 									MatchExpressions: []metav1.LabelSelectorRequirement{
 										{
 											Key:      "app",
 											Operator: metav1.LabelSelectorOpIn,
-											Values:   []string{"rook-ceph-mon"},
+											Values:   []string{"rgw-preferred-app"},
 										},
 									},
 								},
-								TopologyKey: corev1.LabelZoneFailureDomainStable,
+								TopologyKey: "topology.kubernetes.io/zone",
 							},
 						},
 					},
 				},
 			},
-			topologyMap: &ocsv1.NodeTopologyMap{
-				Labels: map[string]ocsv1.TopologyLabelValues{
-					corev1.LabelZoneFailureDomainStable: []string{
-						"zone1",
-						"zone2",
-						"zone3",
+			component: "rgw",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+				NodeAffinity: defaults.DefaultNodeAffinity,
+				PodAffinity: &corev1.PodAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+						{
+							Weight: 100,
+							PodAffinityTerm: corev1.PodAffinityTerm{
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "app",
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{"rgw-preferred-app"},
+										},
+									},
+								},
+								TopologyKey: "topology.kubernetes.io/zone",
+							},
+						},
+					},
+				},
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "topology.kubernetes.io/zone",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "rook_object_store",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-cluster-cephobjectstore"},
+								},
+							},
+						},
 					},
 				},
 			},
 		},
 		{
-			label:          "Case 10: skip podAntiAffinity in mon placement in case of stretched cluster",
-			storageCluster: mockStorageClusterWithArbiter.DeepCopy(),
-			placements:     rookCephv1.PlacementSpec{},
-			labelSelector:  nil,
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					NodeAffinity: defaults.DefaultNodeAffinity,
-					Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
+			name: "mds with custom pod anti affinity",
+			specified: rookCephv1.Placement{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "app",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"rook-ceph-mds"},
+									},
+								},
+							},
+							TopologyKey: "topology.kubernetes.io/zone",
+						},
+					},
 				},
-				"mon": {
-					PodAntiAffinity: &corev1.PodAntiAffinity{},
+			},
+			component: "mds",
+			expected: rookCephv1.Placement{
+				NodeAffinity: defaults.DefaultNodeAffinity,
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "app",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"rook-ceph-mds"},
+									},
+								},
+							},
+							TopologyKey: "topology.kubernetes.io/zone",
+						},
+					},
 				},
-				"mds": {
-					NodeAffinity:    defaults.DefaultNodeAffinity,
-					Tolerations:     defaults.DaemonPlacements["all"].Tolerations,
-					PodAntiAffinity: defaults.DaemonPlacements["mds"].PodAntiAffinity,
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "topology.kubernetes.io/zone",
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "rook_file_system",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"test-cluster-cephfilesystem"},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 		{
-			label:          "Case 11: When PodAntiAffinity is empty and topologyMap is provided ",
-			storageCluster: mockStorageCluster.DeepCopy(),
-			placements: rookCephv1.PlacementSpec{
-				"all": {
-					Tolerations: []corev1.Toleration{
-						getOcsToleration(),
-					},
-				},
-				"mon": {
-					Tolerations: []corev1.Toleration{
-						getOcsToleration(),
-					},
-				},
-				"mds": {
-					Tolerations: []corev1.Toleration{
-						getOcsToleration(),
-					},
-				},
-			},
-			topologyMap: &ocsv1.NodeTopologyMap{
-				Labels: map[string]ocsv1.TopologyLabelValues{
-					zoneTopologyLabel: []string{
-						"zone1",
-						"zone2",
-						"zone3",
+			name: "rbd-mirror with custom pod anti affinity",
+			specified: rookCephv1.Placement{
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "app",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"rook-ceph-rbd-mirror"},
+									},
+								},
+							},
+							TopologyKey: "topology.kubernetes.io/zone",
+						},
 					},
 				},
 			},
-			labelSelector: nil,
-			expectedPlacements: rookCephv1.PlacementSpec{
-				"all": {
-					NodeAffinity: defaults.DefaultNodeAffinity,
-					Tolerations:  defaults.DaemonPlacements["all"].Tolerations,
+			component: "rbd-mirror",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
 				},
-				"mon": {
-					Tolerations: []corev1.Toleration{
-						getOcsToleration(),
+				NodeAffinity: defaults.DefaultNodeAffinity,
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							LabelSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      "app",
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{"rook-ceph-rbd-mirror"},
+									},
+								},
+							},
+							TopologyKey: "topology.kubernetes.io/zone",
+						},
 					},
-					PodAntiAffinity: nil,
 				},
-				"mds": {
-					NodeAffinity:    defaults.DefaultNodeAffinity,
-					Tolerations:     defaults.DaemonPlacements["mds"].Tolerations,
-					PodAntiAffinity: nil,
+			},
+		},
+		{
+			name: "toolbox with custom node affinity",
+			specified: rookCephv1.Placement{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "custom-toolbox-key",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"custom-toolbox-value"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			component: "toolbox",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "custom-toolbox-key",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"custom-toolbox-value"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "noobaa-core with custom tolerations and node affinity",
+			specified: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "custom-noobaa-toleration",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				},
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "custom-noobaa-key",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"custom-noobaa-value"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			component: "noobaa-core",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+					{
+						Key:      "custom-noobaa-toleration",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				},
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "custom-noobaa-key",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"custom-noobaa-value"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "api-server with custom toleration",
+			specified: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					{
+						Key:      "custom-api-toleration",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+			component: "api-server",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+					{
+						Key:      "custom-api-toleration",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+		},
+		{
+			name: "metrics-exporter with custom toleration",
+			specified: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+					{
+						Key:      "custom-metrics-toleration",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+			component: "metrics-exporter",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+					{
+						Key:      "custom-metrics-toleration",
+						Operator: corev1.TolerationOpExists,
+						Effect:   corev1.TaintEffectNoSchedule,
+					},
+				},
+			},
+		},
+		{
+			name:      "component with label selector",
+			component: "all",
+			expected: rookCephv1.Placement{
+				Tolerations: []corev1.Toleration{
+					getOcsToleration(),
+				},
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "cluster.ocs.openshift.io/openshift-storage",
+										Operator: corev1.NodeSelectorOpExists,
+									},
+									{
+										Key:      "custom-label",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{"custom-value"},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
 	}
-
-	for _, c := range cases {
-		var actualPlacement rookCephv1.Placement
-		sc := &ocsv1.StorageCluster{}
-		c.storageCluster.DeepCopyInto(sc)
-		sc.Spec.Placement = c.placements
-		sc.Spec.LabelSelector = c.labelSelector
-		sc.Status.NodeTopologies = c.topologyMap
-		if c.topologyMap != nil {
-			setFailureDomain(sc)
-		}
-		expectedPlacement := c.expectedPlacements["all"]
-		actualPlacement = getPlacement(sc, "all")
-		assert.Equal(t, expectedPlacement, actualPlacement, c.label)
-
-		expectedPlacement = c.expectedPlacements["mon"]
-		actualPlacement = getPlacement(sc, "mon")
-		assert.Equal(t, expectedPlacement, actualPlacement, c.label)
-
-		expectedPlacement = c.expectedPlacements["mds"]
-		testPodAffinity := &corev1.PodAntiAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-				defaults.GetMdsWeightedPodAffinityTerm(100, util.GenerateNameForCephFilesystem(sc.Name)).PodAffinityTerm,
-			},
-		}
-		if expectedPlacement.PodAntiAffinity != nil {
-			topologyKeys := ""
-			if len(expectedPlacement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 0 {
-				topologyKeys = expectedPlacement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].TopologyKey
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			sc := baseStorageCluster.DeepCopy()
+			// Set the placement specification
+			sc.Spec.Placement = map[rookCephv1.KeyType]rookCephv1.Placement{
+				rookCephv1.KeyType(tt.component): tt.specified,
 			}
-			expectedPlacement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = testPodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
-			if topologyKeys != "" {
-				expectedPlacement.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0].TopologyKey = topologyKeys
+			// Handle special case for label selector test
+			if tt.name == "component with label selector" {
+				sc.Spec.LabelSelector = &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "custom-label",
+							Operator: metav1.LabelSelectorOpIn,
+							Values:   []string{"custom-value"},
+						},
+					},
+				}
 			}
-		}
-		actualPlacement = getPlacement(sc, "mds")
-		assert.Equal(t, expectedPlacement, actualPlacement, c.label)
+			result := getPlacement(sc, tt.component)
+			assert.Equal(t, tt.expected, result)
+		})
 	}
 }

--- a/controllers/storagecluster/storagecluster_controller_test.go
+++ b/controllers/storagecluster/storagecluster_controller_test.go
@@ -87,21 +87,6 @@ var mockStorageCluster = &api.StorageCluster{
 	},
 }
 
-var mockStorageClusterWithArbiter = &api.StorageCluster{
-	TypeMeta: metav1.TypeMeta{
-		Kind: "StorageCluster",
-	},
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      mockStorageClusterRequest.Name,
-		Namespace: mockStorageClusterRequest.Namespace,
-	},
-	Spec: api.StorageClusterSpec{
-		Arbiter: api.ArbiterSpec{
-			Enable: true,
-		},
-	},
-}
-
 var mockCephCluster = &rookCephv1.CephCluster{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      statusutil.GenerateNameForCephCluster(mockStorageCluster.DeepCopy()),

--- a/controllers/storagecluster/topology_test.go
+++ b/controllers/storagecluster/topology_test.go
@@ -17,6 +17,10 @@ var rack0 = "rack0"
 var rack1 = "rack1"
 var rack2 = "rack2"
 
+const (
+	WorkerAffinityKey = "node-role.kubernetes.io/worker"
+)
+
 var workerAffinityNode = corev1.Node{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "workAffinityNode",

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/placements.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/placements.go
@@ -10,6 +10,7 @@ var (
 	APIServerKey       = "api-server"
 	MetricsExporterKey = "metrics-exporter"
 
+	monLableSelector = "rook-ceph-mon"
 	// osdLabelSelector is the key in OSD pod. Used
 	// as a label selector for topology spread constraints.
 	osdLabelSelector = "rook-ceph-osd"
@@ -22,6 +23,12 @@ var (
 	DefaultNodeAffinity = &corev1.NodeAffinity{
 		RequiredDuringSchedulingIgnoredDuringExecution: getOcsNodeSelector(),
 	}
+	// MasterNodeToleration is a toleration for master node scheduling
+	MasterNodeToleration = corev1.Toleration{
+		Key:      "node-role.kubernetes.io/master",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}
 	// DaemonPlacements map contains the default placement configs for the
 	// various OCS daemons
 	DaemonPlacements = map[string]rookCephv1.Placement{
@@ -29,36 +36,34 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
+			NodeAffinity: DefaultNodeAffinity,
 		},
 
 		"mon": {
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-					getPodAffinityTerm("rook-ceph-mon"),
-				},
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+				getTopologySpreadConstraint(1, appLabelSelectorKey, []string{monLableSelector}, corev1.DoNotSchedule),
 			},
 		},
 
 		"osd": {
 			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
-				getTopologySpreadConstraintsSpec(1, []string{osdLabelSelector}),
+				getTopologySpreadConstraint(1, appLabelSelectorKey, []string{osdLabelSelector}, corev1.ScheduleAnyway),
 			},
 		},
 
 		"osd-prepare": {
 			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
-				getTopologySpreadConstraintsSpec(1, []string{osdLabelSelector, osdPrepareLabelSelector}),
+				getTopologySpreadConstraint(1, appLabelSelectorKey, []string{osdLabelSelector, osdPrepareLabelSelector}, corev1.ScheduleAnyway),
 			},
 		},
-
 		"rgw": {
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
-					getWeightedPodAffinityTerm(100, "rook-ceph-rgw"),
-				},
+			NodeAffinity: DefaultNodeAffinity,
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+				// leave the label value empty as it will be updated with the objectStore name later in getPlacement()
+				getTopologySpreadConstraint(1, "rook_object_store", []string{}, corev1.DoNotSchedule),
 			},
 		},
 
@@ -66,10 +71,10 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-					// left the selector value empty as it will be updated later in the getPlacement()
-				},
+			NodeAffinity: DefaultNodeAffinity,
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+				// leave the label value empty as it will be updated with the filesystem name later in getPlacement()
+				getTopologySpreadConstraint(1, "rook_file_system", []string{}, corev1.DoNotSchedule),
 			},
 		},
 
@@ -77,10 +82,10 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
-			PodAntiAffinity: &corev1.PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
-					getPodAffinityTerm("rook-ceph-nfs"),
-				},
+			NodeAffinity: DefaultNodeAffinity,
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+				// leave the label value empty as it will be updated with the nfs name later in getPlacement()
+				getTopologySpreadConstraint(1, "ceph_nfs", []string{}, corev1.DoNotSchedule),
 			},
 		},
 
@@ -88,6 +93,7 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
+			NodeAffinity: DefaultNodeAffinity,
 		},
 
 		"noobaa-standalone": {
@@ -100,6 +106,14 @@ var (
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},
+			NodeAffinity: DefaultNodeAffinity,
+		},
+
+		"toolbox": {
+			Tolerations: []corev1.Toleration{
+				getOcsToleration(),
+			},
+			NodeAffinity: DefaultNodeAffinity,
 		},
 
 		APIServerKey: {
@@ -116,77 +130,23 @@ var (
 	}
 )
 
-// getTopologySpreadConstraintsSpec populates values required for topology spread constraints.
-// TopologyKey gets updated in newStorageClassDeviceSets after determining it from determineFailureDomain.
-func getTopologySpreadConstraintsSpec(maxSkew int32, valueLabels []string) corev1.TopologySpreadConstraint {
-	topologySpreadConstraints := corev1.TopologySpreadConstraint{
+// getTopologySpreadConstraint populates values required & returns the topology spread constraint
+func getTopologySpreadConstraint(maxSkew int32, labelKey string, labelValues []string, whenUnsatisfiable corev1.UnsatisfiableConstraintAction) corev1.TopologySpreadConstraint {
+	topologySpreadConstraint := corev1.TopologySpreadConstraint{
 		MaxSkew:           maxSkew,
-		TopologyKey:       corev1.LabelHostname,
-		WhenUnsatisfiable: "ScheduleAnyway",
+		TopologyKey:       corev1.LabelHostname, // TopologyKey gets updated with the failure domain in newStorageClassDeviceSets()/getPlacement()
+		WhenUnsatisfiable: whenUnsatisfiable,
 		LabelSelector: &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{
-					Key:      appLabelSelectorKey,
+					Key:      labelKey,
 					Operator: metav1.LabelSelectorOpIn,
-					Values:   valueLabels,
+					Values:   labelValues,
 				},
 			},
 		},
 	}
-
-	return topologySpreadConstraints
-}
-
-func getWeightedPodAffinityTerm(weight int32, selectorValue ...string) corev1.WeightedPodAffinityTerm {
-	return corev1.WeightedPodAffinityTerm{
-		Weight: weight,
-		PodAffinityTerm: corev1.PodAffinityTerm{
-			LabelSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      appLabelSelectorKey,
-						Operator: metav1.LabelSelectorOpIn,
-						Values:   selectorValue,
-					},
-				},
-			},
-			TopologyKey: corev1.LabelHostname,
-		},
-	}
-}
-
-func GetMdsWeightedPodAffinityTerm(weight int32, selectorValue ...string) corev1.WeightedPodAffinityTerm {
-	return corev1.WeightedPodAffinityTerm{
-		Weight: weight,
-		PodAffinityTerm: corev1.PodAffinityTerm{
-			LabelSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      "rook_file_system",
-						Operator: metav1.LabelSelectorOpIn,
-						Values:   selectorValue,
-					},
-				},
-			},
-			TopologyKey: corev1.LabelHostname,
-		},
-	}
-}
-
-func getPodAffinityTerm(selectorValue ...string) corev1.PodAffinityTerm {
-	podAffinityTerm := corev1.PodAffinityTerm{
-		LabelSelector: &metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{
-				{
-					Key:      appLabelSelectorKey,
-					Operator: metav1.LabelSelectorOpIn,
-					Values:   selectorValue,
-				},
-			},
-		},
-		TopologyKey: corev1.LabelHostname,
-	}
-	return podAffinityTerm
+	return topologySpreadConstraint
 }
 
 func getOcsToleration() corev1.Toleration {


### PR DESCRIPTION
This PR introduces major improvements to the placement configuration system in the OCS operator.
We will now use TSCs for pod distribution of all components from ocs-operator & merge both specified & default placement. Look at individual commits for full details.
Ref-https://issues.redhat.com/browse/DFBUGS-1612