### PR TITLE
DFBUGS-6705:[release-4.20] fix isEncrptionSettingUpdated method

### DIFF
--- a/controllers/storagecluster/cephcluster.go
+++ b/controllers/storagecluster/cephcluster.go
@@ -334,7 +334,8 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 	cephCluster.Spec.Storage.Store = updateOSDStore(found.Spec.Storage.Store)
 
 	// confirm OSD migration if encryption is enabled as day-2 operation
-	if isEncrptionSettingUpdated(sc.Spec.Encryption.ClusterWide, found.Spec.Storage.StorageClassDeviceSets) {
+	encryptionEnabled := sc.Spec.Encryption.ClusterWide || sc.Spec.Encryption.Enable
+	if isEncrptionSettingUpdated(encryptionEnabled, found.Spec.Storage.StorageClassDeviceSets) {
 		cephCluster.Spec.Storage.Migration.Confirmation = "yes-really-migrate-osds"
 	} else {
 		// keeping the same expected state in the corresponding reconcile once encryption is enabled

--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -1991,7 +1991,7 @@ func TestDetermineDefaultCephDeviceClass(t *testing.T) {
 }
 
 func TestIsEncrptionSettingUpdated(t *testing.T) {
-	newStorageClassDeviceSet := []rookCephv1.StorageClassDeviceSet{
+	unencryptedDeviceSets := []rookCephv1.StorageClassDeviceSet{
 		{
 			Name:      "set1",
 			Encrypted: false,
@@ -2002,13 +2002,69 @@ func TestIsEncrptionSettingUpdated(t *testing.T) {
 		},
 	}
 
-	// encryption setting has changed
-	actualResult := isEncrptionSettingUpdated(true, newStorageClassDeviceSet)
-	assert.Equal(t, true, actualResult)
+	encryptedDeviceSets := []rookCephv1.StorageClassDeviceSet{
+		{
+			Name:      "set1",
+			Encrypted: true,
+		},
+		{
+			Name:      "set2",
+			Encrypted: true,
+		},
+	}
 
-	// encryption setting has not changed
-	actualResult = isEncrptionSettingUpdated(false, newStorageClassDeviceSet)
-	assert.Equal(t, false, actualResult)
+	cases := []struct {
+		desc              string
+		clusterWide       bool
+		legacyEnable      bool
+		existingDeviceSet []rookCephv1.StorageClassDeviceSet
+		expected          bool
+	}{
+		{
+			desc:              "clusterWide enabled, devices unencrypted - should detect change",
+			clusterWide:       true,
+			existingDeviceSet: unencryptedDeviceSets,
+			expected:          true,
+		},
+		{
+			desc:              "neither enabled, devices unencrypted - no change",
+			existingDeviceSet: unencryptedDeviceSets,
+			expected:          false,
+		},
+		{
+			desc:              "legacy enable set, devices unencrypted - should detect change",
+			legacyEnable:      true,
+			existingDeviceSet: unencryptedDeviceSets,
+			expected:          true,
+		},
+		{
+			desc:              "both clusterWide and legacy enable set, devices unencrypted - should detect change",
+			clusterWide:       true,
+			legacyEnable:      true,
+			existingDeviceSet: unencryptedDeviceSets,
+			expected:          true,
+		},
+		{
+			desc:              "legacy enable set, devices already encrypted - no change",
+			legacyEnable:      true,
+			existingDeviceSet: encryptedDeviceSets,
+			expected:          false,
+		},
+		{
+			desc:              "clusterWide enabled, devices already encrypted - no change",
+			clusterWide:       true,
+			existingDeviceSet: encryptedDeviceSets,
+			expected:          false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			encryptionEnabled := c.clusterWide || c.legacyEnable
+			actual := isEncrptionSettingUpdated(encryptionEnabled, c.existingDeviceSet)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
 }
 
 func TestGetCephClusterCephConfig(t *testing.T) {


### PR DESCRIPTION
isEncrptionSettingUpdated only checks the
spec.encryption.clusterWide option before
deciding to set the `yes-really-migrate-osds`
flag to cephCluster.

For legacy cluster, < 4.10, the storagecluster
only has spec.encryption.enable for encryption.

So this PR updates the isEncrptionSettingUpdated
function to check for both `spec.encryption.enable` and ``spec.encryption.clusterWide` before setting
the "yes-really-migration-osds` flag in the cephcluster.


(cherry picked from commit 48fbd0338ab4c1a29e7c7e2c053137ca410f1184)