### PR TITLE
DFBUGS-3771: [release-4.19] Remove csi toleration specification & Reserve the rook-ceph-operator-config configmap for overrides

### DIFF
--- a/api/v1/ocsinitialization_types.go
+++ b/api/v1/ocsinitialization_types.go
@@ -54,17 +54,17 @@ type OCSInitializationStatus struct {
 	// operator. Object references will be added to this list after they have
 	// been created AND found in the cluster.
 	// +optional
-	RelatedObjects                []corev1.ObjectReference     `json:"relatedObjects,omitempty"`
-	ErrorMessage                  string                       `json:"errorMessage,omitempty"`
-	SCCsCreated                   bool                         `json:"sCCsCreated,omitempty"`
-	RookCephOperatorConfigCreated bool                         `json:"rookCephOperatorConfigCreated,omitempty"`
-	RookCephOperatorConfig        RookCephOperatorConfigStatus `json:"rookCephOperatorConfig,omitempty"`
+	RelatedObjects []corev1.ObjectReference `json:"relatedObjects,omitempty"`
+	ErrorMessage   string                   `json:"errorMessage,omitempty"`
+	SCCsCreated    bool                     `json:"sCCsCreated,omitempty"`
+	// +kubebuilder:deprecatedversion:warning=This field is deprecated and will be removed in future
+	RookCephOperatorConfigCreated bool `json:"rookCephOperatorConfigCreated,omitempty"`
+	// +kubebuilder:deprecatedversion:warning=This field is deprecated and will be removed in future
+	RookCephOperatorConfig RookCephOperatorConfigStatus `json:"rookCephOperatorConfig,omitempty"`
 }
 
 type RookCephOperatorConfigStatus struct {
-	// CsiPluginTolerationsModified indicates if CsiPluginTolerations are added to the configmap via controller
 	CsiPluginTolerationsModified bool `json:"csiPluginTolerationsModified,omitempty"`
-	// CsiProvisionerTolerationsModified indicates if CsiProvisionerTolerations are added to the configmap via controller
 	CsiProvisionerTolerationsModified bool `json:"csiProvisionerTolerationsModified,omitempty"`
 }
 

--- a/config/crd/bases/ocs.openshift.io_ocsinitializations.yaml
+++ b/config/crd/bases/ocs.openshift.io_ocsinitializations.yaml
@@ -192,12 +192,8 @@ spec:
               rookCephOperatorConfig:
                 properties:
                   csiPluginTolerationsModified:
-                    description: CsiPluginTolerationsModified indicates if CsiPluginTolerations
-                      are added to the configmap via controller
                     type: boolean
                   csiProvisionerTolerationsModified:
-                    description: CsiProvisionerTolerationsModified indicates if CsiProvisionerTolerations
-                      are added to the configmap via controller
                     type: boolean
                 type: object
               rookCephOperatorConfigCreated:

--- a/controllers/defaults/placements.go
+++ b/controllers/defaults/placements.go
@@ -9,8 +9,6 @@ import (
 var (
 	APIServerKey       = "api-server"
 	MetricsExporterKey = "metrics-exporter"
-	CsiPluginKey       = "csi-plugin"
-	CsiProvisionerKey  = "csi-provisioner"
 
 	// osdLabelSelector is the key in OSD pod. Used
 	// as a label selector for topology spread constraints.
@@ -111,18 +109,6 @@ var (
 		},
 
 		MetricsExporterKey: {
-			Tolerations: []corev1.Toleration{
-				getOcsToleration(),
-			},
-		},
-
-		CsiPluginKey: {
-			Tolerations: []corev1.Toleration{
-				getOcsToleration(),
-			},
-		},
-
-		CsiProvisionerKey: {
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},

--- a/controllers/ocsinitialization/ocsinitialization_controller.go
+++ b/controllers/ocsinitialization/ocsinitialization_controller.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
-	"github.com/red-hat-storage/ocs-operator/v4/controllers/defaults"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/platform"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/storagecluster"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
@@ -18,8 +17,6 @@ import (
 	secv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
-	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -409,8 +406,7 @@ func (r *OCSInitializationReconciler) ensureClusterClaimExists() error {
 }
 
 // ensureRookCephOperatorConfigExists ensures that the rook-ceph-operator-config cm exists
-// This configmap is semi-reserved for any user overrides to be applied 4.16 onwards.
-// Earlier it used to be purely reserved for user overrides.
+// This configmap is purely reserved for any user overrides to be applied.
 // We don't reconcile it if it exists as it can reset any values the user has set
 // The configmap is watched by the rook operator and values set here have higher precedence
 // than the default values set in the rook operator pod env vars.
@@ -421,76 +417,11 @@ func (r *OCSInitializationReconciler) ensureRookCephOperatorConfigExists(initial
 			Namespace: initialData.Namespace,
 		},
 	}
-
-	opResult, err := ctrl.CreateOrUpdate(r.ctx, r.Client, rookCephOperatorConfig, func() error {
-
-		if rookCephOperatorConfig.Data == nil {
-			rookCephOperatorConfig.Data = make(map[string]string)
-		}
-
-		csiPluginDefaults := defaults.DaemonPlacements[defaults.CsiPluginKey]
-		csiPluginTolerations := r.getCsiTolerations(defaults.CsiPluginKey)
-		if err := updateTolerationsConfigFunc(rookCephOperatorConfig,
-			csiPluginTolerations, csiPluginDefaults.Tolerations, "CSI_PLUGIN_TOLERATIONS",
-			&initialData.Status.RookCephOperatorConfig.CsiPluginTolerationsModified); err != nil {
-			return err
-		}
-
-		csiProvisionerDefaults := defaults.DaemonPlacements[defaults.CsiProvisionerKey]
-		csiProvisionerTolerations := r.getCsiTolerations(defaults.CsiProvisionerKey)
-		if err := updateTolerationsConfigFunc(rookCephOperatorConfig,
-			csiProvisionerTolerations, csiProvisionerDefaults.Tolerations, "CSI_PROVISIONER_TOLERATIONS",
-			&initialData.Status.RookCephOperatorConfig.CsiProvisionerTolerationsModified); err != nil {
-			return err // nolint:revive
-		}
-
-		// TODO: remove this in the next release, look at commit msg for more info
-		delete(rookCephOperatorConfig.Data, "ROOK_CSI_ENABLE_CEPHFS")
-
-		return nil
-	})
-
-	if err != nil {
-		r.Log.Error(err, "Failed to create/update rook-ceph-operator-config configmap")
+	err := r.Client.Create(r.ctx, rookCephOperatorConfig)
+	if err != nil && !errors.IsAlreadyExists(err) {
 		return err
 	}
-	r.Log.Info("Successfully created/updated rook-ceph-operator-config configmap", "OperationResult", opResult)
-
 	return nil
-}
-
-func updateTolerationsConfigFunc(rookCephOperatorConfig *corev1.ConfigMap,
-	tolerations, defaults []corev1.Toleration, configMapKey string, modifiedFlag *bool) error {
-
-	if tolerations != nil {
-		updatedTolerations := append(tolerations, defaults...)
-		tolerationsYAML, err := yaml.Marshal(updatedTolerations)
-		if err != nil {
-			return err
-		}
-		rookCephOperatorConfig.Data[configMapKey] = string(tolerationsYAML)
-		*modifiedFlag = true
-	} else if tolerations == nil && *modifiedFlag {
-		delete(rookCephOperatorConfig.Data, configMapKey)
-		*modifiedFlag = false
-	}
-
-	return nil
-}
-
-func (r *OCSInitializationReconciler) getCsiTolerations(csiTolerationKey string) []corev1.Toleration {
-
-	var tolerations []corev1.Toleration
-
-	clusters := r.clusters.GetStorageClusters()
-
-	for i := range clusters {
-		if val, ok := clusters[i].Spec.Placement[rookCephv1.KeyType(csiTolerationKey)]; ok {
-			tolerations = append(tolerations, val.Tolerations...)
-		}
-	}
-
-	return tolerations
 }
 
 // ensureOcsOperatorConfigExists ensures that the ocs-operator-config exists & if not create/update it with required values

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_ocsinitializations.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_ocsinitializations.yaml
@@ -192,12 +192,8 @@ spec:
               rookCephOperatorConfig:
                 properties:
                   csiPluginTolerationsModified:
-                    description: CsiPluginTolerationsModified indicates if CsiPluginTolerations
-                      are added to the configmap via controller
                     type: boolean
                   csiProvisionerTolerationsModified:
-                    description: CsiProvisionerTolerationsModified indicates if CsiProvisionerTolerations
-                      are added to the configmap via controller
                     type: boolean
                 type: object
               rookCephOperatorConfigCreated:

--- a/deploy/ocs-operator/manifests/ocsinitialization.crd.yaml
+++ b/deploy/ocs-operator/manifests/ocsinitialization.crd.yaml
@@ -192,12 +192,8 @@ spec:
               rookCephOperatorConfig:
                 properties:
                   csiPluginTolerationsModified:
-                    description: CsiPluginTolerationsModified indicates if CsiPluginTolerations
-                      are added to the configmap via controller
                     type: boolean
                   csiProvisionerTolerationsModified:
-                    description: CsiProvisionerTolerationsModified indicates if CsiProvisionerTolerations
-                      are added to the configmap via controller
                     type: boolean
                 type: object
               rookCephOperatorConfigCreated:

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/ocsinitialization_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/ocsinitialization_types.go
@@ -54,17 +54,17 @@ type OCSInitializationStatus struct {
 	// operator. Object references will be added to this list after they have
 	// been created AND found in the cluster.
 	// +optional
-	RelatedObjects                []corev1.ObjectReference     `json:"relatedObjects,omitempty"`
-	ErrorMessage                  string                       `json:"errorMessage,omitempty"`
-	SCCsCreated                   bool                         `json:"sCCsCreated,omitempty"`
-	RookCephOperatorConfigCreated bool                         `json:"rookCephOperatorConfigCreated,omitempty"`
-	RookCephOperatorConfig        RookCephOperatorConfigStatus `json:"rookCephOperatorConfig,omitempty"`
+	RelatedObjects []corev1.ObjectReference `json:"relatedObjects,omitempty"`
+	ErrorMessage   string                   `json:"errorMessage,omitempty"`
+	SCCsCreated    bool                     `json:"sCCsCreated,omitempty"`
+	// +kubebuilder:deprecatedversion:warning=This field is deprecated and will be removed in future
+	RookCephOperatorConfigCreated bool `json:"rookCephOperatorConfigCreated,omitempty"`
+	// +kubebuilder:deprecatedversion:warning=This field is deprecated and will be removed in future
+	RookCephOperatorConfig RookCephOperatorConfigStatus `json:"rookCephOperatorConfig,omitempty"`
 }
 
 type RookCephOperatorConfigStatus struct {
-	// CsiPluginTolerationsModified indicates if CsiPluginTolerations are added to the configmap via controller
 	CsiPluginTolerationsModified bool `json:"csiPluginTolerationsModified,omitempty"`
-	// CsiProvisionerTolerationsModified indicates if CsiProvisionerTolerations are added to the configmap via controller
 	CsiProvisionerTolerationsModified bool `json:"csiProvisionerTolerationsModified,omitempty"`
 }
 

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/placements.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/placements.go
@@ -9,8 +9,6 @@ import (
 var (
 	APIServerKey       = "api-server"
 	MetricsExporterKey = "metrics-exporter"
-	CsiPluginKey       = "csi-plugin"
-	CsiProvisionerKey  = "csi-provisioner"
 
 	// osdLabelSelector is the key in OSD pod. Used
 	// as a label selector for topology spread constraints.
@@ -111,18 +109,6 @@ var (
 		},
 
 		MetricsExporterKey: {
-			Tolerations: []corev1.Toleration{
-				getOcsToleration(),
-			},
-		},
-
-		CsiPluginKey: {
-			Tolerations: []corev1.Toleration{
-				getOcsToleration(),
-			},
-		},
-
-		CsiProvisionerKey: {
 			Tolerations: []corev1.Toleration{
 				getOcsToleration(),
 			},

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/ocsinitialization_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/ocsinitialization_types.go
@@ -54,17 +54,17 @@ type OCSInitializationStatus struct {
 	// operator. Object references will be added to this list after they have
 	// been created AND found in the cluster.
 	// +optional
-	RelatedObjects                []corev1.ObjectReference     `json:"relatedObjects,omitempty"`
-	ErrorMessage                  string                       `json:"errorMessage,omitempty"`
-	SCCsCreated                   bool                         `json:"sCCsCreated,omitempty"`
-	RookCephOperatorConfigCreated bool                         `json:"rookCephOperatorConfigCreated,omitempty"`
-	RookCephOperatorConfig        RookCephOperatorConfigStatus `json:"rookCephOperatorConfig,omitempty"`
+	RelatedObjects []corev1.ObjectReference `json:"relatedObjects,omitempty"`
+	ErrorMessage   string                   `json:"errorMessage,omitempty"`
+	SCCsCreated    bool                     `json:"sCCsCreated,omitempty"`
+	// +kubebuilder:deprecatedversion:warning=This field is deprecated and will be removed in future
+	RookCephOperatorConfigCreated bool `json:"rookCephOperatorConfigCreated,omitempty"`
+	// +kubebuilder:deprecatedversion:warning=This field is deprecated and will be removed in future
+	RookCephOperatorConfig RookCephOperatorConfigStatus `json:"rookCephOperatorConfig,omitempty"`
 }
 
 type RookCephOperatorConfigStatus struct {
-	// CsiPluginTolerationsModified indicates if CsiPluginTolerations are added to the configmap via controller
 	CsiPluginTolerationsModified bool `json:"csiPluginTolerationsModified,omitempty"`
-	// CsiProvisionerTolerationsModified indicates if CsiProvisionerTolerations are added to the configmap via controller
 	CsiProvisionerTolerationsModified bool `json:"csiProvisionerTolerationsModified,omitempty"`
 }
 


### PR DESCRIPTION
Manual Cherry-pick of https://github.com/red-hat-storage/ocs-operator/pull/3422
Till 4.18, tolerations for csi pods were being added to the storageCluster CR, and those were being passed to rook ceph operator via the rook-ceph-operator-config configMap. From 4.19 onwards, rook no longer deploys the csi, it's now done by ceph-csi-operator.
To add tolerations to csi pods user has to now directly edit the csi driver CR, ref-https://issues.redhat.com/browse/DFBUGS-2764. So to avoid confusion, the code relating to adding the csi tolerations via ocs-operator should be removed.

Then We can just create the configmap and not reconcile it.