### PR TITLE
metrics: fix lock contention during PV cache refresh

### DIFF
--- a/metrics/internal/cache/pv_test.go
+++ b/metrics/internal/cache/pv_test.go
@@ -44,6 +44,9 @@ var _ = Describe("PersistentVolume Cache", func() {
 		pvStore.getNodeNameForPVFn = func(pv *corev1.PersistentVolume, kubeClient kubernetes.Interface) (string, error) {
 			return "node-for-valid-pv", nil
 		}
+		pvStore.runCephRBDChildrenCountFn = func(config *cephMonitorConfig, pool, namespace, image string) (int, error) {
+			return 0, nil
+		}
 
 		When("PV is missing required fields", func() {
 			It("should not add the PV to cache", func() {


### PR DESCRIPTION
- Move slow Ceph CLI operations outside mutex lock to prevent blocking metric collectors during cache refresh
- Previously the lock was held for up to 3 minutes with 100+ PVs, causing `/metrics` endpoint timeouts
- Refactored `Add()` and `Resync()` to prepare data outside lock, then apply atomically

Fixes: https://issues.redhat.com/browse/DFBUGS-4988