### PR TITLE
Changing the maintenance mode indicator

### DIFF
--- a/internal/controller/mirroring/mirroring_controller.go
+++ b/internal/controller/mirroring/mirroring_controller.go
@@ -361,6 +361,24 @@ func (r *MirroringReconciler) reconcileRbdMirror(clientMappingConfig *corev1.Con
 		}
 	}
 
+	annotations := storageCluster.GetAnnotations()
+	if maintenanceModeRequested {
+		if util.AddAnnotation(storageCluster, util.InMaintenanceModeAnnotation, "true") {
+			r.log.Info("Adding maintenance mode annotation to StorageCluster", "StorageCluster", storageCluster.Name)
+			if err := r.update(storageCluster); err != nil {
+				r.log.Error(err, "failed to add maintenance mode annotation to StorageCluster", "StorageCluster", storageCluster.Name)
+				return true
+			}
+		}
+	} else if _, exists := annotations[util.InMaintenanceModeAnnotation]; exists {
+		r.log.Info("Removing maintenance mode annotation from StorageCluster", "StorageCluster", storageCluster.Name)
+		delete(annotations, util.InMaintenanceModeAnnotation)
+		if err := r.update(storageCluster); err != nil {
+			r.log.Error(err, "failed to remove maintenance mode annotation from StorageCluster", "StorageCluster", storageCluster.Name)
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/pkg/util/k8sutil.go
+++ b/pkg/util/k8sutil.go
@@ -66,6 +66,7 @@ const (
 	ForbidMirroringLabel                   = "ocs.openshift.io/forbid-mirroring"
 	BlockPoolMirroringTargetIDAnnotation   = "ocs.openshift.io/mirroring-target-id"
 	RequestMaintenanceModeAnnotation       = "ocs.openshift.io/request-maintenance-mode"
+	InMaintenanceModeAnnotation            = "ocs.openshift.io/in-maintenance-mode"
 	CephRBDMirrorName                      = "cephrbdmirror"
 	OcsClientTimeout                       = 10 * time.Second
 	StorageClientMappingConfigName         = "storage-client-mapping"

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -1244,15 +1244,15 @@ func (s *OCSProviderServer) GetBlockPoolsInfo(ctx context.Context, req *pb.Block
 }
 
 func (s *OCSProviderServer) isSystemInMaintenanceMode(ctx context.Context) (bool, error) {
-	// found - false, not found - true
-	cephRBDMirrors := &rookCephv1.CephRBDMirror{}
-	cephRBDMirrors.Name = util.CephRBDMirrorName
-	cephRBDMirrors.Namespace = s.namespace
-	err := s.client.Get(ctx, client.ObjectKeyFromObject(cephRBDMirrors), cephRBDMirrors)
-	if client.IgnoreNotFound(err) != nil {
+	storageCluster, err := util.GetStorageClusterInNamespace(ctx, s.client, s.namespace)
+	if err != nil {
 		return false, err
 	}
-	return kerrors.IsNotFound(err), nil
+	val, exists := storageCluster.GetAnnotations()[util.InMaintenanceModeAnnotation]
+	if !exists {
+		return false, nil
+	}
+	return strconv.ParseBool(val)
 }
 
 func (s *OCSProviderServer) isConsumerMirrorEnabled(ctx context.Context, consumer *ocsv1alpha1.StorageConsumer) (bool, error) {


### PR DESCRIPTION
This pull request: 
1. Adds an annotation `inMaintenanceMode` to clarify that the system is actually in maintenance mode.
2. References the same annotation in `isSystemInMaintenanceMode` to indicate the status of the system correctly.
Resolves: [DFBUGS-4112](https://issues.redhat.com/browse/DFBUGS-4112) , [DFBUGS-2315](https://issues.redhat.com/browse/DFBUGS-2315)