### PR TITLE
rbac: grant ocs-operator csiaddonsnodes for metrics exporter ClusterRole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -156,6 +156,13 @@ rules:
 - apiGroups:
   - csiaddons.openshift.io
   resources:
+  - csiaddonsnodes
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - csiaddons.openshift.io
+  resources:
   - networkfenceclasses
   verbs:
   - create

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -79,7 +79,7 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2026-04-06T10:33:06Z"
+    createdAt: "2026-04-07T06:25:52Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
@@ -310,6 +310,13 @@ spec:
           - get
           - list
           - update
+        - apiGroups:
+          - csiaddons.openshift.io
+          resources:
+          - csiaddonsnodes
+          verbs:
+          - get
+          - list
         - apiGroups:
           - csiaddons.openshift.io
           resources:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2026-04-06T10:33:06Z"
+    createdAt: "2026-04-07T06:25:52Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",
@@ -329,6 +329,13 @@ spec:
           - get
           - list
           - update
+        - apiGroups:
+          - csiaddons.openshift.io
+          resources:
+          - csiaddonsnodes
+          verbs:
+          - get
+          - list
         - apiGroups:
           - csiaddons.openshift.io
           resources:

--- a/internal/controller/storagecluster/reconcile.go
+++ b/internal/controller/storagecluster/reconcile.go
@@ -125,6 +125,7 @@ var storageClusterFinalizer = "storagecluster.ocs.openshift.io"
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=odf-blackbox-scc,verbs=use;get;create;update;patch;delete
 // +kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,resourceNames=hostnetwork-v2,verbs=use
 // +kubebuilder:rbac:groups=csiaddons.openshift.io,resources=networkfenceclasses,verbs=get;list;watch;create;update;delete
+// +kubebuilder:rbac:groups=csiaddons.openshift.io,resources=csiaddonsnodes,verbs=get;list
 // +kubebuilder:rbac:groups=console.openshift.io,resources=consoleplugins,verbs=get;watch;update
 
 // Reconcile reads that state of the cluster for a StorageCluster object and makes changes based on the state read

--- a/metrics/deploy/rbac.yaml
+++ b/metrics/deploy/rbac.yaml
@@ -100,7 +100,6 @@ rules:
   verbs:
     - get
     - list
-    - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
The metrics exporter ClusterRole includes csiaddons.openshift.io/csiaddonsnodes get and list for blocklist correlation. The ocs-operator service account must hold those verbs to apply or update that ClusterRole (Kubernetes RBAC escalation rules).

- Add kubebuilder RBAC marker and regenerate config/rbac/role.yaml
- Extend OLM CSV and csv template clusterPermissions for ocs-operator
- Align metrics/deploy/rbac.yaml: remove unused watch on csiaddonsnodes

Assisted-by AI