### PR TITLE
 rgw: Support for SSE-S3 with vault Agent

### DIFF
--- a/internal/controller/storagecluster/cephobjectstores.go
+++ b/internal/controller/storagecluster/cephobjectstores.go
@@ -234,37 +234,63 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 		// Set default values in the metadata pool spec as necessary
 		setDefaultMetadataPoolSpec(&obj.Spec.MetadataPool, initData)
 
-		// if kmsConfig is not 'nil', add the KMS details to ObjectStore spec
+		// if kmsConfig is not 'nil', add encryption details to ObjectStore spec.
+		// SSE-KMS and SSE-S3 are mutually exclusive so configure one or the other.
 		if kmsConfigMap != nil {
-
-			// skip if KMS_PROVIDER is ibmkeyprotect or VAULT_AUTH_METHOD is kubernetes, not supported for RGW
-			if kmsConfigMap.Data["KMS_PROVIDER"] == IbmKeyProtectKMSProvider ||
-				kmsConfigMap.Data["KMS_PROVIDER"] == ThalesKMSProvider ||
-				kmsConfigMap.Data["VAULT_AUTH_METHOD"] == VaultSAAuthMethod {
-				r.Log.Info("IBMKeyProtect/Thales as KMS provider or Vault authentication via Service Account is unsupported configuration for RGW KMS, hence skipping")
+			// IBMKeyProtect and Thales are unsupported KMS providers for RGW, skip entirely
+			if kmsConfigMap.Data[KMSProviderKey] == IbmKeyProtectKMSProvider ||
+				kmsConfigMap.Data[KMSProviderKey] == ThalesKMSProvider {
+				r.Log.Info("IBMKeyProtect/Thales as KMS provider is unsupported for RGW, skipping")
 				continue
 			}
-			// Set default KMS_PROVIDER and VAULT_SECRET_ENGINE values, refer https://issues.redhat.com/browse/RHSTOR-1963
-			if _, ok := kmsConfigMap.Data["KMS_PROVIDER"]; !ok {
-				kmsConfigMap.Data["KMS_PROVIDER"] = VaultKMSProvider
+
+			// Set default KMS_PROVIDER, refer https://issues.redhat.com/browse/RHSTOR-1963
+			if _, ok := kmsConfigMap.Data[KMSProviderKey]; !ok {
+				kmsConfigMap.Data[KMSProviderKey] = VaultKMSProvider
 			}
-			rgwConnDetails := make(map[string]string)
-			for key, value := range kmsConfigMap.Data {
-				// ignore kv engine related options
-				if key == "VAULT_BACKEND_PATH" || key == "VAULT_BACKEND" {
+
+			switch kmsConfigMap.Data[VaultRGWAuthMethodKey] {
+			case "":
+				// VAULT_RGW_AUTH_METHOD not set, skip RGW encryption
+				r.Log.Info("VAULT_RGW_AUTH_METHOD not set, skipping RGW encryption configuration")
+			case VaultAgentAuthMethod:
+				if r.images.VaultAgent == "" {
+					r.Log.Info("VAULT_AGENT_IMAGE not set, skipping SSE-S3 Vault Agent configuration for RGW")
 					continue
 				}
-				rgwConnDetails[key] = value
-			}
-			// overwrite SecretEngine value to transit
-			rgwConnDetails["VAULT_SECRET_ENGINE"] = "transit"
-			obj.Spec.Security = &cephv1.ObjectStoreSecuritySpec{
-				SecuritySpec: cephv1.SecuritySpec{
-					KeyManagementService: cephv1.KeyManagementServiceSpec{
-						ConnectionDetails: rgwConnDetails,
-						TokenSecretName:   KMSTokenSecretName,
+				// Configure SSE-S3 with Vault Agent auth.
+				// RGW connects to the ODF-managed Vault Agent service instead of directly to Vault.
+				obj.Spec.Security = &cephv1.ObjectStoreSecuritySpec{
+					ServerSideEncryptionS3: cephv1.KeyManagementServiceSpec{
+						ConnectionDetails: map[string]string{
+							"KMS_PROVIDER":        VaultKMSProvider,
+							"VAULT_ADDR":          VaultAgentServiceURL(initData.Namespace),
+							"VAULT_AUTH_METHOD":   VaultAgentAuthMethod,
+							"VAULT_SECRET_ENGINE": "transit",
+						},
 					},
-				},
+				}
+			case VaultTokenAuthMethod:
+				// Configure SSE-KMS with token auth
+				rgwConnDetails := make(map[string]string)
+				for key, value := range kmsConfigMap.Data {
+					if key == "VAULT_BACKEND_PATH" || key == "VAULT_BACKEND" {
+						continue
+					}
+					rgwConnDetails[key] = value
+				}
+				rgwConnDetails["VAULT_SECRET_ENGINE"] = "transit"
+				obj.Spec.Security = &cephv1.ObjectStoreSecuritySpec{
+					SecuritySpec: cephv1.SecuritySpec{
+						KeyManagementService: cephv1.KeyManagementServiceSpec{
+							ConnectionDetails: rgwConnDetails,
+							TokenSecretName:   KMSTokenSecretName,
+						},
+					},
+				}
+			default:
+				return nil, fmt.Errorf("unsupported %s value %q, must be %q or %q",
+					VaultRGWAuthMethodKey, kmsConfigMap.Data[VaultRGWAuthMethodKey], VaultAgentAuthMethod, VaultTokenAuthMethod)
 			}
 		}
 

--- a/internal/controller/storagecluster/cephobjectstores_test.go
+++ b/internal/controller/storagecluster/cephobjectstores_test.go
@@ -84,6 +84,101 @@ func assertCephObjectStores(t *testing.T, reconciler *StorageClusterReconciler, 
 	assert.Equal(t, expectedCos[0].Spec.Gateway.Instances, int32(2))
 }
 
+func TestCephObjectStoreSSES3WithVaultAgent(t *testing.T) {
+	platform.SetFakePlatformInstanceForTesting(true, configv1.BareMetalPlatformType)
+	defer platform.UnsetFakePlatformInstanceForTesting()
+
+	var objects []client.Object
+	t, reconciler, cr, _ := initStorageClusterResourceCreateUpdateTest(t, objects, nil)
+
+	t.Run("SSE-S3 is configured when VAULT_RGW_AUTH_METHOD is agent", func(t *testing.T) {
+		reconciler.images.VaultAgent = "vault-agent:test"
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"KMS_PROVIDER":          "vault",
+				"VAULT_ADDR":            "https://vault.example.com:8200",
+				"VAULT_AUTH_METHOD":     "token",
+				"VAULT_RGW_AUTH_METHOD": "agent",
+			},
+		}
+		cephObjectStores, err := reconciler.newCephObjectStoreInstances(cr, kmsConfigMap)
+		assert.NoError(t, err)
+		assert.NotNil(t, cephObjectStores[0].Spec.Security)
+		s3 := cephObjectStores[0].Spec.Security.ServerSideEncryptionS3
+		assert.Equal(t, "vault", s3.ConnectionDetails["KMS_PROVIDER"])
+		// VAULT_ADDR should point to the ODF-managed Vault Agent service
+		assert.Equal(t, VaultAgentServiceURL(cr.Namespace), s3.ConnectionDetails["VAULT_ADDR"])
+		assert.Equal(t, "agent", s3.ConnectionDetails["VAULT_AUTH_METHOD"])
+		assert.Equal(t, "transit", s3.ConnectionDetails["VAULT_SECRET_ENGINE"])
+		assert.Empty(t, s3.TokenSecretName)
+	})
+
+	t.Run("SSE-S3 is skipped when VAULT_AGENT_IMAGE is empty", func(t *testing.T) {
+		reconciler.images.VaultAgent = ""
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"KMS_PROVIDER":          "vault",
+				"VAULT_ADDR":            "https://vault.example.com:8200",
+				"VAULT_RGW_AUTH_METHOD": "agent",
+			},
+		}
+		cephObjectStores, err := reconciler.newCephObjectStoreInstances(cr, kmsConfigMap)
+		assert.NoError(t, err)
+		assert.Nil(t, cephObjectStores[0].Spec.Security)
+	})
+
+	t.Run("SSE-KMS is configured when VAULT_RGW_AUTH_METHOD is token", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"KMS_PROVIDER":          "vault",
+				"VAULT_ADDR":            "https://vault.example.com:8200",
+				"VAULT_RGW_AUTH_METHOD": "token",
+			},
+		}
+		cephObjectStores, err := reconciler.newCephObjectStoreInstances(cr, kmsConfigMap)
+		assert.NoError(t, err)
+		assert.NotNil(t, cephObjectStores[0].Spec.Security)
+		// SSE-KMS should be configured
+		kms := cephObjectStores[0].Spec.Security.KeyManagementService
+		assert.Equal(t, "https://vault.example.com:8200", kms.ConnectionDetails["VAULT_ADDR"])
+		assert.Equal(t, KMSTokenSecretName, kms.TokenSecretName)
+		// SSE-S3 should not be configured
+		assert.Empty(t, cephObjectStores[0].Spec.Security.ServerSideEncryptionS3.ConnectionDetails)
+	})
+
+	t.Run("No RGW encryption when VAULT_RGW_AUTH_METHOD is absent", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"KMS_PROVIDER": "vault",
+				"VAULT_ADDR":   "https://vault.example.com:8200",
+			},
+		}
+		cephObjectStores, err := reconciler.newCephObjectStoreInstances(cr, kmsConfigMap)
+		assert.NoError(t, err)
+		assert.Nil(t, cephObjectStores[0].Spec.Security)
+	})
+
+	t.Run("Error when VAULT_RGW_AUTH_METHOD is invalid", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"KMS_PROVIDER":          "vault",
+				"VAULT_ADDR":            "https://vault.example.com:8200",
+				"VAULT_RGW_AUTH_METHOD": "kubernetes",
+			},
+		}
+		_, err := reconciler.newCephObjectStoreInstances(cr, kmsConfigMap)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "kubernetes")
+	})
+
+	t.Run("No RGW encryption when KMS ConfigMap is nil", func(t *testing.T) {
+		cephObjectStores, err := reconciler.newCephObjectStoreInstances(cr, nil)
+		assert.NoError(t, err)
+		assert.Nil(t, cephObjectStores[0].Spec.Security)
+	})
+
+}
+
 func TestGetCephObjectStoreGatewayInstances(t *testing.T) {
 	var cases = []struct {
 		label                                   string

--- a/internal/controller/storagecluster/kms_resources.go
+++ b/internal/controller/storagecluster/kms_resources.go
@@ -37,6 +37,26 @@ const (
 	ThalesKMSProvider = "kmip"
 	// AzureKSMProvider represents the Azure Key vault.
 	AzureKSMProvider = "azure-kv"
+	// VaultAgentAuthMethod is the key to represent vault agent based authentication
+	VaultAgentAuthMethod = "agent"
+	// VaultRGWAuthMethodKey is the key in the KMS ConfigMap to specify the auth method for RGW SSE-S3
+	VaultRGWAuthMethodKey = "VAULT_RGW_AUTH_METHOD"
+	// VaultRGWAgentAddrKey is the key in the KMS ConfigMap to specify the Vault Agent sidecar address for RGW SSE-S3
+	VaultRGWAgentAddrKey = "VAULT_RGW_AGENT_ADDR"
+	// VaultAgentDeploymentName is the name of the Vault Agent deployment managed by ODF
+	VaultAgentDeploymentName = "vault-agent-rgw"
+	// VaultAgentServiceName is the name of the Vault Agent service
+	VaultAgentServiceName = "vault-agent-rgw"
+	// VaultAgentSAName is the name of the Vault Agent service account
+	VaultAgentSAName = "vault-agent-rgw"
+	// VaultAgentConfigMapName is the name of the Vault Agent configuration ConfigMap
+	VaultAgentConfigMapName = "vault-agent-rgw-config"
+	// VaultAgentPort is the port the Vault Agent cache listener runs on
+	VaultAgentPort = 8100
+	// VaultRGWRoleKey is the key in the KMS ConfigMap to specify the Vault K8s auth role for RGW
+	VaultRGWRoleKey = "VAULT_RGW_ROLE"
+	// VaultRGWAuthMountPathKey is the key in the KMS ConfigMap to specify the Vault K8s auth mount path
+	VaultRGWAuthMountPathKey = "VAULT_RGW_AUTH_MOUNT_PATH"
 )
 
 var (

--- a/internal/controller/storagecluster/reconcile.go
+++ b/internal/controller/storagecluster/reconcile.go
@@ -511,6 +511,7 @@ func (r *StorageClusterReconciler) reconcilePhases(
 				&ocsCephFilesystems{},
 				&ocsCephNFS{},
 				&ocsCephNFSService{},
+				&ocsVaultAgent{},
 				&ocsCephObjectStores{},
 				&ocsCephObjectStoreUsers{},
 				&ocsCephRGWRoutes{},

--- a/internal/controller/storagecluster/storagecluster_controller.go
+++ b/internal/controller/storagecluster/storagecluster_controller.go
@@ -76,6 +76,15 @@ func (r *StorageClusterReconciler) initializeImageVars() error {
 		err := fmt.Errorf("BLACKBOX_EXPORTER_IMAGE environment variable not found")
 		r.Log.Error(err, "BLACKBOX_EXPORTER_IMAGE environment variable not set; will use default image")
 	}
+
+	// TODO(GA): VAULT_AGENT_IMAGE is not set by default in the CSV (dev preview).
+	// For GA, add a downstream vault image to the CSV env vars and relatedImages
+	// so that SSE-S3 with Vault Agent works out of the box.
+	r.images.VaultAgent = os.Getenv("VAULT_AGENT_IMAGE")
+	if r.images.VaultAgent == "" {
+		r.Log.Info("VAULT_AGENT_IMAGE environment variable not set; Vault Agent deployment for RGW SSE-S3 will not be available")
+	}
+
 	return nil
 }
 
@@ -87,6 +96,7 @@ type ImageMap struct {
 	OCSMetricsExporter string
 	BlackboxExporter   string
 	KubeRBACProxy      string
+	VaultAgent         string
 }
 
 // StorageClusterReconciler reconciles a StorageCluster object

--- a/internal/controller/storagecluster/uninstall_reconciler.go
+++ b/internal/controller/storagecluster/uninstall_reconciler.go
@@ -327,6 +327,7 @@ func (r *StorageClusterReconciler) deleteResources(sc *ocsv1.StorageCluster) (re
 		&ocsS3EndpointsConfig{},
 		&ocsCephObjectStoreUsers{},
 		&ocsCephObjectStores{},
+		&ocsVaultAgent{},
 		&ocsCephRbdMirrors{},
 		&ocsCephNFS{},
 		&ocsCephNFSService{},

--- a/internal/controller/storagecluster/vault_agent.go
+++ b/internal/controller/storagecluster/vault_agent.go
@@ -1,0 +1,495 @@
+package storagecluster
+
+import (
+	"fmt"
+	"strings"
+
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	vaultAgentDefaultRole          = "rook-ceph-rgw"
+	vaultAgentDefaultAuthMountPath = "auth/kubernetes"
+	vaultAgentConfigFile           = "vault-agent-config.hcl"
+	vaultAgentTLSCAMountPath       = "/vault/tls/ca"
+	vaultAgentTLSCertMountPath     = "/vault/tls/client-cert"
+	vaultAgentTLSKeyMountPath      = "/vault/tls/client-key"
+	vaultAgentTokenPath            = "/vault/token"
+)
+
+var vaultAgentLabels = map[string]string{
+	"app": VaultAgentDeploymentName,
+}
+
+type ocsVaultAgent struct{}
+
+func (obj *ocsVaultAgent) ensureCreated(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
+	required, err := obj.isVaultAgentRequired(r, instance)
+	if err != nil {
+		r.Log.Error(err, "Failed to determine if Vault Agent is required")
+		return reconcile.Result{}, err
+	}
+	if !required {
+		return obj.ensureDeleted(r, instance)
+	}
+
+	if r.images.VaultAgent == "" {
+		r.Log.Info("VAULT_AGENT_IMAGE not set, skipping Vault Agent deployment for RGW SSE-S3")
+		return reconcile.Result{}, nil
+	}
+
+	kmsConfigMap, err := util.GetKMSConfigMap(defaults.KMSConfigMapName, instance, r.Client)
+	if err != nil {
+		r.Log.Error(err, "Failed to get KMS ConfigMap for Vault Agent")
+		return reconcile.Result{}, err
+	}
+	if kmsConfigMap == nil {
+		return reconcile.Result{}, nil
+	}
+
+	if err := r.createVaultAgentServiceAccount(instance); err != nil {
+		r.Log.Error(err, "Failed to create Vault Agent ServiceAccount")
+		return reconcile.Result{}, err
+	}
+	if err := r.createVaultAgentConfigMap(instance, kmsConfigMap); err != nil {
+		r.Log.Error(err, "Failed to create Vault Agent ConfigMap")
+		return reconcile.Result{}, err
+	}
+	if err := r.createVaultAgentDeployment(instance, kmsConfigMap); err != nil {
+		r.Log.Error(err, "Failed to create Vault Agent Deployment")
+		return reconcile.Result{}, err
+	}
+	if err := r.createVaultAgentService(instance); err != nil {
+		r.Log.Error(err, "Failed to create Vault Agent Service")
+		return reconcile.Result{}, err
+	}
+
+	r.Log.Info("Vault Agent resources reconciled successfully")
+	return reconcile.Result{}, nil
+}
+
+func (obj *ocsVaultAgent) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
+	resources := []client.Object{
+		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: VaultAgentServiceName, Namespace: instance.Namespace}},
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: VaultAgentDeploymentName, Namespace: instance.Namespace}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: VaultAgentConfigMapName, Namespace: instance.Namespace}},
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: VaultAgentSAName, Namespace: instance.Namespace}},
+	}
+
+	for _, obj := range resources {
+		err := r.Delete(r.ctx, obj)
+		if err != nil && !apierrors.IsNotFound(err) {
+			r.Log.Error(err, "Failed to delete Vault Agent resource", "Kind", fmt.Sprintf("%T", obj), "Name", obj.GetName())
+			return reconcile.Result{}, err
+		}
+	}
+	return reconcile.Result{}, nil
+}
+
+// isVaultAgentRequired checks whether the Vault Agent deployment is needed.
+// It returns true only when all of the following are satisfied:
+//   - Cluster or device-set encryption is enabled
+//   - KMS is enabled
+//   - KMS provider is vault (or empty, which defaults to vault)
+//   - VAULT_RGW_AUTH_METHOD is set to "agent"
+func (obj *ocsVaultAgent) isVaultAgentRequired(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (bool, error) {
+	if util.IsClusterOrDeviceSetEncrypted(instance) && instance.Spec.Encryption.KeyManagementService.Enable {
+		kmsConfigMap, err := util.GetKMSConfigMap(defaults.KMSConfigMapName, instance, r.Client)
+		if err != nil {
+			return false, err
+		}
+		if kmsConfigMap == nil {
+			return false, nil
+		}
+		// Empty provider defaults to vault, so only reject if explicitly non-vault
+		kmsProvider := kmsConfigMap.Data[KMSProviderKey]
+		if kmsProvider != "" && kmsProvider != VaultKMSProvider {
+			return false, nil
+		}
+		return kmsConfigMap.Data[VaultRGWAuthMethodKey] == VaultAgentAuthMethod, nil
+	}
+	return false, nil
+}
+
+func (r *StorageClusterReconciler) createVaultAgentServiceAccount(instance *ocsv1.StorageCluster) error {
+	desired := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      VaultAgentSAName,
+			Namespace: instance.Namespace,
+			Labels:    vaultAgentLabels,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: instance.APIVersion,
+				Kind:       instance.Kind,
+				Name:       instance.Name,
+				UID:        instance.UID,
+			}},
+		},
+	}
+	actual := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
+
+	err := r.Get(r.ctx, types.NamespacedName{Name: actual.Name, Namespace: actual.Namespace}, actual)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return r.Create(r.ctx, desired)
+		}
+		return err
+	}
+
+	if equality.Semantic.DeepEqual(desired.Labels, actual.Labels) &&
+		equality.Semantic.DeepEqual(desired.OwnerReferences, actual.OwnerReferences) {
+		return nil
+	}
+	actual.Labels = desired.Labels
+	actual.OwnerReferences = desired.OwnerReferences
+	return r.Update(r.ctx, actual)
+}
+
+func (r *StorageClusterReconciler) createVaultAgentConfigMap(instance *ocsv1.StorageCluster, kmsConfigMap *corev1.ConfigMap) error {
+	hclConfig := generateVaultAgentConfig(kmsConfigMap)
+
+	desired := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      VaultAgentConfigMapName,
+			Namespace: instance.Namespace,
+			Labels:    vaultAgentLabels,
+		},
+		Data: map[string]string{
+			vaultAgentConfigFile: hclConfig,
+		},
+	}
+
+	actual := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, actual, func() error {
+		if actual.CreationTimestamp.IsZero() {
+			actual.Labels = desired.Labels
+			if err := controllerutil.SetControllerReference(instance, actual, r.Scheme); err != nil {
+				return err
+			}
+		}
+		actual.Data = desired.Data
+		return nil
+	})
+	return err
+}
+
+func (r *StorageClusterReconciler) createVaultAgentDeployment(instance *ocsv1.StorageCluster, kmsConfigMap *corev1.ConfigMap) error {
+	volumes, volumeMounts := getVaultAgentTLSVolumes(kmsConfigMap)
+
+	// Always need the config volume and token volume
+	volumes = append(volumes,
+		corev1.Volume{
+			Name: "config",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: VaultAgentConfigMapName,
+					},
+				},
+			},
+		},
+		corev1.Volume{
+			Name: "token",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{
+					Medium: corev1.StorageMediumMemory,
+				},
+			},
+		},
+	)
+	volumeMounts = append(volumeMounts,
+		corev1.VolumeMount{
+			Name:      "config",
+			MountPath: "/etc/vault",
+			ReadOnly:  true,
+		},
+		corev1.VolumeMount{
+			Name:      "token",
+			MountPath: vaultAgentTokenPath,
+		},
+	)
+
+	desired := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      VaultAgentDeploymentName,
+			Namespace: instance.Namespace,
+			Labels:    vaultAgentLabels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(int32(2)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: vaultAgentLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: vaultAgentLabels,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: VaultAgentSAName,
+					Containers: []corev1.Container{
+						{
+							Name:    "vault-agent",
+							Image:   r.images.VaultAgent,
+							Command: []string{"vault"},
+							Args: []string{
+								"agent",
+								"-config=/etc/vault/" + vaultAgentConfigFile,
+							},
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "cache",
+									ContainerPort: int32(VaultAgentPort),
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							VolumeMounts: volumeMounts,
+							Resources:    getDaemonResources("vault-agent", instance),
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot:             ptr.To(true),
+								ReadOnlyRootFilesystem:   ptr.To(true),
+								AllowPrivilegeEscalation: ptr.To(false),
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeRuntimeDefault,
+								},
+							},
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt(VaultAgentPort),
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       15,
+								FailureThreshold:    6,
+							},
+							LivenessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									TCPSocket: &corev1.TCPSocketAction{
+										Port: intstr.FromInt(VaultAgentPort),
+									},
+								},
+								InitialDelaySeconds: 15,
+								PeriodSeconds:       20,
+								FailureThreshold:    6,
+							},
+						},
+					},
+					Volumes:           volumes,
+					PriorityClassName: systemClusterCritical,
+				},
+			},
+		},
+	}
+
+	actual := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, actual, func() error {
+		if actual.CreationTimestamp.IsZero() {
+			actual.Spec.Selector = desired.Spec.Selector
+			if err := controllerutil.SetControllerReference(instance, actual, r.Scheme); err != nil {
+				return err
+			}
+		}
+		actual.Spec.Replicas = desired.Spec.Replicas
+		actual.Spec.Template = desired.Spec.Template
+		return nil
+	})
+	return err
+}
+
+func (r *StorageClusterReconciler) createVaultAgentService(instance *ocsv1.StorageCluster) error {
+	desired := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      VaultAgentServiceName,
+			Namespace: instance.Namespace,
+			Labels:    vaultAgentLabels,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: vaultAgentLabels,
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "cache",
+					Port:       int32(VaultAgentPort),
+					TargetPort: intstr.FromInt(VaultAgentPort),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+			Type: corev1.ServiceTypeClusterIP,
+		},
+	}
+
+	actual := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
+
+	err := r.Get(r.ctx, types.NamespacedName{Name: actual.Name, Namespace: actual.Namespace}, actual)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			if err := controllerutil.SetControllerReference(instance, desired, r.Scheme); err != nil {
+				return err
+			}
+			return r.Create(r.ctx, desired)
+		}
+		return err
+	}
+
+	// Preserve ClusterIP across updates
+	if actual.Spec.ClusterIP != "" {
+		desired.Spec.ClusterIP = actual.Spec.ClusterIP
+	}
+
+	if !equality.Semantic.DeepEqual(desired.Labels, actual.Labels) ||
+		!equality.Semantic.DeepEqual(desired.Spec.Selector, actual.Spec.Selector) ||
+		!equality.Semantic.DeepEqual(desired.Spec.Ports, actual.Spec.Ports) {
+		actual.Labels = desired.Labels
+		actual.Spec.Selector = desired.Spec.Selector
+		actual.Spec.Ports = desired.Spec.Ports
+		if err := controllerutil.SetControllerReference(instance, actual, r.Scheme); err != nil {
+			return err
+		}
+		return r.Update(r.ctx, actual)
+	}
+	return nil
+}
+
+// generateVaultAgentConfig creates the Vault Agent HCL configuration from the KMS ConfigMap
+func generateVaultAgentConfig(kmsConfigMap *corev1.ConfigMap) string {
+	vaultAddr := kmsConfigMap.Data["VAULT_ADDR"]
+	role := kmsConfigMap.Data[VaultRGWRoleKey]
+	if role == "" {
+		role = vaultAgentDefaultRole
+	}
+	authMountPath := kmsConfigMap.Data[VaultRGWAuthMountPathKey]
+	if authMountPath == "" {
+		authMountPath = vaultAgentDefaultAuthMountPath
+	}
+
+	tlsBlock := generateVaultAgentTLSConfig(kmsConfigMap)
+
+	return fmt.Sprintf(`disable_mlock = true
+
+vault {
+  address = %q
+%s}
+
+auto_auth {
+  method "kubernetes" {
+    mount_path = %q
+    config = {
+      role = %q
+    }
+  }
+  sink "file" {
+    config = {
+      path = "%s/.vault-token"
+    }
+  }
+}
+
+cache {
+  use_auto_auth_token = true
+}
+
+listener "tcp" {
+  address     = "0.0.0.0:%d"
+  tls_disable = true
+}
+`, vaultAddr, tlsBlock, authMountPath, role, vaultAgentTokenPath, VaultAgentPort)
+}
+
+// generateVaultAgentTLSConfig generates the tls_config block for the Vault Agent HCL
+func generateVaultAgentTLSConfig(kmsConfigMap *corev1.ConfigMap) string {
+	var lines []string
+	if s := kmsConfigMap.Data["VAULT_CACERT"]; s != "" {
+		lines = append(lines, fmt.Sprintf("    ca_cert     = %q", vaultAgentTLSCAMountPath+"/cert"))
+	}
+	if s := kmsConfigMap.Data["VAULT_CLIENT_CERT"]; s != "" {
+		lines = append(lines, fmt.Sprintf("    client_cert = %q", vaultAgentTLSCertMountPath+"/cert"))
+	}
+	if s := kmsConfigMap.Data["VAULT_CLIENT_KEY"]; s != "" {
+		lines = append(lines, fmt.Sprintf("    client_key  = %q", vaultAgentTLSKeyMountPath+"/key"))
+	}
+	if len(lines) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("  tls_config {\n%s\n  }\n", strings.Join(lines, "\n"))
+}
+
+// getVaultAgentTLSVolumes returns volumes and volume mounts for TLS secrets
+func getVaultAgentTLSVolumes(kmsConfigMap *corev1.ConfigMap) ([]corev1.Volume, []corev1.VolumeMount) {
+	var volumes []corev1.Volume
+	var mounts []corev1.VolumeMount
+
+	type tlsVolumeSpec struct {
+		configKey string
+		name      string
+		mountPath string
+	}
+
+	specs := []tlsVolumeSpec{
+		{"VAULT_CACERT", "vault-tls-ca", vaultAgentTLSCAMountPath},
+		{"VAULT_CLIENT_CERT", "vault-tls-client-cert", vaultAgentTLSCertMountPath},
+		{"VAULT_CLIENT_KEY", "vault-tls-client-key", vaultAgentTLSKeyMountPath},
+	}
+
+	for _, spec := range specs {
+		secretName := kmsConfigMap.Data[spec.configKey]
+		if secretName == "" {
+			continue
+		}
+		volumes = append(volumes, corev1.Volume{
+			Name: spec.name,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretName,
+				},
+			},
+		})
+		mounts = append(mounts, corev1.VolumeMount{
+			Name:      spec.name,
+			MountPath: spec.mountPath,
+			ReadOnly:  true,
+		})
+	}
+
+	return volumes, mounts
+}
+
+// VaultAgentServiceURL returns the in-cluster URL for the Vault Agent service
+func VaultAgentServiceURL(namespace string) string {
+	return fmt.Sprintf("http://%s.%s.svc:%d", VaultAgentServiceName, namespace, VaultAgentPort)
+}

--- a/internal/controller/storagecluster/vault_agent_test.go
+++ b/internal/controller/storagecluster/vault_agent_test.go
@@ -1,0 +1,168 @@
+package storagecluster
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGenerateVaultAgentConfig(t *testing.T) {
+	t.Run("Basic config without TLS", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"KMS_PROVIDER":          "vault",
+				"VAULT_ADDR":            "https://vault.example.com:8200",
+				"VAULT_RGW_AUTH_METHOD": "agent",
+			},
+		}
+
+		config := generateVaultAgentConfig(kmsConfigMap)
+
+		assert.Contains(t, config, "disable_mlock = true")
+		assert.Contains(t, config, `address = "https://vault.example.com:8200"`)
+		assert.Contains(t, config, `mount_path = "auth/kubernetes"`)
+		assert.Contains(t, config, `role = "rook-ceph-rgw"`)
+		assert.Contains(t, config, "use_auto_auth_token = true")
+		assert.Contains(t, config, "0.0.0.0:8100")
+		assert.Contains(t, config, "tls_disable = true")
+		assert.NotContains(t, config, "tls_config")
+	})
+
+	t.Run("Config with custom role and auth mount path", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"VAULT_ADDR":                "https://vault.example.com:8200",
+				"VAULT_RGW_ROLE":            "custom-rgw-role",
+				"VAULT_RGW_AUTH_MOUNT_PATH": "auth/k8s-cluster1",
+			},
+		}
+
+		config := generateVaultAgentConfig(kmsConfigMap)
+
+		assert.Contains(t, config, `role = "custom-rgw-role"`)
+		assert.Contains(t, config, `mount_path = "auth/k8s-cluster1"`)
+	})
+
+	t.Run("Config with TLS CA cert only", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"VAULT_ADDR":   "https://vault.example.com:8200",
+				"VAULT_CACERT": "vault-ca-secret",
+			},
+		}
+
+		config := generateVaultAgentConfig(kmsConfigMap)
+
+		assert.Contains(t, config, "tls_config")
+		assert.Contains(t, config, `ca_cert`)
+		assert.Contains(t, config, "/vault/tls/ca/cert")
+		assert.NotContains(t, config, "client_cert")
+		assert.NotContains(t, config, "client_key")
+	})
+
+	t.Run("Config with full TLS", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"VAULT_ADDR":        "https://vault.example.com:8200",
+				"VAULT_CACERT":      "vault-ca-secret",
+				"VAULT_CLIENT_CERT": "vault-client-cert-secret",
+				"VAULT_CLIENT_KEY":  "vault-client-key-secret",
+			},
+		}
+
+		config := generateVaultAgentConfig(kmsConfigMap)
+
+		assert.Contains(t, config, "tls_config")
+		assert.Contains(t, config, "/vault/tls/ca/cert")
+		assert.Contains(t, config, "/vault/tls/client-cert/cert")
+		assert.Contains(t, config, "/vault/tls/client-key/key")
+	})
+}
+
+func TestGenerateVaultAgentTLSConfig(t *testing.T) {
+	t.Run("No TLS secrets returns empty string", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"VAULT_ADDR": "https://vault.example.com:8200",
+			},
+		}
+		result := generateVaultAgentTLSConfig(kmsConfigMap)
+		assert.Empty(t, result)
+	})
+
+	t.Run("CA cert only", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"VAULT_CACERT": "my-ca-secret",
+			},
+		}
+		result := generateVaultAgentTLSConfig(kmsConfigMap)
+		assert.Contains(t, result, "ca_cert")
+		assert.NotContains(t, result, "client_cert")
+		assert.NotContains(t, result, "client_key")
+	})
+}
+
+func TestGetVaultAgentTLSVolumes(t *testing.T) {
+	t.Run("No TLS secrets returns empty slices", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"VAULT_ADDR": "https://vault.example.com:8200",
+			},
+		}
+		volumes, mounts := getVaultAgentTLSVolumes(kmsConfigMap)
+		assert.Empty(t, volumes)
+		assert.Empty(t, mounts)
+	})
+
+	t.Run("All TLS secrets present", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"VAULT_CACERT":      "ca-secret",
+				"VAULT_CLIENT_CERT": "cert-secret",
+				"VAULT_CLIENT_KEY":  "key-secret",
+			},
+		}
+		volumes, mounts := getVaultAgentTLSVolumes(kmsConfigMap)
+		assert.Len(t, volumes, 3)
+		assert.Len(t, mounts, 3)
+
+		// Verify secret names are used
+		assert.Equal(t, "ca-secret", volumes[0].Secret.SecretName)
+		assert.Equal(t, "cert-secret", volumes[1].Secret.SecretName)
+		assert.Equal(t, "key-secret", volumes[2].Secret.SecretName)
+
+		// Verify mount paths
+		assert.Equal(t, vaultAgentTLSCAMountPath, mounts[0].MountPath)
+		assert.Equal(t, vaultAgentTLSCertMountPath, mounts[1].MountPath)
+		assert.Equal(t, vaultAgentTLSKeyMountPath, mounts[2].MountPath)
+
+		// All mounts should be read-only
+		for _, m := range mounts {
+			assert.True(t, m.ReadOnly)
+		}
+	})
+
+	t.Run("Only CA cert present", func(t *testing.T) {
+		kmsConfigMap := &corev1.ConfigMap{
+			Data: map[string]string{
+				"VAULT_CACERT": "ca-secret",
+			},
+		}
+		volumes, mounts := getVaultAgentTLSVolumes(kmsConfigMap)
+		assert.Len(t, volumes, 1)
+		assert.Len(t, mounts, 1)
+		assert.Equal(t, "ca-secret", volumes[0].Secret.SecretName)
+	})
+}
+
+func TestVaultAgentServiceURL(t *testing.T) {
+	url := VaultAgentServiceURL("openshift-storage")
+	assert.Equal(t, "http://vault-agent-rgw.openshift-storage.svc:8100", url)
+
+	url = VaultAgentServiceURL("")
+	assert.True(t, strings.Contains(url, "vault-agent-rgw"))
+	assert.True(t, strings.Contains(url, "8100"))
+}

--- a/pkg/defaults/resources.go
+++ b/pkg/defaults/resources.go
@@ -84,6 +84,16 @@ var (
 				"cpu":    resource.MustParse("100m"),
 			},
 		},
+		"vault-agent": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+		},
 		"kube-rbac-proxy-main": {
 			Requests: corev1.ResourceList{
 				"memory": resource.MustParse("40Mi"),
@@ -391,6 +401,12 @@ var (
 			Requests: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("10m"),
 				corev1.ResourceMemory: resource.MustParse("75Mi"),
+			},
+		},
+		"vault-agent": {
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+				corev1.ResourceMemory: resource.MustParse("50Mi"),
 			},
 		},
 		"rook-ceph-tools": {


### PR DESCRIPTION
Adds support for RGW SSE-S3 encryption with Vault by deploying a standalone Vault Agent as a Deployment and Service managed by ODF. RGW pods connect to it over the in-cluster service.


Testing: 

- Added env variable to the ocs operator CSV file. 

```
 oc get pods | grep vault                                                                                                                                                                                        ─╯
vault-agent-rgw-5c94cc4885-27pvw                                  1/1     Running     0          3h37m
vault-agent-rgw-5c94cc4885-ftxqr                                  1/1     Running     0          3h37m
```

```
oc get service | grep agent                                                                                                                                                                                     ─╯
vault-agent-rgw                                    ClusterIP      172.30.243.9     <none>                                                                    8100/TCP                                                   4h22m
```

```
oc get cm vault-agent-rgw-config -o yaml                                                                                                                                                                        ─╯
apiVersion: v1
data:
  vault-agent-config.hcl: |
    disable_mlock = true

    vault {
      address = "https://vault.qe.rh-ocs.com:8200"
      tls_config {
        ca_cert     = "/vault/tls/ca/cert"
        client_cert = "/vault/tls/client-cert/cert"
        client_key  = "/vault/tls/client-key/key"
      }
    }

    auto_auth {
      method "kubernetes" {
        mount_path = "auth/kubernetes"
        config = {
          role = "rook-ceph-rgw"
        }
      }
      sink "file" {
        config = {
          path = "/vault/token/.vault-token"
        }
      }
    }

    cache {
      use_auto_auth_token = true
    }

    listener "tcp" {
      address     = "0.0.0.0:8100"
      tls_disable = true
    }
kind: ConfigMap
metadata:
  creationTimestamp: "2026-04-09T09:00:48Z"
  labels:
    app: vault-agent-rgw
  name: vault-agent-rgw-config
  namespace: openshift-storage
  ownerReferences:
  - apiVersion: ocs.openshift.io/v1
    blockOwnerDeletion: true
    controller: true
    kind: StorageCluster
    name: ocs-storagecluster
    uid: 7d96bf81-0977-4f96-9123-ff76fa5ec619
  resourceVersion: "173980"
  uid: ceee11e9-86d2-43c0-adbc-d4a7e9b5a7fc
```

cephobjectstore CR updated by the OCS operator to add S3 credentials: 
```
....
security:
      keyRotation:
        enabled: false
      kms: {}
      s3:
        connectionDetails:
          KMS_PROVIDER: vault
          VAULT_ADDR: http://vault-agent-rgw.openshift-storage.svc:8100
          VAULT_AUTH_METHOD: agent
          VAULT_SECRET_ENGINE: transit
```

RGW daemon pods were updated (by rook)  to add the new crypt args while running rgw daemon: 
```
 - --rgw-crypt-sse-s3-backend=vault
    - --rgw-crypt-sse-s3-vault-addr=http://vault-agent-rgw.openshift-storage.svc:8100
    - --rgw-crypt-sse-s3-vault-auth=agent
    - --rgw-crypt-sse-s3-vault-prefix=/v1/transit
    - --rgw-crypt-sse-s3-vault-secret-engine=transit
 ```

Upload encrypted object: 
```
 aws s3api put-object --bucket sse-s3-test --key test-object --server-side-encryption AES256
{
    "ETag": "\"eba30a8547b6193c006a46e98b73c092\"",
    "ChecksumCRC64NVME": "0yjPg1yyVZE=",
    "ChecksumType": "FULL_OBJECT",
    "ServerSideEncryption": "AES256"
}
```

 Verifying encryption metadata (HEAD)
```
aws s3api head-object --bucket sse-s3-test --key test-object
{
    "AcceptRanges": "bytes",
    "LastModified": "2026-04-09T13:15:36+00:00",
    "ContentLength": 73,
    "ETag": "\"eba30a8547b6193c006a46e98b73c092\"",
    "ContentType": "binary/octet-stream",
    "ServerSideEncryption": "AES256",
    "Metadata": {}
}
```

Download encrypted object: 
```
aws s3api get-object --bucket sse-s3-test --key test-object
{
    "AcceptRanges": "bytes",
    "LastModified": "2026-04-09T13:15:36+00:00",
    "ContentLength": 73,
    "ETag": "\"eba30a8547b6193c006a46e98b73c092\"",
    "ChecksumCRC64NVME": "0yjPg1yyVZE=",
    "ChecksumType": "FULL_OBJECT",
    "ContentType": "binary/octet-stream",
    "ServerSideEncryption": "AES256",
    "Metadata": {}
}```
