### PR TITLE
disable dual-stack on CephCluster

### DIFF
--- a/internal/controller/storagecluster/cephcluster.go
+++ b/internal/controller/storagecluster/cephcluster.go
@@ -256,6 +256,7 @@ func (obj *ocsCephCluster) ensureCreated(r *StorageClusterReconciler, sc *ocsv1.
 	// So spec.Network.DualStack never set to true in the CephCluster resource
 	r.Log.Info("Setting IPFamily", "IPFamily", ipFamily, "CephCluster", klog.KRef(cephCluster.Namespace, cephCluster.Name))
 	cephCluster.Spec.Network.IPFamily = ipFamily
+	cephCluster.Spec.Network.DualStack = false
 
 	// Check if this CephCluster already exists
 	found := &rookCephv1.CephCluster{}


### PR DESCRIPTION
Explicitly set DualStack=false on the CephCluster to prevent Rook from enabling --ms-bind-ipv6=true on MGR daemons. When dual-stack is enabled, Rook passes --public-addr with only the pod's IPv4 address, causing the MGR to bind its IPv6 listener to the unroutable wildcard [::]. OSDs then fail to connect to the MGR, PG stats are never reported, and the cluster is stuck in Progressing state.

The DualStack=false safeguard was inadvertently removed in PR #3651 while refactoring getIPFamilyConfig() for IPv6-primary support. IPv6-primary clusters are unaffected by this change since IPFamily is still set from the primary cluster network CIDR.