### PR TITLE
external: do not create metrics cephclient CR for external mode

### DIFF
--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -114,11 +114,15 @@ func (r *StorageClusterReconciler) enableMetricsExporter(
 
 	// create a `ocs-metrics-exporter-ceph-auth` secret for metrics exporter
 	// create a cephclient and it will create the secret
-	err = r.createMetricsExporterCephClient(instance)
-	if err != nil {
-		r.Log.Error(err, "Failed to create ceph client for metrics exporter.")
-		return err
+	// and create ceph clients if external storage is not enabled
+	if !instance.Spec.ExternalStorage.Enable {
+		err = r.createMetricsExporterCephClient(instance)
+		if err != nil {
+			r.Log.Error(err, "Failed to create ceph client for metrics exporter.")
+			return err
+		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
in external mode we dont have admin privileges
and so we should avoid creating cephclient from the ocs operator,
If needed in future we can create the cephclient
from the python script.

Currently external mode will rely on the fall back mechanism to use the csi rbd secret for getting the metrics exporter run.