### PR TITLE
Add configurable resource limits for kube-rbac-proxy containers

### DIFF
--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -74,6 +74,26 @@ var (
 				"cpu":    resource.MustParse("1"),
 			},
 		},
+		"kube-rbac-proxy-main": {
+			Requests: corev1.ResourceList{
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+			Limits: corev1.ResourceList{
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+		},
+		"kube-rbac-proxy-self": {
+			Requests: corev1.ResourceList{
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+			Limits: corev1.ResourceList{
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+		},
 		"crashcollector": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("50m"),
@@ -266,16 +286,6 @@ var (
 	}
 
 	MonitoringResources = map[string]corev1.ResourceRequirements{
-		"kube-rbac-proxy": {
-			Requests: corev1.ResourceList{
-				"memory": resource.MustParse("30Mi"),
-				"cpu":    resource.MustParse("50m"),
-			},
-			Limits: corev1.ResourceList{
-				"memory": resource.MustParse("30Mi"),
-				"cpu":    resource.MustParse("50m"),
-			},
-		},
 		"alertmanager": {
 			Requests: corev1.ResourceList{
 				"cpu":    resource.MustParse("100m"),

--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -380,7 +380,7 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 				HostNetwork: shouldUseHostNetworking(instance),
 				Containers: []corev1.Container{
 					{
-						Resources: defaults.MonitoringResources["kube-rbac-proxy"],
+						Resources: getDaemonResources("kube-rbac-proxy-main", instance),
 						Name:      "kube-rbac-proxy-main",
 						SecurityContext: &corev1.SecurityContext{
 							Capabilities: &corev1.Capabilities{
@@ -419,7 +419,7 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 						},
 					},
 					{
-						Resources: defaults.MonitoringResources["kube-rbac-proxy"],
+						Resources: getDaemonResources("kube-rbac-proxy-self", instance),
 						Name:      "kube-rbac-proxy-self",
 						SecurityContext: &corev1.SecurityContext{
 							Capabilities: &corev1.Capabilities{

--- a/metrics/deploy/deployment.yaml
+++ b/metrics/deploy/deployment.yaml
@@ -25,10 +25,10 @@ spec:
       containers:
       - resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 40Mi
           requests:
-            cpu: 10m
+            cpu: 50m
             memory: 40Mi
         name: kube-rbac-proxy-main
         securityContext:
@@ -59,10 +59,10 @@ spec:
           mountPath: /etc/kube-rbac-policy
       - resources:
           limits:
-            cpu: 10m
+            cpu: 50m
             memory: 40Mi
           requests:
-            cpu: 10m
+            cpu: 50m
             memory: 40Mi
         name: kube-rbac-proxy-self
         securityContext:

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
@@ -74,6 +74,26 @@ var (
 				"cpu":    resource.MustParse("1"),
 			},
 		},
+		"kube-rbac-proxy-main": {
+			Requests: corev1.ResourceList{
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+			Limits: corev1.ResourceList{
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+		},
+		"kube-rbac-proxy-self": {
+			Requests: corev1.ResourceList{
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+			Limits: corev1.ResourceList{
+				"memory": resource.MustParse("40Mi"),
+				"cpu":    resource.MustParse("50m"),
+			},
+		},
 		"crashcollector": {
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("50m"),
@@ -266,16 +286,6 @@ var (
 	}
 
 	MonitoringResources = map[string]corev1.ResourceRequirements{
-		"kube-rbac-proxy": {
-			Requests: corev1.ResourceList{
-				"memory": resource.MustParse("30Mi"),
-				"cpu":    resource.MustParse("50m"),
-			},
-			Limits: corev1.ResourceList{
-				"memory": resource.MustParse("30Mi"),
-				"cpu":    resource.MustParse("50m"),
-			},
-		},
 		"alertmanager": {
 			Requests: corev1.ResourceList{
 				"cpu":    resource.MustParse("100m"),


### PR DESCRIPTION
The kube-rbac-proxy containers in ocs-metrics-exporter are experiencing OOMKills with hardcoded 30Mi/50m resource limits. Multiple customers in production are affected with containers restarting hundreds of times due to memory pressure.

Allow kube-rbac-proxy resource limits to be configured via StorageCluster.Spec.Resources, falling back to existing defaults when not specified.