### PR TITLE
Add placement for onboarding validation keys generator job

### DIFF
--- a/internal/controller/storagecluster/provider_server.go
+++ b/internal/controller/storagecluster/provider_server.go
@@ -400,6 +400,9 @@ func getOnboardingJobObject(instance *ocsv1.StorageCluster) *batchv1.Job {
 							},
 						},
 					},
+					// Use the same tolerations as the Provider API Server
+					// As the generator job is too insignificant to have it's own placement
+					Tolerations: getPlacement(instance, defaults.APIServerKey).Tolerations,
 				},
 			},
 		},


### PR DESCRIPTION
Previously the generator job was running with no placement. This caused issue where nodes had taints(even the default ocs taint). This change adds the same tolerations as the Provider API Server to the generator job as the job is insignificant to have it's own placement.
Fixes-https://issues.redhat.com/browse/DFBUGS-5757