### PR TITLE
DFBUGS-4268: [release-4.19] Skip adding default node affinity for Noobaa standalone or external mode

### DIFF
--- a/controllers/storagecluster/noobaa_system_reconciler.go
+++ b/controllers/storagecluster/noobaa_system_reconciler.go
@@ -179,14 +179,7 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 	placement := getPlacement(sc, component)
 
 	nb.Spec.Tolerations = placement.Tolerations
-
-	if !r.IsNoobaaStandalone || ok {
-		// Add affinity if not in noobaa-standalone mode or if placement is specified
-		nb.Spec.Affinity = &corev1.Affinity{NodeAffinity: placement.NodeAffinity}
-	} else if nb.Spec.Affinity != nil {
-		// Clear the affinity if it was set previously to handle upgrades
-		nb.Spec.Affinity = nil
-	}
+	nb.Spec.Affinity = &corev1.Affinity{NodeAffinity: placement.NodeAffinity}
 
 	nb.Spec.Image = &r.images.NooBaaCore
 

--- a/controllers/storagecluster/placement.go
+++ b/controllers/storagecluster/placement.go
@@ -73,9 +73,14 @@ func getPlacement(sc *ocsv1.StorageCluster, component string) rookCephv1.Placeme
 	// StorageCluster has no label selector, set the default node
 	// affinity.
 	if placement.NodeAffinity == nil && sc.Spec.LabelSelector == nil {
-		// Don't add node affinity again for these rook-ceph daemons as it is already added via the "all" key
-		if component != "mgr" && component != "mon" && component != "osd" && component != "osd-prepare" {
-			placement.NodeAffinity = defaults.DefaultNodeAffinity
+		// In noobaa-standalone mode or external mode the default ocs labels are not added to the nodes
+		// so we should not add the default ocs node affinity for these modes
+		if (sc.Spec.MultiCloudGateway == nil || ReconcileStrategy(sc.Spec.MultiCloudGateway.ReconcileStrategy) != ReconcileStrategyStandalone) &&
+			!sc.Spec.ExternalStorage.Enable {
+			// Don't add node affinity again for these rook-ceph daemons as it is already added via the "all" key
+			if component != "mgr" && component != "mon" && component != "osd" && component != "osd-prepare" {
+				placement.NodeAffinity = defaults.DefaultNodeAffinity
+			}
 		}
 	}
 


### PR DESCRIPTION
In noobaa-standalone mode or external mode, the default ocs labels are not added to the nodes. So we should not add the default ocs node affinity for these modes.
manual cherry-pick of https://github.com/red-hat-storage/ocs-operator/pull/3512