### PR TITLE
DFBUGS-5812: [release-4.21] metrics: update metrics port

### DIFF
--- a/controllers/storagecluster/exporter.go
+++ b/controllers/storagecluster/exporter.go
@@ -28,7 +28,7 @@ const (
 	metricsExporterName     = "ocs-metrics-exporter"
 	prometheusRoleName      = "ocs-metrics-svc"
 	metricsExporterRoleName = metricsExporterName
-	metricsMainPort         = 18080
+	metricsMainPort         = 18082
 	metricsSelfPort         = 18081
 	portMetricsMain         = "https-main"
 	portMetricsSelf         = "https-self"

--- a/metrics/deploy/deployment.yaml
+++ b/metrics/deploy/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         image: quay.io/brancz/kube-rbac-proxy:v0.17.1
         args:
           - '--secure-listen-address=0.0.0.0:8443'
-          - '--upstream=http://127.0.0.1:18080/'
+          - '--upstream=http://127.0.0.1:18082/'
           - --tls-cert-file=/etc/tls/private/tls.crt
           - --tls-private-key-file=/etc/tls/private/tls.key
           - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
@@ -98,13 +98,13 @@ spec:
         readinessProbe:
           httpGet:
             path: /metrics
-            port: 18080
+            port: 18082
             scheme: HTTP
           initialDelaySeconds: 15
         livenessProbe:
           httpGet:
             path: /healthz
-            port: 18080
+            port: 18082
             scheme: HTTP
           initialDelaySeconds: 15
         image: quay.io/ocs-dev/ocs-operator
@@ -117,7 +117,7 @@ spec:
           - '--ceph-auth-namespace'
           - openshift-storage
           - '--port'
-          - "18080"
+          - "18082"
           - '--exporter-port'
           - "18081"
         securityContext:


### PR DESCRIPTION
this commit updates the metrics port to
18082 as 18080 is being used by core dns
in case host networking is enabled.

The initial code change with 18080 passed because
it was tested without the flag --host 127.0.0.1
https://github.com/red-hat-storage/ocs-operator/pull/3733/changes#diff-c8c2ada9fa19662b34e42e041169be42d88a1f7ff1c81700f82cb8ac683e0509R471

Hence we didnt see this error.
I have tested this change in both internal mode cluster
and host enabled cluster: 18082 port is not being used
