### PR TITLE
DFBUGS-3793:[release-4.18] add node affinity to metrics-exporter and provider-server deployments

### DIFF
--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -519,6 +519,9 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 					},
 				},
 				Tolerations: getPlacement(instance, defaults.MetricsExporterKey).Tolerations,
+				Affinity: &corev1.Affinity{
+					NodeAffinity: getPlacement(instance, defaults.MetricsExporterKey).NodeAffinity,
+				},
 			},
 		}
 		return nil

--- a/controllers/storagecluster/provider_server.go
+++ b/controllers/storagecluster/provider_server.go
@@ -338,7 +338,10 @@ func GetProviderAPIServerDeployment(instance *ocsv1.StorageCluster) *appsv1.Depl
 							},
 						},
 					},
-					Tolerations:        getPlacement(instance, defaults.APIServerKey).Tolerations,
+					Tolerations: getPlacement(instance, defaults.APIServerKey).Tolerations,
+					Affinity: &corev1.Affinity{
+						NodeAffinity: getPlacement(instance, defaults.APIServerKey).NodeAffinity,
+					},
 					ServiceAccountName: ocsProviderServerName,
 				},
 			},

--- a/controllers/storagecluster/provider_server_test.go
+++ b/controllers/storagecluster/provider_server_test.go
@@ -381,6 +381,9 @@ func GetProviderAPIServerDeploymentForTest(instance *ocsv1.StorageCluster) *apps
 					},
 					ServiceAccountName: ocsProviderServerName,
 					Tolerations:        getPlacement(instance, defaults.APIServerKey).Tolerations,
+					Affinity: &corev1.Affinity{
+						NodeAffinity: getPlacement(instance, defaults.APIServerKey).NodeAffinity,
+					},
 				},
 			},
 		},


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/red-hat-storage/ocs-operator/pull/3433

Signed-off-by: Nitin Goyal <nigoyal@redhat.com>