### PR TITLE
Clear stale ceph Upgradeable condition when cluster is healthy

### DIFF
--- a/internal/controller/storagecluster/cephcluster.go
+++ b/internal/controller/storagecluster/cephcluster.go
@@ -325,6 +325,7 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 			util.MapExternalCephClusterNegativeConditions(&r.conditions, found)
 		} else {
 			util.MapCephClusterNegativeConditions(&r.conditions, found)
+			util.RemoveCephClusterNegativeConditions(&sc.Status.Conditions, found)
 		}
 	}
 

--- a/pkg/util/status.go
+++ b/pkg/util/status.go
@@ -223,6 +223,24 @@ func RemoveExternalCephClusterNegativeConditions(conditions *[]conditionsv1.Cond
 	}
 }
 
+// RemoveCephClusterNegativeConditions clears stale ceph-origin Upgradeable=False from StorageCluster status once internal CephCluster is Created and HEALTH_OK.
+func RemoveCephClusterNegativeConditions(conditions *[]conditionsv1.Condition, found *cephv1.CephCluster) {
+	if found.Status.State != cephv1.ClusterStateCreated {
+		return
+	}
+	if found.Status.CephStatus != nil && found.Status.CephStatus.Health != "HEALTH_OK" {
+		return
+	}
+	c := conditionsv1.FindStatusCondition(*conditions, conditionsv1.ConditionUpgradeable)
+	if c == nil || c.Status != corev1.ConditionFalse {
+		return
+	}
+	switch c.Reason {
+	case "ClusterStateCreating", "ClusterStateUpdating", "CephClusterHealthNotOK":
+		conditionsv1.RemoveStatusCondition(conditions, conditionsv1.ConditionUpgradeable)
+	}
+}
+
 // MapCephClusterNoConditions sets status conditions to progressing. Used when component operator isn't
 // reporting any status, and we have to assume progress.
 func MapCephClusterNoConditions(conditions *[]conditionsv1.Condition, reason string, message string) {


### PR DESCRIPTION
MapCephClusterNegativeConditions only adds negatives. Upgradeable=False from an earlier Creating/updating or unhealthy phase could remain in StorageCluster status after Ceph reached Created and HEALTH_OK.

Add RemoveCephClusterNegativeConditions to drop that ceph-origin Upgradeable=False from status when appropriate, and invoke it from the internal Ceph reconcile path after mapping negatives.

Ref-https://redhat.atlassian.net/browse/DFBUGS-6544

Assisted by AI

Inspired from https://github.com/red-hat-storage/ocs-operator/pull/1947