### PR TITLE
controllers: update keyType of rbdMirrorPeer based on the annotation

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -55,6 +55,9 @@ const (
 	poolTypeMetadata = "metadata"
 )
 
+const (
+	rbdMirrorUserTypeAnnotationKey = "ocs.openshift.io/rbdMirroringKeyType"
+)
 
 type knownDiskType struct {
 	speed            diskSpeed
@@ -506,11 +509,20 @@ func newCephCluster(r *StorageClusterReconciler, sc *ocsv1.StorageCluster, kmsCo
 		return nil, err
 	}
 
+	rbdMirrorPeerKeyType := "aes256k"
+	annotations := sc.GetAnnotations()
+	if val := annotations[rbdMirrorUserTypeAnnotationKey]; val != "" {
+		rbdMirrorPeerKeyType = annotations[rbdMirrorUserTypeAnnotationKey]
+	}
+
 	security := rookCephv1.ClusterSecuritySpec{
 		CephX: rookCephv1.ClusterCephxConfig{
 			Daemon: rookCephv1.CephxConfig{
 				KeyRotationPolicy: rookCephv1.KeyGenerationCephxKeyRotationPolicy,
 				KeyGeneration:     uint32(desiredCephxKeyGen),
+			},
+			RBDMirrorPeer: rookCephv1.CephxConfig{
+				KeyType: rookCephv1.CephxKeyType(rbdMirrorPeerKeyType),
 			},
 			AllowedCiphers: []rookCephv1.CephxKeyType{
 				rookCephv1.CephxKeyTypeAes,


### PR DESCRIPTION
The keyType matches the annotation value when present, otherwise it uses the new default keyType.