### PR TITLE
update blackbox deployment to add correct selector

### DIFF
--- a/internal/controller/storagecluster/blackbox_exporter.go
+++ b/internal/controller/storagecluster/blackbox_exporter.go
@@ -27,7 +27,6 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
-	"github.com/red-hat-storage/ocs-operator/v4/version"
 	"go.uber.org/multierr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -52,9 +51,7 @@ const (
 )
 
 var blackboxExporterLabels = map[string]string{
-	componentLabel: "blackbox-exporter",
-	nameLabel:      blackboxExporterName,
-	versionLabel:   version.Version,
+	"app": blackboxExporterName,
 }
 
 type MultusNetStatus struct {


### PR DESCRIPTION
this commit updates the blackbox deployment,
Currently we have version labels in the selector
but since the selector is not mutable and in case
of upgrade the version change is showing the issue

Currently we get this msg on upgrade:
```
{"level":"error","ts":"2026-04-09T09:20:07Z","logger":"controllers.StorageCluster","msg":"Failed to create/update Deployment for Blackbox Exporter","Request.Namespace":"openshift-storage","Request.Name":"ocs-storagecluster","error":"Deployment.apps \"odf-blackbox-exporter\" is invalid: spec.template.metadata.labels: Invalid value: {\"app.kubernetes.io/component\":\"blackbox-exporter\",\"app.kubernetes.io/name\":\"odf-blackbox-exporter\",\"app.kubernetes.io/version\":\"4.22.0\"}: `selector` does not match template `labels`","stacktrace":"github.com/red-hat-storage/ocs-operator/v4/internal/controller/storagecluster.(*StorageClusterReconciler).createBlackboxDeployment\n\t/workspace/internal/controller/storagecluster/blackbox_exporter.go:437\ngithub.com/red-hat-storage/ocs-operator/v4/internal/controller/storagecluster.(*StorageClusterReconciler).deployBlackboxExporter\n\t/workspace/internal/controller/storagecluster/blackbox_exporter.go:84\ngithub.com/red-hat-storage/ocs-operator/v4/internal/controller/storagecluster.(*StorageClusterReconciler).reconcilePhases\n\t/workspace/internal/controller/storagecluster/reconcile.go:723\ngithub.com/red-hat-storage/ocs-operator/v4/internal/controller/storagecluster.(*StorageClusterReconciler).Reconcile\n\t/workspace/internal/controller/storagecluster/reconcile.go:175\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:216\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:461\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/workspace/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:296"}
```