### PR TITLE
Allow configurable MON timeout on IBM Cloud

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -277,8 +277,11 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 	}
 
 	if platform == configv1.IBMCloudPlatformType {
-		r.Log.Info("Increasing Mon failover timeout to 15m.", "Platform", platform)
-		cephCluster.Spec.HealthCheck.DaemonHealth.Monitor.Timeout = "15m"
+		healthCheck := sc.Spec.ManagedResources.CephCluster.HealthCheck
+		if healthCheck == nil || healthCheck.DaemonHealth.Monitor.Timeout == "" {
+			r.Log.Info("Setting defaults for Mon failover timeout to 15m.", "Platform", platform)
+			cephCluster.Spec.HealthCheck.DaemonHealth.Monitor.Timeout = "15m"
+		}
 	}
 
 	ipFamily, isDualStack, err := getIPFamilyConfig(r.Client)


### PR DESCRIPTION
**Description:**
This PR updates the IBM Cloud condition to respect the `StorageCluster` CR configuration for MON timeout.

* If no timeout is set in `StorageCluster.spec.managedResources.cephCluster.healthCheck.daemonHealth.monitor.timeout`, the default remains `15m` for IBM Cloud.
* If a timeout is specified, it overrides the IBM Cloud default.

This ensures consistency with the new MON timeout configuration feature introduced in #2940 

Jira Link: https://issues.redhat.com/browse/RHSTOR-7337