### PR TITLE
DFBUGS-4462: [release-4.20] Make it possible to clear target size ratio on ocs created pools

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -214,6 +214,9 @@ type ManageCephCluster struct {
 	// CleanupPolicy defines the cleanup policy for the Rook Ceph cluster.
 	// +optional
 	CleanupPolicy *rookCephv1.CleanupPolicySpec `json:"cleanupPolicy,omitempty"`
+
+	// If set to true, ocs-operator will not set the default target size ratio for the data pools it creates.
+	ClearDefaultTargetSizeRatio bool `json:"clearDefaultTargetSizeRatio,omitempty"`
 }
 
 // ManageCephConfig defines how to reconcile the Ceph configuration

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -1023,6 +1023,10 @@ spec:
                               was reinstalled but OSD disk still contains the metadata from previous ceph cluster.
                             type: boolean
                         type: object
+                      clearDefaultTargetSizeRatio:
+                        description: If set to true, ocs-operator will not set the
+                          default target size ratio for the data pools it creates.
+                        type: boolean
                       continueUpgradeAfterChecksEvenIfNotHealthy:
                         description: Whether or not continue if PGs are not clean
                           during an upgrade

--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -1505,7 +1505,7 @@ func setDefaultDataPoolSpec(poolSpec *rookCephv1.PoolSpec, sc *ocsv1.StorageClus
 		if poolSpec.Replicated.ReplicasPerFailureDomain == 0 || arbiterEnabled(sc) {
 			poolSpec.Replicated.ReplicasPerFailureDomain = defaultReplicatedSpec.ReplicasPerFailureDomain
 		}
-		if poolSpec.Replicated.TargetSizeRatio == 0.0 {
+		if poolSpec.Replicated.TargetSizeRatio == 0.0 && !sc.Spec.ManagedResources.CephCluster.ClearDefaultTargetSizeRatio {
 			poolSpec.Replicated.TargetSizeRatio = defaultReplicatedSpec.TargetSizeRatio
 		}
 	}

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -1023,6 +1023,10 @@ spec:
                               was reinstalled but OSD disk still contains the metadata from previous ceph cluster.
                             type: boolean
                         type: object
+                      clearDefaultTargetSizeRatio:
+                        description: If set to true, ocs-operator will not set the
+                          default target size ratio for the data pools it creates.
+                        type: boolean
                       continueUpgradeAfterChecksEvenIfNotHealthy:
                         description: Whether or not continue if PGs are not clean
                           during an upgrade

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -1025,6 +1025,10 @@ spec:
                               was reinstalled but OSD disk still contains the metadata from previous ceph cluster.
                             type: boolean
                         type: object
+                      clearDefaultTargetSizeRatio:
+                        description: If set to true, ocs-operator will not set the
+                          default target size ratio for the data pools it creates.
+                        type: boolean
                       continueUpgradeAfterChecksEvenIfNotHealthy:
                         description: Whether or not continue if PGs are not clean
                           during an upgrade

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -214,6 +214,9 @@ type ManageCephCluster struct {
 	// CleanupPolicy defines the cleanup policy for the Rook Ceph cluster.
 	// +optional
 	CleanupPolicy *rookCephv1.CleanupPolicySpec `json:"cleanupPolicy,omitempty"`
+
+	// If set to true, ocs-operator will not set the default target size ratio for the data pools it creates.
+	ClearDefaultTargetSizeRatio bool `json:"clearDefaultTargetSizeRatio,omitempty"`
 }
 
 // ManageCephConfig defines how to reconcile the Ceph configuration

--- a/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
+++ b/vendor/github.com/red-hat-storage/ocs-operator/api/v4/v1/storagecluster_types.go
@@ -214,6 +214,9 @@ type ManageCephCluster struct {
 	// CleanupPolicy defines the cleanup policy for the Rook Ceph cluster.
 	// +optional
 	CleanupPolicy *rookCephv1.CleanupPolicySpec `json:"cleanupPolicy,omitempty"`
+
+	// If set to true, ocs-operator will not set the default target size ratio for the data pools it creates.
+	ClearDefaultTargetSizeRatio bool `json:"clearDefaultTargetSizeRatio,omitempty"`
 }
 
 // ManageCephConfig defines how to reconcile the Ceph configuration


### PR DESCRIPTION
Currently until 4.20 ocs operator applies a target size ratio of 0.49 on all the data pools it creates. Although possible to specify a diff ratio but it's not possible for a user to not specify any ratio if they want. We have seen that as the auto scaler has evolved having the target size ratio is creating PG scaling issues and not having any target size ratio actually works better. But as removing the target size ratio completely is too big of a change we are giving an option to make it possible to omit/remove the target size ratio from the pools if a user wants. This will help support team quickly address PG scaling related issues.