### PR TITLE
server: fix panic in server when srcKubeObj is nil

### DIFF
--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -2598,7 +2598,7 @@ func getKubeResourcesForClass[T CommonClassSpecAccessors](
 				logger.Info("Encountered unsupported provisioner", "Resource", classDisplayName, "Name", srcName)
 			} else if errors.Is(err, util.ErrUnsupportedDriver) {
 				logger.Info("Encountered unsupported driver", "Resource", classDisplayName, "Name", srcName)
-			} else if reflect.ValueOf(srcKubeObj).IsNil() {
+			} else if srcKubeObj == nil || reflect.ValueOf(srcKubeObj).IsNil() {
 				logger.Info("Resource name does not points to a builtin or an existing object, skipping", "Resource", classDisplayName, "Name", srcName)
 			} else if srcKubeObj.GetLabels()[util.ExternalClassLabelKey] == "true" {
 				logger.Info("Resource is an external object, skipping", "Resource", classDisplayName, "Name", srcName)


### PR DESCRIPTION
add a check in getKubeResourcesForClasses, to fix panic when srcKubeObj is nil

Fixes: [DFBUGS-6760](https://redhat.atlassian.net/browse/DFBUGS-6760)
