### PR TITLE
fix missing toleration in rook-ceph-rbd-mirror pod

### DIFF
--- a/internal/controller/mirroring/mirroring_controller.go
+++ b/internal/controller/mirroring/mirroring_controller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 
 	"github.com/go-logr/logr"
+	storageclusterctrl "github.com/red-hat-storage/ocs-operator/v4/internal/controller/storagecluster"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
@@ -306,6 +307,12 @@ func (r *MirroringReconciler) reconcileRbdMirror(clientMappingConfig *corev1.Con
 		return true
 	}
 
+	storageCluster, err := util.GetStorageClusterInNamespace(r.ctx, r.Client, clientMappingConfig.Namespace)
+	if err != nil {
+		r.log.Error(err, "failed to get StorageCluster")
+		return true
+	}
+
 	maintenanceModeRequested := len(storageConsumers.Items) >= 1
 
 	if shouldMirror && !maintenanceModeRequested {
@@ -314,6 +321,7 @@ func (r *MirroringReconciler) reconcileRbdMirror(clientMappingConfig *corev1.Con
 				return err
 			}
 			rbdMirror.Spec.Count = 1
+			rbdMirror.Spec.Placement = storageclusterctrl.GetPlacement(storageCluster, "rbd-mirror")
 			return nil
 		})
 		if err != nil {

--- a/internal/controller/mirroring/mirroring_controller.go
+++ b/internal/controller/mirroring/mirroring_controller.go
@@ -42,6 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -103,6 +104,26 @@ func (r *MirroringReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	)
 
+	placementChangePredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldSC, oldOk := e.ObjectOld.(*ocsv1.StorageCluster)
+			newSC, newOk := e.ObjectNew.(*ocsv1.StorageCluster)
+			if !oldOk || !newOk {
+				return false
+			}
+			// Trigger reconcile only if Spec.Placement changed
+			return !reflect.DeepEqual(oldSC.Spec.Placement, newSC.Spec.Placement)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
 	generationChangePredicate := builder.WithPredicates(predicate.GenerationChangedPredicate{})
 
 	return ctrl.NewControllerManagedBy(mgr).
@@ -139,6 +160,11 @@ func (r *MirroringReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			&rookCephv1.CephBlockPoolRadosNamespace{},
 			enqueueConfigMapRequest,
 			generationChangePredicate,
+		).
+		Watches(
+			&ocsv1.StorageCluster{},
+			enqueueConfigMapRequest,
+			builder.WithPredicates(placementChangePredicate),
 		).
 		Complete(r)
 }

--- a/internal/controller/mirroring/mirroring_controller_test.go
+++ b/internal/controller/mirroring/mirroring_controller_test.go
@@ -1,0 +1,85 @@
+package mirroring
+
+import (
+	"context"
+	"testing"
+
+	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
+	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
+	storageclusterctrl "github.com/red-hat-storage/ocs-operator/v4/internal/controller/storagecluster"
+	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
+
+	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func TestReconcileRbdMirror_UsesGetPlacement(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := rookCephv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := ocsv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := ocsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	namespace := "test-namespace"
+	storageCluster := &ocsv1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-storagecluster",
+			Namespace: namespace,
+		},
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-configmap",
+			Namespace: namespace,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(configMap, storageCluster).
+		WithIndex(&ocsv1alpha1.StorageConsumer{}, util.AnnotationIndexName, func(obj client.Object) []string {
+			consumer := obj.(*ocsv1alpha1.StorageConsumer)
+			if val, ok := consumer.Annotations[util.RequestMaintenanceModeAnnotation]; ok {
+				return []string{val}
+			}
+			return []string{}
+		}).
+		Build()
+
+	reconciler := &MirroringReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+		ctx:    context.TODO(),
+		log:    logf.Log.WithName("controller_mirroring_test"),
+	}
+
+	errorOccurred := reconciler.reconcileRbdMirror(configMap, true)
+	assert.False(t, errorOccurred)
+
+	rbdMirror := &rookCephv1.CephRBDMirror{}
+	err := fakeClient.Get(context.TODO(), types.NamespacedName{
+		Name:      util.CephRBDMirrorName,
+		Namespace: namespace,
+	}, rbdMirror)
+	assert.NoError(t, err)
+
+	expectedPlacement := storageclusterctrl.GetPlacement(storageCluster, "rbd-mirror")
+	assert.Equal(t, expectedPlacement, rbdMirror.Spec.Placement,
+		"RBDMirror placement should match GetPlacement(storageCluster, 'rbd-mirror')")
+}

--- a/internal/controller/storagecluster/blackbox_exporter.go
+++ b/internal/controller/storagecluster/blackbox_exporter.go
@@ -336,7 +336,7 @@ modules:
 
 // createBlackboxDeployment deploys the Blackbox Exporter
 func (r *StorageClusterReconciler) createBlackboxDeployment(ctx context.Context, instance *ocsv1.StorageCluster) error {
-	placement := getPlacement(instance, defaults.BlackboxExporterKey)
+	placement := GetPlacement(instance, defaults.BlackboxExporterKey)
 	desired := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      blackboxExporterName,

--- a/internal/controller/storagecluster/cephcluster.go
+++ b/internal/controller/storagecluster/cephcluster.go
@@ -490,12 +490,12 @@ func newCephCluster(r *StorageClusterReconciler, sc *ocsv1.StorageCluster, kmsCo
 			},
 			Placement: func() rookCephv1.PlacementSpec {
 				placement := rookCephv1.PlacementSpec{
-					"all": getPlacement(sc, "all"),
-					"mon": getPlacement(sc, "mon"),
-					"mgr": getPlacement(sc, "mgr"),
+					"all": GetPlacement(sc, "all"),
+					"mon": GetPlacement(sc, "mon"),
+					"mgr": GetPlacement(sc, "mgr"),
 				}
 				if arbiterEnabled(sc) {
-					placement["arbiter"] = getPlacement(sc, "arbiter")
+					placement["arbiter"] = GetPlacement(sc, "arbiter")
 				}
 				return placement
 			}(),
@@ -834,8 +834,8 @@ func newStorageClassDeviceSets(sc *ocsv1.StorageCluster) []rookCephv1.StorageCla
 			}
 
 			// Default placements for osd and prepareosd
-			defaultPlacement := getPlacement(sc, "osd")
-			defaultPreparePlacement := getPlacement(sc, "prepareosd")
+			defaultPlacement := GetPlacement(sc, "osd")
+			defaultPreparePlacement := GetPlacement(sc, "prepareosd")
 
 			// create a device class match expression
 			deviceClassMatchExpression := metav1.LabelSelectorRequirement{

--- a/internal/controller/storagecluster/cephcluster_test.go
+++ b/internal/controller/storagecluster/cephcluster_test.go
@@ -663,8 +663,8 @@ func TestStorageClassDeviceSetCreation(t *testing.T) {
 				assert.DeepEqual(t, deviceSet.DataPVCTemplate.Spec, scds.VolumeClaimTemplates[0].Spec)
 				assert.Equal(t, true, scds.Portable)
 				assert.Equal(t, sc.Spec.Encryption.ClusterWide, scds.Encrypted)
-				defaultExpectedOSDPlacement := getPlacement(sc, "osd")
-				defaultExpectedPreparePlacement := getPlacement(sc, "prepareosd")
+				defaultExpectedOSDPlacement := GetPlacement(sc, "osd")
+				defaultExpectedPreparePlacement := GetPlacement(sc, "prepareosd")
 
 				// create a device class match expression
 				deviceClassMatchExpression := metav1.LabelSelectorRequirement{
@@ -900,7 +900,7 @@ func TestStorageClassDeviceSetCreationForArbiter(t *testing.T) {
 		deviceSet := c.sc.Spec.StorageDeviceSets[0]
 
 		for i, scds := range actual {
-			defaultOsdPlacement := getPlacement(c.sc, "osd")
+			defaultOsdPlacement := GetPlacement(c.sc, "osd")
 			// create a device class match expression
 			deviceClassMatchExpression := metav1.LabelSelectorRequirement{
 				Key:      deviceClassPlacementKey,

--- a/internal/controller/storagecluster/cephfilesystem.go
+++ b/internal/controller/storagecluster/cephfilesystem.go
@@ -39,7 +39,7 @@ func (r *StorageClusterReconciler) newCephFilesystemInstances(initStorageCluster
 			MetadataServer: cephv1.MetadataServerSpec{
 				ActiveCount:   int32(getActiveMetadataServers(initStorageCluster)),
 				ActiveStandby: true,
-				Placement:     getPlacement(initStorageCluster, "mds"),
+				Placement:     GetPlacement(initStorageCluster, "mds"),
 				Resources:     getDaemonResources("mds", initStorageCluster),
 				// set PriorityClassName for the MDS pods
 				PriorityClassName: systemClusterCritical,

--- a/internal/controller/storagecluster/cephnfs.go
+++ b/internal/controller/storagecluster/cephnfs.go
@@ -33,7 +33,7 @@ func (r *StorageClusterReconciler) newCephNFSInstances(initData *ocsv1.StorageCl
 			Spec: cephv1.NFSGaneshaSpec{
 				Server: cephv1.GaneshaServerSpec{
 					Active:    1,
-					Placement: getPlacement(initData, "nfs"),
+					Placement: GetPlacement(initData, "nfs"),
 					Resources: getDaemonResources("nfs", initData),
 					// set high PriorityClassName for the NFS pods, since this will block io for
 					// pods using NFS volumes.

--- a/internal/controller/storagecluster/cephobjectstores.go
+++ b/internal/controller/storagecluster/cephobjectstores.go
@@ -209,7 +209,7 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 						},
 					},
 					Instances: int32(getCephObjectStoreGatewayInstances(initData)),
-					Placement: getPlacement(initData, "rgw"),
+					Placement: GetPlacement(initData, "rgw"),
 					Resources: getDaemonResources("rgw", initData),
 					// set PriorityClassName for the rgw pods
 					PriorityClassName: systemClusterCritical,

--- a/internal/controller/storagecluster/cephobjectstores_test.go
+++ b/internal/controller/storagecluster/cephobjectstores_test.go
@@ -74,7 +74,7 @@ func assertCephObjectStores(t *testing.T, reconciler *StorageClusterReconciler, 
 			t, func() bool { return expectedCos[0].Spec.Gateway.Instances == 1 },
 			"there should be one 'Spec.Gateway.Instances' by default")
 		assert.Equal(
-			t, expectedCos[0].Spec.Gateway.Placement, getPlacement(cr, "rgw"))
+			t, expectedCos[0].Spec.Gateway.Placement, GetPlacement(cr, "rgw"))
 	}
 
 	assert.Equal(t, len(expectedCos[0].OwnerReferences), 1)

--- a/internal/controller/storagecluster/cephrbdmirrors.go
+++ b/internal/controller/storagecluster/cephrbdmirrors.go
@@ -62,7 +62,7 @@ func (r *StorageClusterReconciler) newCephRbdMirrorInstances(initData *ocsv1.Sto
 					return initData.Spec.ManagedResources.CephRBDMirror.DaemonCount
 				}(),
 				Resources: getDaemonResources("rbd-mirror", initData),
-				Placement: getPlacement(initData, "rbd-mirror"),
+				Placement: GetPlacement(initData, "rbd-mirror"),
 			},
 		},
 	}

--- a/internal/controller/storagecluster/cephtoolbox.go
+++ b/internal/controller/storagecluster/cephtoolbox.go
@@ -36,8 +36,8 @@ func (r *StorageClusterReconciler) ensureToolsDeployment(sc *ocsv1.StorageCluste
 	var isFound bool
 	namespace := sc.Namespace
 
-	tolerations := getPlacement(sc, "toolbox").Tolerations
-	nodeAffinity := getPlacement(sc, "toolbox").NodeAffinity
+	tolerations := GetPlacement(sc, "toolbox").Tolerations
+	nodeAffinity := GetPlacement(sc, "toolbox").NodeAffinity
 
 	toolsDeployment := newToolsDeployment(namespace, tolerations, nodeAffinity)
 	foundToolsDeployment := &appsv1.Deployment{}

--- a/internal/controller/storagecluster/exporter.go
+++ b/internal/controller/storagecluster/exporter.go
@@ -473,9 +473,9 @@ func deployMetricsExporter(ctx context.Context, r *StorageClusterReconciler, ins
 						},
 					},
 				},
-				Tolerations: getPlacement(instance, defaults.MetricsExporterKey).Tolerations,
+				Tolerations: GetPlacement(instance, defaults.MetricsExporterKey).Tolerations,
 				Affinity: &corev1.Affinity{
-					NodeAffinity: getPlacement(instance, defaults.MetricsExporterKey).NodeAffinity,
+					NodeAffinity: GetPlacement(instance, defaults.MetricsExporterKey).NodeAffinity,
 				},
 			},
 		}

--- a/internal/controller/storagecluster/noobaa_system_reconciler.go
+++ b/internal/controller/storagecluster/noobaa_system_reconciler.go
@@ -164,7 +164,7 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 	if !r.IsNoobaaStandalone || !ok {
 		component = "noobaa-core"
 	}
-	placement := getPlacement(sc, component)
+	placement := GetPlacement(sc, component)
 
 	nb.Spec.Tolerations = placement.Tolerations
 	nb.Spec.Affinity = &nbv1.AffinitySpec{

--- a/internal/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/internal/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -371,7 +371,7 @@ func TestSetNooBaaDesiredState(t *testing.T) {
 		assert.Equalf(t, noobaa.Name, "noobaa", "[%s] noobaa name not set correctly", c.label)
 		assert.Equal(t, *noobaa.Spec.DBSpec.DBStorageClass, c.dbStorageClassName)
 		assert.Equal(t, *noobaa.Spec.PVPoolDefaultStorageClass, c.dbStorageClassName)
-		noobaaplacement := getPlacement(&c.sc, "noobaa-core")
+		noobaaplacement := GetPlacement(&c.sc, "noobaa-core")
 		topologyMap := c.sc.Status.NodeTopologies
 		if topologyMap != nil {
 			topologyKey := getFailureDomain(&c.sc)

--- a/internal/controller/storagecluster/placement.go
+++ b/internal/controller/storagecluster/placement.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// getPlacement returns placement configuration for ceph components with appropriate topology
-func getPlacement(sc *ocsv1.StorageCluster, component string) rookCephv1.Placement {
+// GetPlacement returns placement configuration for ceph components with appropriate topology
+func GetPlacement(sc *ocsv1.StorageCluster, component string) rookCephv1.Placement {
 	var placement rookCephv1.Placement
 	defaultPlacement := defaults.DaemonPlacements[component]
 	specifiedPlacement, specified := sc.Spec.Placement[rookCephv1.KeyType(component)]

--- a/internal/controller/storagecluster/placement_test.go
+++ b/internal/controller/storagecluster/placement_test.go
@@ -707,7 +707,7 @@ func TestGetPlacement(t *testing.T) {
 			if tt.name == "component with empty label selector" {
 				sc.Spec.LabelSelector = &metav1.LabelSelector{}
 			}
-			result := getPlacement(sc, tt.component)
+			result := GetPlacement(sc, tt.component)
 			assert.Equal(t, tt.expected, result)
 		})
 	}

--- a/internal/controller/storagecluster/provider_server.go
+++ b/internal/controller/storagecluster/provider_server.go
@@ -320,9 +320,9 @@ func GetProviderAPIServerDeployment(instance *ocsv1.StorageCluster) *appsv1.Depl
 							},
 						},
 					},
-					Tolerations: getPlacement(instance, defaults.APIServerKey).Tolerations,
+					Tolerations: GetPlacement(instance, defaults.APIServerKey).Tolerations,
 					Affinity: &corev1.Affinity{
-						NodeAffinity: getPlacement(instance, defaults.APIServerKey).NodeAffinity,
+						NodeAffinity: GetPlacement(instance, defaults.APIServerKey).NodeAffinity,
 					},
 					PriorityClassName:  systemClusterCritical,
 					ServiceAccountName: ocsProviderServerName,
@@ -402,7 +402,7 @@ func getOnboardingJobObject(instance *ocsv1.StorageCluster) *batchv1.Job {
 					},
 					// Use the same tolerations as the Provider API Server
 					// As the generator job is too insignificant to have it's own placement
-					Tolerations: getPlacement(instance, defaults.APIServerKey).Tolerations,
+					Tolerations: GetPlacement(instance, defaults.APIServerKey).Tolerations,
 				},
 			},
 		},

--- a/internal/controller/storagecluster/provider_server_test.go
+++ b/internal/controller/storagecluster/provider_server_test.go
@@ -359,9 +359,9 @@ func GetProviderAPIServerDeploymentForTest(instance *ocsv1.StorageCluster) *apps
 					},
 					PriorityClassName:  systemClusterCritical,
 					ServiceAccountName: ocsProviderServerName,
-					Tolerations:        getPlacement(instance, defaults.APIServerKey).Tolerations,
+					Tolerations:        GetPlacement(instance, defaults.APIServerKey).Tolerations,
 					Affinity: &corev1.Affinity{
-						NodeAffinity: getPlacement(instance, defaults.APIServerKey).NodeAffinity,
+						NodeAffinity: GetPlacement(instance, defaults.APIServerKey).NodeAffinity,
 					},
 				},
 			},

--- a/pkg/defaults/placements.go
+++ b/pkg/defaults/placements.go
@@ -64,7 +64,7 @@ var (
 			},
 			NodeAffinity: DefaultNodeAffinity,
 			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
-				// leave the label value empty as it will be updated with the objectStore name later in getPlacement()
+				// leave the label value empty as it will be updated with the objectStore name later in GetPlacement()
 				getTopologySpreadConstraint(1, "rook_object_store", []string{}, corev1.DoNotSchedule),
 			},
 		},
@@ -75,7 +75,7 @@ var (
 			},
 			NodeAffinity: DefaultNodeAffinity,
 			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
-				// leave the label value empty as it will be updated with the filesystem name later in getPlacement()
+				// leave the label value empty as it will be updated with the filesystem name later in GetPlacement()
 				getTopologySpreadConstraint(1, "rook_file_system", []string{}, corev1.DoNotSchedule),
 			},
 		},
@@ -86,7 +86,7 @@ var (
 			},
 			NodeAffinity: DefaultNodeAffinity,
 			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
-				// leave the label value empty as it will be updated with the nfs name later in getPlacement()
+				// leave the label value empty as it will be updated with the nfs name later in GetPlacement()
 				getTopologySpreadConstraint(1, "ceph_nfs", []string{}, corev1.DoNotSchedule),
 			},
 		},
@@ -145,7 +145,7 @@ var (
 func getTopologySpreadConstraint(maxSkew int32, labelKey string, labelValues []string, whenUnsatisfiable corev1.UnsatisfiableConstraintAction) corev1.TopologySpreadConstraint {
 	topologySpreadConstraint := corev1.TopologySpreadConstraint{
 		MaxSkew:           maxSkew,
-		TopologyKey:       corev1.LabelHostname, // TopologyKey gets updated with the failure domain in newStorageClassDeviceSets()/getPlacement()
+		TopologyKey:       corev1.LabelHostname, // TopologyKey gets updated with the failure domain in newStorageClassDeviceSets()/GetPlacement()
 		WhenUnsatisfiable: whenUnsatisfiable,
 		LabelSelector: &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{


### PR DESCRIPTION
Fix rbd-mirror pods failing to schedule on tainted nodes by using GetPlacement to configure placement from          StorageCluster. Add watch on StorageCluster to keep placement in sync.