### PR TITLE
DFBUGS-5903: [release-4.19] cephclients: expand cephfs cephclient permission for multiple fs

### DIFF
--- a/controllers/storageconsumer/storageconsumer_controller.go
+++ b/controllers/storageconsumer/storageconsumer_controller.go
@@ -260,7 +260,6 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 				}
 				if err := r.reconcileCephClientCephFSProvisioner(
 					util.GenerateCsiCephFsProvisionerCephClientName(csiCephUserCurrGen, r.storageConsumer.UID),
-					util.GenerateNameForCephFilesystem(storageCluster.Name),
 					consumerResources.GetSubVolumeGroupName(),
 					consumerConfigMap,
 					csiCephUserCurrGen,
@@ -270,7 +269,6 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 
 				if err := r.reconcileCephClientCephFSNode(
 					util.GenerateCsiCephFsNodeCephClientName(csiCephUserCurrGen, r.storageConsumer.UID),
-					util.GenerateNameForCephFilesystem(storageCluster.Name),
 					consumerResources.GetSubVolumeGroupName(),
 					consumerConfigMap,
 					csiCephUserCurrGen,
@@ -682,7 +680,6 @@ func (r *StorageConsumerReconciler) reconcileCephClientRBDNode(
 
 func (r *StorageConsumerReconciler) reconcileCephClientCephFSProvisioner(
 	cephClientName string,
-	cephFileSystemName string,
 	subVolumeGroupName string,
 	additionalOwner client.Object,
 	csiCephUserGeneration int64,
@@ -702,7 +699,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSProvisioner(
 		cephClient.Spec.Caps = map[string]string{
 			"mon": "allow r, allow command 'osd blocklist'",
 			"mgr": "allow rw",
-			"osd": fmt.Sprintf("allow rw tag cephfs metadata=%s", cephFileSystemName),
+			"osd": "allow rw tag cephfs metadata=*",
 			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
 		}
 		return nil
@@ -714,7 +711,6 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSProvisioner(
 
 func (r *StorageConsumerReconciler) reconcileCephClientCephFSNode(
 	cephClientName string,
-	cephFileSystemName string,
 	subVolumeGroupName string,
 	additionalOwner client.Object,
 	csiCephUserGeneration int64,
@@ -734,7 +730,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSNode(
 		cephClient.Spec.Caps = map[string]string{
 			"mon": "allow r",
 			"mgr": "allow rw",
-			"osd": fmt.Sprintf("allow rw tag cephfs *=%s", cephFileSystemName),
+			"osd": "allow rw tag cephfs *=*",
 			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
 		}
 		return nil


### PR DESCRIPTION
expand cephclient permission to be able to access multiple ceph filesystems

This is an manual cherry-pick of https://github.com/red-hat-storage/ocs-operator/pull/3708