### PR TITLE
Make possible to mark EnableCrushUpdates as false

### DIFF
--- a/controllers/storagecluster/cephblockpools.go
+++ b/controllers/storagecluster/cephblockpools.go
@@ -16,6 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+var (
+	cephBlockPoolsSpecifiedPoolSpecPath = []string{"spec", "managedResources", "cephBlockPools", "poolSpec"}
+)
+
 type ocsCephBlockPools struct{}
 
 func (o *ocsCephBlockPools) deleteCephBlockPool(r *StorageClusterReconciler, cephBlockPool *cephv1.CephBlockPool) (reconcile.Result, error) {
@@ -71,7 +75,7 @@ func (o *ocsCephBlockPools) reconcileCephBlockPool(r *StorageClusterReconciler, 
 		}
 
 		// Set default values in the poolSpec as necessary
-		setDefaultDataPoolSpec(&cephBlockPool.Spec.PoolSpec, storageCluster)
+		r.setDefaultDataPoolSpec(&cephBlockPool.Spec.PoolSpec, storageCluster, cephBlockPoolsSpecifiedPoolSpecPath)
 		cephBlockPool.Spec.PoolSpec.EnableRBDStats = true
 
 		return controllerutil.SetControllerReference(storageCluster, cephBlockPool, r.Scheme)

--- a/controllers/storagecluster/cephobjectstores.go
+++ b/controllers/storagecluster/cephobjectstores.go
@@ -18,6 +18,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+var (
+	cephObjectStoreSpecifiedDataPoolSpecPath     = []string{"spec", "managedResources", "cephObjectStores", "dataPoolSpec"}
+	cephObjectStoreSpecifiedMetadataPoolSpecPath = []string{"spec", "managedResources", "cephObjectStores", "metadataPoolSpec"}
+)
+
 type ocsCephObjectStores struct{}
 
 // ensureCreated ensures that CephObjectStore resources exist in the desired
@@ -216,10 +221,10 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 		}
 
 		// Set default values in the data pool spec as necessary
-		setDefaultDataPoolSpec(&obj.Spec.DataPool, initData)
+		r.setDefaultDataPoolSpec(&obj.Spec.DataPool, initData, cephObjectStoreSpecifiedDataPoolSpecPath)
 
 		// Set default values in the metadata pool spec as necessary
-		setDefaultMetadataPoolSpec(&obj.Spec.MetadataPool, initData)
+		r.setDefaultMetadataPoolSpec(&obj.Spec.MetadataPool, initData, cephObjectStoreSpecifiedMetadataPoolSpecPath)
 
 		// if kmsConfig is not 'nil', add the KMS details to ObjectStore spec
 		if kmsConfigMap != nil {

--- a/controllers/storagecluster/storagecluster_controller.go
+++ b/controllers/storagecluster/storagecluster_controller.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -96,6 +97,7 @@ type StorageClusterReconciler struct {
 	clusters                  *util.Clusters
 	OperatorNamespace         string
 	AvailableCrds             map[string]bool
+	unstructuredSC            *unstructured.Unstructured
 }
 
 // SetupWithManager sets up a controller with manager

--- a/main.go
+++ b/main.go
@@ -170,6 +170,7 @@ func main() {
 		LeaderElection:          enableLeaderElection,
 		LeaderElectionID:        "ab76f4c9.openshift.io",
 		LeaderElectionNamespace: operatorNamespace,
+		Client:                  apiclient.Options{Cache: &apiclient.CacheOptions{Unstructured: true}},
 		Cache:                   cache.Options{DefaultNamespaces: defaultNamespaces},
 	})
 	if err != nil {


### PR DESCRIPTION
The enableCrushUpdates field is a bool field, and after we get the storageCluster as a structured object it's impossible to know if the field is set to false because it was not specified or because it was explicitly set to false. Hence till now we were setting the field to true always. 

Now we are getting the storageCluster as unstructured, and we can check if the field exists in the unstructured object. If it does, it means the user has explicitly set the field. If it does not, it means the field is not specified by the user. This way the user can now make the field enableCrushUpdates as false.

Ref-https://issues.redhat.com/browse/DFBUGS-3813