### PR TITLE
Add liveness probe to OCS Operator

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,6 +30,9 @@ spec:
         image: ocs-dev/ocs-operator:latest
         imagePullPolicy: Always
         name: ocs-operator
+        ports:
+          - name: healthz
+            containerPort: 8081
         env:
           - name: WATCH_NAMESPACE
             valueFrom:
@@ -38,13 +41,23 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: 8081
+            port: healthz
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
-              drop:
+            drop:
               - all
           readOnlyRootFilesystem: true
         terminationMessagePolicy: FallbackToLogsOnError

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -79,7 +79,7 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2025-10-15T10:57:28Z"
+    createdAt: "2025-10-30T10:14:09Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
@@ -624,13 +624,26 @@ spec:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 image: quay.io/ocs-dev/ocs-operator:latest
                 imagePullPolicy: Always
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /healthz
+                    port: healthz
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
                 name: ocs-operator
+                ports:
+                - containerPort: 8081
+                  name: healthz
                 readinessProbe:
+                  failureThreshold: 3
                   httpGet:
                     path: /readyz
-                    port: 8081
+                    port: healthz
                   initialDelaySeconds: 5
                   periodSeconds: 10
+                  timeoutSeconds: 5
                 resources: {}
                 securityContext:
                   allowPrivilegeEscalation: false

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2025-10-15T10:57:28Z"
+    createdAt: "2025-10-30T10:14:09Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",
@@ -663,13 +663,26 @@ spec:
                       fieldPath: metadata.namespace
                 image: quay.io/ocs-dev/ocs-operator:latest
                 imagePullPolicy: Always
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /healthz
+                    port: healthz
+                  initialDelaySeconds: 15
+                  periodSeconds: 10
+                  timeoutSeconds: 5
                 name: ocs-operator
+                ports:
+                - containerPort: 8081
+                  name: healthz
                 readinessProbe:
+                  failureThreshold: 3
                   httpGet:
                     path: /readyz
-                    port: 8081
+                    port: healthz
                   initialDelaySeconds: 5
                   periodSeconds: 10
+                  timeoutSeconds: 5
                 resources:
                   limits:
                     cpu: 250m

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	apiclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -302,6 +303,12 @@ func main() {
 		setupLog.Info("OCSInitialization resource already exists")
 	default:
 		setupLog.Error(err, "failed to create OCSInitialization custom resource")
+		os.Exit(1)
+	}
+
+	// Liveness (/healthz)
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to add a health check")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
- Register /healthz endpoint in main.go
- Add liveness, readiness, and startup probes to manager Deployment

https://issues.redhat.com/browse/RHSTOR-7587

**Tested privat image:**
Test pass on IBM cloud OCP  4.20.0-0.nightly-2025-10-30-114955 
      
1.Create private image
```
export REGISTRY_NAMESPACE=oviner
export IMAGE_TAG=liveness-nov3
make ocs-operator
podman push quay.io/$REGISTRY_NAMESPACE/ocs-operator:$IMAGE_TAG
make ocs-metrics-exporter
podman push quay.io/$REGISTRY_NAMESPACE/ocs-metrics-exporter:$IMAGE_TAG
make operator-bundle
podman push quay.io/$REGISTRY_NAMESPACE/ocs-operator-bundle:$IMAGE_TAG
make operator-catalog
podman push quay.io/$REGISTRY_NAMESPACE/ocs-operator-catalog:$IMAGE_TAG
oc label nodes oviner5-ocs-jt5gb-worker-1-hbd44 cluster.ocs.openshift.io/openshift-storage=''
oc label nodes oviner5-ocs-jt5gb-worker-2-6mv5s cluster.ocs.openshift.io/openshift-storage=''
oc label nodes oviner5-ocs-jt5gb-worker-3-lxg9w cluster.ocs.openshift.io/openshift-storage=''
make install
```

2.Check opertor:
```
$ oc get csv -n openshift-storage 
NAME                                        DISPLAY                            VERSION   REPLACES   PHASE
cephcsi-operator.v4.21.0                    CephCSI operator                   4.21.0               Succeeded
csi-addons.v0.12.0                          CSI Addons                         0.12.0               Succeeded
noobaa-operator.v5.20.0                     NooBaa Operator                    5.20.0               Succeeded
ocs-client-operator.v4.21.0                 OpenShift Data Foundation Client   4.21.0               Succeeded
ocs-operator.v4.21.0                        OpenShift Container Storage        4.21.0               Succeeded
odf-external-snapshotter-operator.v4.20.0   Snapshot Controller                4.20.0               Succeeded
recipe.v0.0.1                               Recipe                             0.0.1                Succeeded
rook-ceph-operator.v4.20.0                  Rook-Ceph                          4.20.0               Succeeded

$ oc get pod -n openshift-storage ocs-operator-7d6d9497df-hdnns -o yaml| grep oviner
    containerImage: quay.io/oviner/ocs-operator:liveness-nov3
      value: quay.io/oviner/ocs-metrics-exporter:liveness-nov3
      value: quay.io/oviner/ocs-operator:liveness-nov3
      value: quay.io/oviner/ocs-operator:liveness-nov3
    image: quay.io/oviner/ocs-operator:liveness-nov3
  nodeName: oviner2-ocs-622qc-worker-3-x2smh
```

3. Inspect current value in the CSV
```
$ oc -n openshift-storage get csv ocs-operator.v4.21.0   -o jsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].livenessProbe.httpGet.path}{"\n"}'
/healthz
```

4. Patch the CSV to force liveness failure
```
$ oc -n openshift-storage patch csv ocs-operator.v4.21.0 --type=json -p='[
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/livenessProbe/httpGet/path","value":"/bad"},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/livenessProbe/initialDelaySeconds","value":5},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/livenessProbe/periodSeconds","value":5},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/livenessProbe/failureThreshold","value":1}
]'
clusterserviceversion.operators.coreos.com/ocs-operator.v4.21.0 patched
```

5. Verify the Deployment picked it up and watch restarts
```
$  oc -n openshift-storage get pod -l name=ocs-operator -w
NAME                           READY   STATUS    RESTARTS     AGE
ocs-operator-7f8fcf75c-s7nj5   0/1     Running   1 (9s ago)   19s
ocs-operator-7f8fcf75c-s7nj5   1/1     Running   1 (10s ago)   20s
ocs-operator-7f8fcf75c-s7nj5   0/1     Running   2 (2s ago)    22s
ocs-operator-7f8fcf75c-s7nj5   1/1     Running   2 (10s ago)   30s
ocs-operator-7f8fcf75c-s7nj5   0/1     Running   3 (2s ago)    32s
ocs-operator-7f8fcf75c-s7nj5   1/1     Running   3 (10s ago)   40s
ocs-operator-7f8fcf75c-s7nj5   0/1     CrashLoopBackOff   3 (1s ago)    41s
```

6. Restore the CSV to the good settings
```
$ oc -n openshift-storage patch csv ocs-operator.v4.21.0 --type=json -p='[
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/livenessProbe/httpGet/path","value":"/healthz"},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/livenessProbe/httpGet/port","value":"healthz"},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/livenessProbe/initialDelaySeconds","value":15},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/livenessProbe/periodSeconds","value":10},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/livenessProbe/failureThreshold","value":3}
]'
clusterserviceversion.operators.coreos.com/ocs-operator.v4.21.0 patched
```

7.Check ocs-operator pod  status
```
$ oc -n openshift-storage get pod -l name=ocs-operator 
NAME                            READY   STATUS    RESTARTS   AGE
ocs-operator-7d6d9497df-wqd5x   1/1     Running   0          101s
```


8.Inspect current readinessProbe in the CSV
```
$ oc -n openshift-storage get csv ocs-operator.v4.21.0 \
  -o jsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].readinessProbe.httpGet.path}{"\n"}'
/readyz


$ oc -n openshift-storage get csv ocs-operator.v4.21.0 \
  -o jsonpath='{.spec.install.spec.deployments[0].spec.template.spec.containers[0].readinessProbe.httpGet.port}{"\n"}'
healthz
```

9. Patch the CSV to force readiness failure:
```
$ oc -n openshift-storage patch csv ocs-operator.v4.21.0 --type=json -p='[
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/readinessProbe/httpGet/path","value":"/bad-ready"},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/readinessProbe/initialDelaySeconds","value":5},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/readinessProbe/periodSeconds","value":5},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/readinessProbe/failureThreshold","value":1}
]'
clusterserviceversion.operators.coreos.com/ocs-operator.v4.21.0 patched

```

10. Verify pod becomes NotReady but does not restart
```
$ oc -n openshift-storage get pod -l name=ocs-operator 
NAME                            READY   STATUS    RESTARTS   AGE
ocs-operator-86d4c9f999-fpb62   0/1     Running   0          2m24s

```

11. Restore readinessProbe to the good settings
```
$ oc -n openshift-storage patch csv ocs-operator.v4.21.0 --type=json -p='[
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/readinessProbe/httpGet/path","value":"/readyz"},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/readinessProbe/httpGet/port","value":"healthz"},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/readinessProbe/initialDelaySeconds","value":5},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/readinessProbe/periodSeconds","value":10},
  {"op":"replace","path":"/spec/install/spec/deployments/0/spec/template/spec/containers/0/readinessProbe/failureThreshold","value":3}
]'
clusterserviceversion.operators.coreos.com/ocs-operator.v4.21.0 patched
```

12.Confirm the pod is Ready again: [take 3 min]
```
$ oc -n openshift-storage get pod -l name=ocs-operator 
NAME                            READY   STATUS    RESTARTS   AGE
ocs-operator-7d6d9497df-qn5l6   1/1     Running   0          17s

```
