### PR TITLE
DFBUGS-6406: [release-4.18] Send OCS Sub channel to clients after validating with PackageManifest

### DIFF
--- a/deploy/ocs-operator/manifests/provider-role.yaml
+++ b/deploy/ocs-operator/manifests/provider-role.yaml
@@ -61,6 +61,14 @@ rules:
       - operators.coreos.com
     resources:
       - subscriptions
+      - clusterserviceversions
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - packages.operators.coreos.com
+    resources:
+      - packagemanifests
     verbs:
       - get
       - list

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -61,6 +61,14 @@ rules:
       - operators.coreos.com
     resources:
       - subscriptions
+      - clusterserviceversions
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - packages.operators.coreos.com
+    resources:
+      - packagemanifests
     verbs:
       - get
       - list

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -18,6 +18,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
@@ -47,7 +48,9 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	klog "k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
@@ -70,6 +73,12 @@ const (
 	monSecret                        = "rook-ceph-mon"
 	volumeReplicationClass5mSchedule = "5m"
 	mirroringTokenKey                = "rbdMirrorBootstrapPeerSecretName"
+)
+
+var (
+	knownOcsInstalledCsvName        string
+	knownOcsSubscriptionChannelName string
+	ocsSubChannelAndCsvMutex        sync.Mutex
 )
 
 type OCSProviderServer struct {
@@ -1104,9 +1113,119 @@ func (s *OCSProviderServer) getOCSSubscriptionChannel(ctx context.Context) (stri
 		return sub.Spec.Package == "ocs-operator"
 	})
 	if subscription == nil {
-		return "", fmt.Errorf("unable to find ocs-operator subscription")
+		klog.Info("unable to find ocs-operator subscription")
+		return "", nil
 	}
-	return subscription.Spec.Channel, nil
+
+	ocsSubChannelAndCsvMutex.Lock()
+	defer ocsSubChannelAndCsvMutex.Unlock()
+
+	// If the installed CSV has changed then validate the current channel otherwise return the known valid channel
+	if subscription.Status.InstalledCSV != knownOcsInstalledCsvName {
+		ok, err := s.isSubscriptionChannelValid(ctx, subscription)
+		if err != nil || !ok {
+			return "", err
+		}
+		knownOcsInstalledCsvName = subscription.Status.InstalledCSV
+		knownOcsSubscriptionChannelName = subscription.Spec.Channel
+	}
+
+	return knownOcsSubscriptionChannelName, nil
+}
+
+func (s *OCSProviderServer) isSubscriptionChannelValid(ctx context.Context, subscription *opv1a1.Subscription) (bool, error) {
+	installedCSVName := subscription.Status.InstalledCSV
+	channelName := subscription.Spec.Channel
+	packageName := subscription.Spec.Package
+
+	// Check if the installed CSV of the subscription is in Succeeded phase
+	if installedCSVName == "" {
+		klog.Infof("subscription %q does not have an installed CSV", subscription.Name)
+		return false, nil
+	}
+	csv := &opv1a1.ClusterServiceVersion{}
+	err := s.client.Get(ctx, client.ObjectKey{Name: installedCSVName, Namespace: s.namespace}, csv)
+	if err != nil {
+		klog.Errorf("failed to get installed CSV %q: %v", installedCSVName, err)
+		return false, err
+	}
+	if csv.Status.Phase != opv1a1.CSVPhaseSucceeded {
+		klog.Infof("installed CSV %q is in phase %q, not Succeeded", csv.Name, csv.Status.Phase)
+		return false, nil
+	}
+
+	// Check if the installed CSV is the expected one for the channel from the package manifest
+	packageManifestList := &unstructured.UnstructuredList{}
+	packageManifestList.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "packages.operators.coreos.com",
+		Version: "v1",
+		Kind:    "PackageManifest",
+	})
+	err = s.client.List(
+		ctx,
+		packageManifestList,
+		client.InNamespace(s.namespace),
+		// Field match prone to future change, but better than processing hundreds of resources, consuming more CPU/memory
+		client.MatchingFields{"metadata.name": packageName},
+	)
+	if err != nil {
+		klog.Errorf("failed to list packageManifests for package %q: %v", packageName, err)
+		return false, err
+	}
+	var packageManifest *unstructured.Unstructured
+	for i := range packageManifestList.Items {
+		pm := &packageManifestList.Items[i]
+		labels := pm.GetLabels()
+		if labels["catalog"] == subscription.Spec.CatalogSource &&
+			labels["catalog-namespace"] == subscription.Spec.CatalogSourceNamespace {
+			packageManifest = pm
+			break
+		}
+	}
+	if packageManifest == nil {
+		klog.Errorf("PackageManifest %q not found for catalog %q in namespace %q",
+			packageName, subscription.Spec.CatalogSource, subscription.Spec.CatalogSourceNamespace)
+		return false, nil
+	}
+	channels, found, err := unstructured.NestedSlice(packageManifest.Object, "status", "channels")
+	if err != nil {
+		klog.Errorf("error getting channels from PackageManifest %q: %v", packageManifest.GetName(), err)
+		return false, err
+	}
+	if !found {
+		klog.Infof("channels not found in PackageManifest %q", packageManifest.GetName())
+		return false, nil
+	}
+	for _, ch := range channels {
+		chMap, ok := ch.(map[string]any)
+		if !ok {
+			continue
+		}
+		if chn, ok := chMap["name"].(string); !ok || chn != channelName {
+			continue
+		}
+		entries, ok := chMap["entries"].([]any)
+		if !ok {
+			klog.Infof("channel %q in PackageManifest %q has no entries", channelName, packageManifest.GetName())
+			return false, nil
+		}
+		for _, entry := range entries {
+			entryMap, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			if entryCSVName, ok := entryMap["name"].(string); ok && entryCSVName == installedCSVName {
+				klog.Infof("subscription for %q with channel %q is valid with installed CSV %q",
+					subscription.Spec.Package, channelName, installedCSVName)
+				return true, nil
+			}
+		}
+		klog.Infof("installed CSV %q is not in channel %q entries in PackageManifest %q",
+			installedCSVName, channelName, packageManifest.GetName())
+		return false, nil
+	}
+	klog.Infof("channel %q not found in PackageManifest %q", channelName, packageManifest.GetName())
+	return false, nil
 }
 
 func isEncryptionInTransitEnabled(networkSpec *rookCephv1.NetworkSpec) bool {


### PR DESCRIPTION
A subscription channel change is pushed to the client and can start its upgrade. If the client updates before the provider’s CSV is ready, the provider may treat the client as ahead and set NotUpgradeable, deadlocking the path. Even requiring the provider CSV in Succeeded phase first, leaves a brief window where spec.channel is already updated but installedCSV lags the new graph; we would still advertise a channel the cluster has not fully moved to.
After the CSV is Succeeded, validate the channel by loading the ocs-operator PackageManifest (unstructured) and matching status.installedCSV to an entry in status.channels[].entries[].name for spec.channel—not to currentCSV alone, since the catalog head does not represent every valid patch on the line. That rejects the inconsistent window while still allowing non-tip patch levels. Serialize cached state with a mutex on concurrent provider RPCs;
add RBAC to get ClusterServiceVersions and PackageManifests in the operator namespace.

Backport of https://github.com/red-hat-storage/ocs-operator/pull/3227, https://github.com/red-hat-storage/ocs-operator/pull/3296, https://github.com/red-hat-storage/ocs-operator/pull/3796