### PR TITLE
Remove duplicate PVC usage alerts from local ceph rules

### DIFF
--- a/internal/controller/storagecluster/cephcluster_test.go
+++ b/internal/controller/storagecluster/cephcluster_test.go
@@ -1283,7 +1283,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 func TestParsePrometheusRules(t *testing.T) {
 	prometheusRules, err := parsePrometheusRule(localPrometheusRules)
 	assert.NilError(t, err)
-	assert.Equal(t, 12, len(prometheusRules.Spec.Groups))
+	assert.Equal(t, 11, len(prometheusRules.Spec.Groups))
 
 	prometheusRules, err = parsePrometheusRule(externalPrometheusRules)
 	assert.NilError(t, err)

--- a/internal/controller/storagecluster/prometheus/localcephrules.yaml
+++ b/internal/controller/storagecluster/prometheus/localcephrules.yaml
@@ -235,36 +235,6 @@ spec:
       for: 1h
       labels:
         severity: warning
-  - name: persistent-volume-alert.rules
-    rules:
-    - alert: PersistentVolumeUsageNearFull
-      annotations:
-        description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed 90%. Free up some space or expand the PVC.
-        message: PVC {{ $labels.persistentvolumeclaim }} is nearing full. Data deletion or PVC expansion is required.
-        severity_level: warning
-        storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/PersistentVolumeUsageNearFull.md
-      expr: |
-        max by (namespace, persistentvolumeclaim) (
-          (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"}))
-        ) > 0.90
-      for: 5s
-      labels:
-        severity: warning
-    - alert: PersistentVolumeUsageCritical
-      annotations:
-        description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed 95%. Free up some space or expand the PVC immediately.
-        message: PVC {{ $labels.persistentvolumeclaim }} is critically full. Data deletion or PVC expansion is required.
-        severity_level: error
-        storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/PersistentVolumeUsageCritical.md
-      expr: |
-        max by (namespace, persistentvolumeclaim) (
-          (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"}))
-        ) > 0.95
-      for: 5s
-      labels:
-        severity: critical
   - name: cluster-state-alert.rules
     rules:
     - alert: CephClusterErrorState


### PR DESCRIPTION

- Remove the `persistent-volume-alert.rules` group from localcephrules.yaml (PersistentVolumeUsageNearFull and PersistentVolumeUsageCritical)
- These alerts are now owned by ocs-client-operator's prometheus-pvc-rules


Fixes: https://redhat.atlassian.net/browse/DFBUGS-4768

