### PR TITLE
Enable caching + add new non-admin endpoints to UX backend server

### DIFF
--- a/config/rbac/oauth_proxy_role.yaml
+++ b/config/rbac/oauth_proxy_role.yaml
@@ -10,6 +10,7 @@ rules:
 - apiGroups: ["authorization.k8s.io"]
   resources:
   - subjectaccessreviews
+  - selfsubjectaccessreviews
   verbs: ["create"]
 - apiGroups:
   - storage.k8s.io
@@ -17,3 +18,30 @@ rules:
   - storageclasses
   verbs:
   - create
+  - get
+  - list
+  - watch
+- apiGroups:
+  - objectbucket.io
+  resources:
+  - objectbuckets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ceph.rook.io
+  resources:
+  - cephobjectstores
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ocs.openshift.io
+  resources:
+  - storageclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/controllers/util/csi.go
+++ b/controllers/util/csi.go
@@ -2,10 +2,14 @@ package util
 
 const (
 	StorageClassDriverNamePrefix = "openshift-storage"
-	RbdDriverName                = StorageClassDriverNamePrefix + ".rbd.csi.ceph.com"
-	CephFSDriverName             = StorageClassDriverNamePrefix + ".cephfs.csi.ceph.com"
-	NfsDriverName                = StorageClassDriverNamePrefix + ".nfs.csi.ceph.com"
-	ObcDriverName                = StorageClassDriverNamePrefix + ".ceph.rook.io/bucket"
+	RbdDriverNameSuffix          = ".rbd.csi.ceph.com"
+	CephFSDriverNameSuffix       = ".cephfs.csi.ceph.com"
+	NfsDriverNameSuffix          = ".nfs.csi.ceph.com"
+	ObcDriverNameSuffix           = ".ceph.rook.io/bucket"
+	RbdDriverName                = StorageClassDriverNamePrefix + RbdDriverNameSuffix
+	CephFSDriverName             = StorageClassDriverNamePrefix + CephFSDriverNameSuffix
+	NfsDriverName                = StorageClassDriverNamePrefix + NfsDriverNameSuffix
+	ObcDriverName                = StorageClassDriverNamePrefix + ObcDriverNameSuffix
 )
 
 var (

--- a/controllers/util/noobaa.go
+++ b/controllers/util/noobaa.go
@@ -1,0 +1,6 @@
+package util
+
+const (
+	NoobaaDriverNameSuffix = ".noobaa.io/obc"
+	NoobaaResourceName     = "noobaa"
+)

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -79,7 +79,7 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2025-10-30T10:14:09Z"
+    createdAt: "2025-11-10T08:04:57Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.30.0
@@ -588,6 +588,7 @@ spec:
           - authorization.k8s.io
           resources:
           - subjectaccessreviews
+          - selfsubjectaccessreviews
           verbs:
           - create
         - apiGroups:
@@ -596,6 +597,33 @@ spec:
           - storageclasses
           verbs:
           - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - objectbucket.io
+          resources:
+          - objectbuckets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ceph.rook.io
+          resources:
+          - cephobjectstores
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
+          - storageclusters
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: ux-backend-server
       deployments:
       - name: ocs-operator

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2025-10-30T10:14:09Z"
+    createdAt: "2025-11-10T08:04:57Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",
@@ -607,6 +607,7 @@ spec:
           - authorization.k8s.io
           resources:
           - subjectaccessreviews
+          - selfsubjectaccessreviews
           verbs:
           - create
         - apiGroups:
@@ -615,6 +616,33 @@ spec:
           - storageclasses
           verbs:
           - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - objectbucket.io
+          resources:
+          - objectbuckets
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ceph.rook.io
+          resources:
+          - cephobjectstores
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ocs.openshift.io
+          resources:
+          - storageclusters
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: ux-backend-server
       deployments:
       - name: ocs-operator
@@ -773,7 +801,7 @@ spec:
                 - -tls-key=/etc/tls/private/tls.key
                 - -cookie-secret-file=/etc/proxy/secrets/session_secret
                 - -openshift-service-account=ux-backend-server
-                - -openshift-delegate-urls={"/":{"group":"ocs.openshift.io","resource":"storageclusters","namespace":"openshift-storage","verb":"create"}}
+                - -openshift-delegate-urls={"/":{"group":"ocs.openshift.io","resource":"storageclusters","namespace":"openshift-storage","verb":"create"},"/info/":{"group":"authorization.k8s.io","resource":"selfsubjectaccessreviews","verb":"create"}}
                 - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
                 image: quay.io/openshift/origin-oauth-proxy:4.20.0
                 imagePullPolicy: IfNotPresent

--- a/deploy/ocs-operator/manifests/ux_backend_role.yaml
+++ b/deploy/ocs-operator/manifests/ux_backend_role.yaml
@@ -28,3 +28,11 @@ rules:
   - cephblockpools
   verbs:
   - create
+- apiGroups:
+  - noobaa.io
+  resources:
+  - noobaas
+  verbs:
+  - get
+  - list
+  - watch

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/csi.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/csi.go
@@ -2,10 +2,14 @@ package util
 
 const (
 	StorageClassDriverNamePrefix = "openshift-storage"
-	RbdDriverName                = StorageClassDriverNamePrefix + ".rbd.csi.ceph.com"
-	CephFSDriverName             = StorageClassDriverNamePrefix + ".cephfs.csi.ceph.com"
-	NfsDriverName                = StorageClassDriverNamePrefix + ".nfs.csi.ceph.com"
-	ObcDriverName                = StorageClassDriverNamePrefix + ".ceph.rook.io/bucket"
+	RbdDriverNameSuffix          = ".rbd.csi.ceph.com"
+	CephFSDriverNameSuffix       = ".cephfs.csi.ceph.com"
+	NfsDriverNameSuffix          = ".nfs.csi.ceph.com"
+	ObcDriverNameSuffix           = ".ceph.rook.io/bucket"
+	RbdDriverName                = StorageClassDriverNamePrefix + RbdDriverNameSuffix
+	CephFSDriverName             = StorageClassDriverNamePrefix + CephFSDriverNameSuffix
+	NfsDriverName                = StorageClassDriverNamePrefix + NfsDriverNameSuffix
+	ObcDriverName                = StorageClassDriverNamePrefix + ObcDriverNameSuffix
 )
 
 var (

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/noobaa.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/noobaa.go
@@ -1,0 +1,6 @@
+package util
+
+const (
+	NoobaaDriverNameSuffix = ".noobaa.io/obc"
+	NoobaaResourceName     = "noobaa"
+)

--- a/rbac/ux_backend_role.yaml
+++ b/rbac/ux_backend_role.yaml
@@ -28,3 +28,11 @@ rules:
   - cephblockpools
   verbs:
   - create
+- apiGroups:
+  - noobaa.io
+  resources:
+  - noobaas
+  verbs:
+  - get
+  - list
+  - watch

--- a/services/ux-backend/handlers/bucket/handler.go
+++ b/services/ux-backend/handlers/bucket/handler.go
@@ -1,0 +1,91 @@
+package bucket
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers"
+
+	nbv1a1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	uxutil "github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/util"
+	"k8s.io/klog/v2"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	creationMethodOBC = "obc"
+	creationMethodS3  = "s3"
+)
+
+func HandleMessage(w http.ResponseWriter, r *http.Request, client ctrlclient.Client) {
+	switch r.Method {
+	case "GET":
+		handleGet(w, r, client)
+	default:
+		handleUnsupportedMethod(w, r)
+	}
+}
+
+// request format: /info/bucket/<bucket-name>
+func handleGet(w http.ResponseWriter, r *http.Request, client ctrlclient.Client) {
+	bucketName := r.PathValue("name")
+	if bucketName == "" {
+		klog.Errorf("bucket name is required in path")
+		http.Error(w, "bucket name is required in path", http.StatusBadRequest)
+		return
+	}
+
+	creationMethod, err := getBucketCreationMethod(r.Context(), client, bucketName)
+	if err != nil {
+		klog.Errorf("failed to get bucket creation method: %v", err)
+		http.Error(w, fmt.Sprintf("Failed to get bucket creation method: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	result := map[string]string{
+		"createdVia": creationMethod,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		klog.Errorf("failed to encode response: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+}
+
+func getBucketCreationMethod(ctx context.Context, client ctrlclient.Client, bucketName string) (string, error) {
+	klog.Infof("Getting creation method for bucket '%s'", bucketName)
+	
+	objectBucketList := &nbv1a1.ObjectBucketList{}
+	if err := client.List(ctx, objectBucketList, ctrlclient.MatchingFields{uxutil.IndexBucketName: bucketName}, ctrlclient.Limit(1)); err != nil {
+		return "", fmt.Errorf("failed to list ObjectBuckets by bucketName index: %w", err)
+	}
+	
+	if len(objectBucketList.Items) > 0 {
+		klog.Infof("Found ObjectBucket '%s' with bucket name '%s'", objectBucketList.Items[0].Name, bucketName)
+		return creationMethodOBC, nil
+	}
+	
+	// There are two ways to create a bucket:
+	// 1. Either via OBC (ObjectBucketClaim) CR
+	// 2. Or via S3 endpoint directly
+	// This endpoint is only called on existing buckets, so we assume S3 creation if no OBC is found.
+	klog.Infof("No ObjectBucket found with bucket name '%s', assuming S3 creation", bucketName)
+	return creationMethodS3, nil
+}
+
+func handleUnsupportedMethod(w http.ResponseWriter, r *http.Request) {
+	klog.Infof("Only GET method should be used for this endpoint %s", r.URL.Path)
+	w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+	w.Header().Set("Allow", "GET")
+	w.WriteHeader(http.StatusMethodNotAllowed)
+
+	if _, err := w.Write([]byte(fmt.Sprintf("Unsupported method: %s", r.Method))); err != nil {
+		klog.Errorf("failed to write data to response writer: %v", err)
+	}
+}

--- a/services/ux-backend/handlers/featureflags/handler.go
+++ b/services/ux-backend/handlers/featureflags/handler.go
@@ -1,0 +1,170 @@
+package featureflags
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers"
+
+	nbv1a1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/klog/v2"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	flagNoobaa string = "noobaa"
+	flagRGW    string = "rgw"
+)
+
+func HandleMessage(w http.ResponseWriter, r *http.Request, client ctrlclient.Client, namespace string) {
+	switch r.Method {
+	case "GET":
+		handleGet(w, r, client, namespace)
+	default:
+		handleUnsupportedMethod(w, r)
+	}
+}
+
+// request format (comma-separated flags): /info/featureflags?flags=noobaa,rgw
+func handleGet(w http.ResponseWriter, r *http.Request, client ctrlclient.Client, namespace string) {
+	flagsQuery := r.URL.Query().Get("flags")
+	if flagsQuery == "" {
+		klog.Errorf("flags parameter is required")
+		http.Error(w, "flags parameter is required", http.StatusBadRequest)
+		return
+	}
+
+	flagNames := strings.Split(flagsQuery, ",")
+	for i, flag := range flagNames {
+		flagNames[i] = strings.TrimSpace(flag)
+	}
+
+	type flagResult struct {
+		Value bool   `json:"value"`
+		Error string `json:"error,omitempty"`
+	}
+
+	result := make(map[string]flagResult)
+	for _, flagName := range flagNames {
+		switch flagName {
+		case flagNoobaa:
+			value, err := checkNoobaaFlag(r.Context(), client, namespace)
+			if err != nil {
+				klog.Errorf("failed to check noobaa flag: %v", err)
+				result[flagName] = flagResult{Value: false, Error: err.Error()}
+			} else {
+				result[flagName] = flagResult{Value: value}
+			}
+		case flagRGW:
+			value, err := checkRGWFlag(r.Context(), client, namespace)
+			if err != nil {
+				klog.Errorf("failed to check rgw flag: %v", err)
+				result[flagName] = flagResult{Value: false, Error: err.Error()}
+			} else {
+				result[flagName] = flagResult{Value: value}
+			}
+		default:
+			result[flagName] = flagResult{Value: false, Error: "unsupported flag"}
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	allFlagsFailed := true
+	for _, res := range result {
+		if res.Error == "" {
+			allFlagsFailed = false
+			break
+		}
+	}
+
+	// if all flags failed, returning "500" as response
+	// if some flags succeeded, returning "200" with partial results and error details
+	if allFlagsFailed && len(result) > 0 {
+		w.WriteHeader(http.StatusInternalServerError)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		klog.Errorf("failed to encode response: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+}
+
+func checkNoobaaFlag(ctx context.Context, client ctrlclient.Client, namespace string) (bool, error) {
+	klog.Info("Checking NooBaa CR existence in namespace:", namespace)
+	noobaa := &nbv1a1.NooBaa{}
+	if err := client.Get(ctx, ctrlclient.ObjectKey{Name: util.NoobaaResourceName, Namespace: namespace}, noobaa); err != nil {
+		if ctrlclient.IgnoreNotFound(err) == nil {
+			klog.Info("No NooBaa CR found in namespace:", namespace)
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to get NooBaa CR: %w", err)
+	}
+	klog.Info("Found NooBaa CR in namespace:", namespace)
+
+	klog.Info("Checking for NooBaa StorageClass existence")
+	storageClassList := &storagev1.StorageClassList{}
+	if err := client.List(ctx, storageClassList); err != nil {
+		return false, fmt.Errorf("failed to list StorageClasses: %w", err)
+	}
+
+	for _, sc := range storageClassList.Items {
+		if strings.HasSuffix(sc.Provisioner, util.NoobaaDriverNameSuffix) {
+			klog.Info("Found NooBaa StorageClass:", sc.Name, "with provisioner:", sc.Provisioner)
+			return true, nil
+		}
+	}
+
+	klog.Info("No NooBaa StorageClasses found")
+	return false, nil
+}
+
+func checkRGWFlag(ctx context.Context, client ctrlclient.Client, namespace string) (bool, error) {
+	klog.Info("Checking CephObjectStore existence")
+	cephObjectStoreList := &cephv1.CephObjectStoreList{}
+	if err := client.List(ctx, cephObjectStoreList, ctrlclient.Limit(1)); err != nil {
+		return false, fmt.Errorf("failed to list CephObjectStores: %w", err)
+	}
+
+	if len(cephObjectStoreList.Items) == 0 {
+		klog.Info("No CephObjectStores found")
+		return false, nil
+	}
+	klog.Info("Found CephObjectStore")
+
+	klog.Info("Checking for RGW StorageClass existence")
+	storageClassList := &storagev1.StorageClassList{}
+	if err := client.List(ctx, storageClassList); err != nil {
+		return false, fmt.Errorf("failed to list StorageClasses: %w", err)
+	}
+
+	for _, sc := range storageClassList.Items {
+		if strings.HasSuffix(sc.Provisioner, util.ObcDriverNameSuffix) {
+			klog.Info("Found RGW StorageClass:", sc.Name, "with provisioner:", sc.Provisioner)
+			return true, nil
+		}
+	}
+
+	klog.Info("No RGW StorageClasses found")
+	return false, nil
+}
+
+func handleUnsupportedMethod(w http.ResponseWriter, r *http.Request) {
+	klog.Infof("Only GET method should be used for this endpoint %s", r.URL.Path)
+	w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+	w.Header().Set("Allow", "GET")
+	w.WriteHeader(http.StatusMethodNotAllowed)
+
+	if _, err := w.Write([]byte(fmt.Sprintf("Unsupported method: %s", r.Method))); err != nil {
+		klog.Errorf("failed to write data to response writer: %v", err)
+	}
+}

--- a/services/ux-backend/handlers/storages/handler.go
+++ b/services/ux-backend/handlers/storages/handler.go
@@ -1,0 +1,147 @@
+package storages
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers"
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+
+	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"k8s.io/klog/v2"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	deploymentTypeInternal = "internal"
+	deploymentTypeExternal = "external"
+)
+
+func HandleMessage(w http.ResponseWriter, r *http.Request, client ctrlclient.Client, namespace string) {
+	switch r.Method {
+	case "GET":
+		handleGet(w, r, client, namespace)
+	default:
+		handleUnsupportedMethod(w, r)
+	}
+}
+
+// request format: /info/storages
+func handleGet(w http.ResponseWriter, r *http.Request, client ctrlclient.Client, namespace string) {
+	result, err := getStorageInfo(r.Context(), client, namespace)
+	if err != nil {
+		klog.Errorf("failed to get storage info: %v", err)
+		http.Error(w, fmt.Sprintf("Failed to get storage info: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	if err := json.NewEncoder(w).Encode(result); err != nil {
+		klog.Errorf("failed to encode response: %v", err)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+}
+
+type storageInfoResponse struct {
+	OperatorNamespace string                                   `json:"operatorNamespace"`
+	ClusterNamespaces map[string]clusterNamespaceStorageInfo `json:"clusterNamespaces"`
+}
+
+type clusterNamespaceStorageInfo struct {
+	StorageClusterName string `json:"storageClusterName"`
+	DeploymentType     string `json:"deploymentType"`
+	RgwSecureEndpoint  string `json:"rgwSecureEndpoint,omitempty"`
+}
+
+func getStorageInfo(ctx context.Context, client ctrlclient.Client, namespace string) (*storageInfoResponse, error) {
+	klog.Info("Getting storage info")
+
+	storageClusterList := &ocsv1.StorageClusterList{}
+	if err := client.List(ctx, storageClusterList); err != nil {
+		return nil, fmt.Errorf("failed to list StorageClusters: %w", err)
+	}
+
+	cephObjectStoreList := &cephv1.CephObjectStoreList{}
+	if err := client.List(ctx, cephObjectStoreList); err != nil {
+		return nil, fmt.Errorf("failed to list CephObjectStores: %w", err)
+	}
+
+	cosByNamespace := make(map[string]*cephv1.CephObjectStore)
+	for i := range cephObjectStoreList.Items {
+		cos := &cephObjectStoreList.Items[i]
+		cosNamespace := cos.Namespace
+		if _, exists := cosByNamespace[cosNamespace]; !exists {
+			cosByNamespace[cosNamespace] = cos
+		}
+	}
+
+	result := &storageInfoResponse{
+		OperatorNamespace: namespace,
+		ClusterNamespaces: make(map[string]clusterNamespaceStorageInfo),
+	}
+
+	for _, sc := range storageClusterList.Items {
+		if sc.Status.Phase == util.PhaseIgnored {
+			continue
+		}
+
+		scNamespace := sc.Namespace
+		namespaceInfo := clusterNamespaceStorageInfo{
+			StorageClusterName: sc.Name,
+			DeploymentType:     getDeploymentType(&sc),
+		}
+
+		if cos, exists := cosByNamespace[scNamespace]; exists {
+			rgwEndpoint := getRgwSecureEndpoint(cos)
+			if rgwEndpoint != "" {
+				namespaceInfo.RgwSecureEndpoint = rgwEndpoint
+			}
+		}
+
+		result.ClusterNamespaces[scNamespace] = namespaceInfo
+	}
+
+	return result, nil
+}
+
+func getDeploymentType(sc *ocsv1.StorageCluster) string {
+	if sc.Spec.ExternalStorage.Enable {
+		return deploymentTypeExternal
+	}
+
+	return deploymentTypeInternal
+}
+
+func getRgwSecureEndpoint(cos *cephv1.CephObjectStore) string {
+	if cos.Status == nil {
+		return ""
+	}
+
+	if endpoint := cos.Status.Info["secureEndpoint"]; endpoint != "" {
+		return endpoint
+	}
+
+	// fallback
+	if len(cos.Status.Endpoints.Secure) > 0 {
+		return cos.Status.Endpoints.Secure[0]
+	}
+
+	return ""
+}
+
+func handleUnsupportedMethod(w http.ResponseWriter, r *http.Request) {
+	klog.Infof("Only GET method should be used for this endpoint %s", r.URL.Path)
+	w.Header().Set("Content-Type", handlers.ContentTypeTextPlain)
+	w.Header().Set("Allow", "GET")
+	w.WriteHeader(http.StatusMethodNotAllowed)
+
+	if _, err := w.Write([]byte(fmt.Sprintf("Unsupported method: %s", r.Method))); err != nil {
+		klog.Errorf("failed to write data to response writer: %v", err)
+	}
+}

--- a/services/ux-backend/main.go
+++ b/services/ux-backend/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -9,14 +10,24 @@ import (
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/controllers/util"
+	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers/bucket"
 	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers/expandstorage"
+	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers/featureflags"
 	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers/onboarding/peertokens"
+	"github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/handlers/storages"
+	uxutil "github.com/red-hat-storage/ocs-operator/v4/services/ux-backend/util"
+
+	noobaaapis "github.com/noobaa/noobaa-operator/v5/pkg/apis"
+	nbv1a1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	storagev1 "k8s.io/api/storage/v1"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type serverConfig struct {
@@ -48,8 +59,11 @@ func loadAndValidateServerConfig() (*serverConfig, error) {
 }
 
 func main() {
-
 	klog.Info("Starting ux backend server")
+
+	ctrlruntimelog.SetLogger(klog.NewKlogr())
+
+	ctx := context.Background()
 
 	config, err := loadAndValidateServerConfig()
 	if err != nil {
@@ -73,11 +87,60 @@ func main() {
 	if err := storagev1.AddToScheme(scheme); err != nil {
 		klog.Exitf("failed to add storagev1 to scheme. %v", err)
 	}
-
-	cl, err := util.NewK8sClient(scheme)
-	if err != nil {
-		klog.Exitf("failed to create kube client: %v", err)
+	if err := noobaaapis.AddToScheme(scheme); err != nil {
+		klog.Exitf("failed to add noobaaapis to scheme. %v", err)
 	}
+
+	klog.Info("Setting up cached client for the ux backend server")
+	clientConfig, err := ctrlconfig.GetConfig()
+	if err != nil {
+		klog.Exitf("failed to get cached client config: %v", err)
+	}
+
+	cache, err := ctrlcache.New(clientConfig, ctrlcache.Options{
+		Scheme: scheme,
+		DefaultNamespaces: map[string]ctrlcache.Config{
+			namespace:                    {},
+			"openshift-storage-extended": {},
+		},
+	})
+	if err != nil {
+		klog.Exitf("failed to create cache: %v", err)
+	}
+
+	if err := cache.IndexField(ctx, &nbv1a1.ObjectBucket{}, uxutil.IndexBucketName, func(obj client.Object) []string {
+		ob := obj.(*nbv1a1.ObjectBucket)
+		if ob.Spec.Endpoint != nil {
+			return []string{ob.Spec.Endpoint.BucketName}
+		}
+		return []string{}
+	}); err != nil {
+		klog.Exitf("failed to add bucketName index for ObjectBuckets: %v", err)
+	}
+
+	cl, err := client.New(clientConfig, client.Options{
+		Scheme: scheme,
+		Cache: &client.CacheOptions{
+			Reader: cache,
+		},
+	})
+	if err != nil {
+		klog.Exitf("failed to create cached kube client: %v", err)
+	}
+
+	klog.Info("Starting cache for ux backend server")
+	go func() {
+		if err := cache.Start(ctx); err != nil {
+			klog.Errorf("failed to start cache: %v", err)
+			os.Exit(1)
+		}
+	}()
+
+	if !cache.WaitForCacheSync(ctx) {
+		panic("cache did not sync")
+	}
+
+	// Authenticated + Authorized endpoints (require both authentication and authorization)
 
 	http.HandleFunc("/onboarding/peer-tokens", func(w http.ResponseWriter, r *http.Request) {
 		peertokens.HandleMessage(w, r, config.tokenLifetimeInHours, cl, namespace)
@@ -85,6 +148,20 @@ func main() {
 
 	http.HandleFunc("/expandstorage", func(w http.ResponseWriter, r *http.Request) {
 		expandstorage.HandleMessage(w, r, cl, namespace)
+	})
+
+	// Authenticated endpoints (require authentication but not authorization)
+
+	http.HandleFunc("/info/featureflags", func(w http.ResponseWriter, r *http.Request) {
+		featureflags.HandleMessage(w, r, cl, namespace)
+	})
+
+	http.HandleFunc("/info/bucket/{name}", func(w http.ResponseWriter, r *http.Request) {
+		bucket.HandleMessage(w, r, cl)
+	})
+
+	http.HandleFunc("/info/storages", func(w http.ResponseWriter, r *http.Request) {
+		storages.HandleMessage(w, r, cl, namespace)
 	})
 
 	klog.Info("ux backend server listening on port ", config.listenPort)

--- a/services/ux-backend/util/const.go
+++ b/services/ux-backend/util/const.go
@@ -1,0 +1,5 @@
+package util
+
+const (
+	IndexBucketName = "index:bucketName"
+)

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -737,7 +737,7 @@ func getUXBackendServerDeployment() appsv1.DeploymentSpec {
 							"-tls-key=/etc/tls/private/tls.key",
 							"-cookie-secret-file=/etc/proxy/secrets/session_secret",
 							"-openshift-service-account=ux-backend-server",
-							`-openshift-delegate-urls={"/":{"group":"ocs.openshift.io","resource":"storageclusters","namespace":"openshift-storage","verb":"create"}}`,
+							`-openshift-delegate-urls={"/":{"group":"ocs.openshift.io","resource":"storageclusters","namespace":"openshift-storage","verb":"create"},"/info/":{"group":"authorization.k8s.io","resource":"selfsubjectaccessreviews","verb":"create"}}`,
 							"-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"},
 						Ports: []corev1.ContainerPort{
 							{


### PR DESCRIPTION
https://issues.redhat.com/browse/RHSTOR-7965
https://issues.redhat.com/browse/RHSTOR-7970
https://issues.redhat.com/browse/RHSTOR-8003

### Introduced Changes:

- Segregated 2 paths for OAuth Proxy:
   - **"/":** (Default) Only authenticated + authorized users allowed. This path is needed for admin user APIs.
   - **"/info/":** Only authenticated users allowed (no authorization). This path is needed for any OpenShift user (admin or non-admin) APIs.

- Enabled cached client:
   - `DefaultNamespaces` set to watch `openshift-storage` and `openshift-storage-extended` only.
   - Indexing (cluster-scoped resources).
 
- Added 3 new endpoints to "/info/" path:
   - **"/info/featureflags?flags=noobaa,rgw":**
     - Enable/Disable (or Show/Hide) features on UI based on flags.
     - Will be used globally by UI (irrespective of user type or which page user navigate to).
     - Faster & lightweight (less response size, we don't need all the info, we only need to know the subset).
   - **"/info/bucket/\<bucket-name\>":**
     - Determine whether a S3 bucket (NooBaa/RGW) is created via OBC or directly via S3 API.
     - Specific non-admin only use case for now.
   - **"/info/storages":**
     - Comprehensive namespace-wise cluster state.
     - Specific non-admin only use case for now. Also, only called when/if user go to a specific UI page (local usage), so only needed sometimes optionally.
     - **Comparatively** slower and comprehensive (we need all the information for UI to make any decision, so response is **relatively** bigger).

### Testing (endpoint):
```
$ curl -k -H "Authorization: Bearer <ADMIN_USER>" https://ux-backend-proxy.openshift
-storage.svc.cluster.local:8888/info/featureflags?flags=noobaa,rgw,fakeFlag

>> {"fakeFlag":{"value":false,"error":"unsupported flag"},"noobaa":{"value":true},"rgw":{"value":false}}
```

```
$ curl -k -H "Authorization: Bearer <NON_ADMIN_USER>" https://ux-backend-proxy.openshift
-storage.svc.cluster.local:8888/info/featureflags?flags=noobaa,rgw,fakeFlag

>> {"fakeFlag":{"value":false,"error":"unsupported flag"},"noobaa":{"value":true},"rgw":{"value":false}}
```

```
$ curl -k -H "Authorization: Bearer <ADMIN_USER>" https://ux-backend-proxy.openshift
-storage.svc.cluster.local:8888/info/bucket/test-bucket

>> {"createdVia":"obc"}
```

```
$ curl -k -H "Authorization: Bearer <ADMIN_USER>" https://ux-backend-proxy.openshift
-storage.svc.cluster.local:8888/info/bucket/test-e60c8369-b6d9-4e84-bf2d-89cae86cbafd

>> {"createdVia":"s3"}
```

```
$ curl -k -H "Authorization: Bearer <NON_ADMIN_USER>" https://ux-backend-proxy.openshift
-storage.svc.cluster.local:8888/info/bucket/test-e60c8369-b6d9-4e84-bf2d-89cae86cbafd

>> {"createdVia":"s3"}
```

```
$ curl -v -k -H "Authorization: Bearer <FAKE_USER>" https://ux-backend-proxy.o
penshift-storage.svc.cluster.local:8888/info/featureflags?flags=noobaa,rgw,fakeFlag

>> HTTP/1.1 403 Forbidden
```

```
$ curl -v -k -H "Authorization: Bearer <FAKE_USER>" https://ux-backend-proxy.o
penshift-storage.svc.cluster.local:8888/info/bucket/test-bucket

>> HTTP/1.1 403 Forbidden
```

```
$ curl -v -k -H "Authorization: Bearer <NON_ADMIN_USER>" https://ux-backend-proxy.o
penshift-storage.svc.cluster.local:8888/info/storages

>> {"operatorNamespace":"openshift-storage","clusterNamespaces":{"openshift-storage":{"storageClusterName":"test","deploymentType":"internal"}}}
```

```
$ curl -v -k -H "Authorization: Bearer <NON_ADMIN_USER>" https://ux-backend-proxy.o
penshift-storage.svc.cluster.local:8888/info/storages

>> {"operatorNamespace":"openshift-storage","clusterNamespaces":{"openshift-storage":{"storageClusterName":"test","deploymentType":"internal"}}}
```

### Testing (cache):

First request - slower (populates cache)
```
{"operatorNamespace":"openshift-storage","clusterNamespaces":{"openshift-storage":{"storageClusterName":"test","deploymentType":"internal"}}}

real    0m0.459s
user    0m0.009s
sys     0m0.006s
```

Subsequent requests - faster (cache exists)
```
{"operatorNamespace":"openshift-storage","clusterNamespaces":{"openshift-storage":{"storageClusterName":"test-new","deploymentType":"internal"}}}

real    0m0.023s
user    0m0.010s
sys     0m0.004s
```