### PR TITLE
autoscaler: add atleast 10% of storage with scaling

### DIFF
--- a/docs/design/storage-auto-scale.md
+++ b/docs/design/storage-auto-scale.md
@@ -100,7 +100,13 @@ Controller:
        
     1)  If the Osd size is less than maxOsdSize(default:8Tib), do vertical scaling by doubling the each osd sizes for that device class.
             
-    2)  If the Osd size is equal to maxOsdSize(default:8Tib), do a horizontal scaling, by adding 1 osd of maxOsdSize(default:8Tib) on each `storageDeviceSet`.
+    2)  If the Osd size is equal to maxOsdSize(default:8Tib), do a horizontal scaling, by adding x osd of maxOsdSize(default:8Tib) on each `storageDeviceSet`.   Calculation of x?
+    -   Calculate 10% of the current total storage capacity
+    -   Determine how many OSDs are needed to achieve this capacity increase 
+    -   Convert to device sets (accounting for replicas), with a minimum of 1 device set 
+    -   Check if adding the calculated device sets would exceed storageCapacityLimit 
+    -   If limit would be exceeded, calculate the maximum device sets that can be added without exceeding the limit 
+    -   If not even 1 device set can be added, mark limitReached as true and don't scale
    
 10) Calculate the `expectedStorageCapacity` based on expected size and count.
    

--- a/internal/controller/storageautoscaler/storageautoscaler_controller.go
+++ b/internal/controller/storageautoscaler/storageautoscaler_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"time"
@@ -157,10 +158,10 @@ func (r *StorageAutoscalerReconciler) Reconcile(ctx context.Context, request rec
 	r.Log.Info("scaling is required", "device class", storageAutoScaler.Spec.DeviceClass)
 
 	// calculate the expectedStorageCapacity
-	startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity := calculateExpectedOsdSizeAndCount(storageCluster, storageAutoScaler)
+	startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity, devicesToAdd, limitReached := calculateExpectedOsdSizeAndCount(storageCluster, storageAutoScaler)
 
-	if expectedStorageCapacity.Cmp(storageAutoScaler.Spec.StorageCapacityLimit) > 0 {
-		r.Log.Info("storage capacity limit reached")
+	if limitReached {
+		r.Log.Info("storage capacity limit reached, cannot scale further")
 		// update the status
 		bool := true
 		storageAutoScaler.Status.StorageCapacityLimitReached = &bool
@@ -200,7 +201,8 @@ func (r *StorageAutoscalerReconciler) Reconcile(ctx context.Context, request rec
 		if deviceClassMatchesDeviceSet(deviceClass, deviceSet) {
 			storageCluster.Spec.StorageDeviceSets[i].DataPVCTemplate.Spec.Resources.Requests["storage"] = expectedOsdSize
 			if startOsdCount != expectedOsdCount {
-				storageCluster.Spec.StorageDeviceSets[i].Count = storageCluster.Spec.StorageDeviceSets[i].Count + 1
+				// use the calculated devicesToAdd from calculateExpectedOsdSizeAndCount
+				storageCluster.Spec.StorageDeviceSets[i].Count = storageCluster.Spec.StorageDeviceSets[i].Count + devicesToAdd
 			}
 			r.Log.Info("scaling storage cluster", "device set", storageCluster.Spec.StorageDeviceSets[i])
 		}
@@ -525,9 +527,10 @@ func (r *StorageAutoscalerReconciler) checkIfCephClusterIsNotHealthy(ctx context
 	return false, nil
 }
 
-func calculateExpectedOsdSizeAndCount(storageCluster *ocsv1.StorageCluster, storageAutoScaler *ocsv1.StorageAutoScaler) (resource.Quantity, resource.Quantity, int, int, resource.Quantity, resource.Quantity) {
+func calculateExpectedOsdSizeAndCount(storageCluster *ocsv1.StorageCluster, storageAutoScaler *ocsv1.StorageAutoScaler) (resource.Quantity, resource.Quantity, int, int, resource.Quantity, resource.Quantity, int, bool) {
 	var startOsdSize, expectedOsdSize resource.Quantity
-	var startOsdCount, expectedOsdCount, deviceSetCount, replicaCount int
+	var startOsdCount, expectedOsdCount, deviceSetCount, replicaCount, devicesToAdd int
+	var limitReached bool
 
 	// assuming heterogeneous distribution of osd across device sets
 	// so osd size and count is same for all device sets
@@ -550,14 +553,56 @@ func calculateExpectedOsdSizeAndCount(storageCluster *ocsv1.StorageCluster, stor
 		// vertical scaling
 		// double the osd size
 		expectedOsdSize = *resource.NewQuantity(startOsdSize.Value()*2, startOsdSize.Format)
+
+		// check if vertical scaling would exceed the limit
+		expectedCapacity := *resource.NewQuantity(int64(deviceSetCount*startOsdCount)*expectedOsdSize.Value(), expectedOsdSize.Format)
+		if expectedCapacity.Cmp(storageAutoScaler.Spec.StorageCapacityLimit) > 0 {
+			// cannot scale even vertically
+			limitReached = true
+		}
 	} else {
 		// horizontal scaling
-		expectedOsdCount = ((startOsdCount / replicaCount) + 1) * replicaCount
+		// increase by 10% of the cluster capacity (minimum 1 device set)
+		// calculate 10% of total capacity
+		currentCapacity := int64(startOsdCount) * startOsdSize.Value()
+		targetIncrease := currentCapacity / 10
+
+		// calculate how many OSDs needed to achieve this capacity increase
+		capacityPerDeviceSet := int64(replicaCount) * startOsdSize.Value()
+
+		// convert to device sets (accounting for replicas)
+		devicesToAdd = int(math.Ceil(float64(targetIncrease) / float64(capacityPerDeviceSet)))
+		if devicesToAdd < 1 {
+			devicesToAdd = 1
+		}
+
+		// check if adding devicesToAdd would exceed the limit
+		potentialOsdCount := ((startOsdCount / replicaCount) + devicesToAdd) * replicaCount
+		potentialCapacity := *resource.NewQuantity(int64(deviceSetCount*potentialOsdCount)*startOsdSize.Value(), startOsdSize.Format)
+
+		if potentialCapacity.Cmp(storageAutoScaler.Spec.StorageCapacityLimit) > 0 {
+			// calculate the maximum device sets we can add without exceeding the limit
+			remainingCapacity := storageAutoScaler.Spec.StorageCapacityLimit.Value() - startStorageCapacity.Value()
+			capacityPerDeviceSet := int64(replicaCount*deviceSetCount) * startOsdSize.Value()
+
+			maxDeviceSetsToAdd := int(remainingCapacity / capacityPerDeviceSet)
+
+			if maxDeviceSetsToAdd < 1 {
+				// cannot add even one device set, limit reached
+				limitReached = true
+				devicesToAdd = 1
+			} else {
+				// add the maximum we can without exceeding the limit
+				devicesToAdd = maxDeviceSetsToAdd
+			}
+		}
+
+		expectedOsdCount = ((startOsdCount / replicaCount) + devicesToAdd) * replicaCount
 	}
 
 	expectedStorageCapacity := *resource.NewQuantity(int64(deviceSetCount*expectedOsdCount)*expectedOsdSize.Value(), startOsdSize.Format)
 
-	return startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity
+	return startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity, devicesToAdd, limitReached
 }
 
 func deviceClassMatchesDeviceSet(deviceClass string, deviceSet ocsv1.StorageDeviceSet) bool {

--- a/internal/controller/storageautoscaler/storageautoscaler_controller_test.go
+++ b/internal/controller/storageautoscaler/storageautoscaler_controller_test.go
@@ -39,17 +39,20 @@ func TestCalculateExpectedOsdSizeAndCount(t *testing.T) {
 
 		storageautoscaler := &ocsv1.StorageAutoScaler{
 			Spec: ocsv1.StorageAutoScalerSpec{
-				DeviceClass: "ssd",
-				MaxOsdSize:  resource.MustParse("1Ti"),
+				DeviceClass:          "ssd",
+				MaxOsdSize:           resource.MustParse("1Ti"),
+				StorageCapacityLimit: resource.MustParse("100Ti"),
 			},
 		}
 
-		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
+		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity, devicesToAdd, limitReached := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
 
 		assert.Equal(t, resource.MustParse("1Ti"), startOsdSize)
 		assert.Equal(t, resource.MustParse("1Ti"), expectedOsdSize)
 		assert.Equal(t, 9, startOsdCount)
 		assert.Equal(t, 12, expectedOsdCount)
+		assert.Equal(t, 1, devicesToAdd)
+		assert.False(t, limitReached)
 		testExpectedStorageCapacity := resource.MustParse("12Ti")
 		assert.True(t, testExpectedStorageCapacity.Cmp(expectedStorageCapacity) == 0, "Quantities are equal")
 		testStartStorageCapacity := resource.MustParse("9Ti")
@@ -80,12 +83,13 @@ func TestCalculateExpectedOsdSizeAndCount(t *testing.T) {
 
 		storageautoscaler := &ocsv1.StorageAutoScaler{
 			Spec: ocsv1.StorageAutoScalerSpec{
-				DeviceClass: "ssd",
-				MaxOsdSize:  resource.MustParse("4Ti"),
+				DeviceClass:          "ssd",
+				MaxOsdSize:           resource.MustParse("4Ti"),
+				StorageCapacityLimit: resource.MustParse("100Ti"),
 			},
 		}
 
-		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
+		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity, devicesToAdd, limitReached := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
 
 		testStartOsdSize := resource.MustParse("1Ti")
 		assert.True(t, testStartOsdSize.Cmp(startOsdSize) == 0, "Quantities are equal")
@@ -93,10 +97,333 @@ func TestCalculateExpectedOsdSizeAndCount(t *testing.T) {
 		assert.True(t, testExpectedOsdSize.Cmp(expectedOsdSize) == 0, "Quantities are equal")
 		assert.Equal(t, 9, startOsdCount)
 		assert.Equal(t, 9, expectedOsdCount)
+		assert.Equal(t, 0, devicesToAdd)
+		assert.False(t, limitReached)
 		testExpectedStorageCapacity := resource.MustParse("18Ti")
 		assert.True(t, testExpectedStorageCapacity.Cmp(expectedStorageCapacity) == 0, "Quantities are equal")
 		testStartStorageCapacity := resource.MustParse("9Ti")
 		assert.True(t, testStartStorageCapacity.Cmp(startStorageCapacity) == 0, "Quantities are equal")
+	})
+
+	// vertical scaling hits capacity limit
+	t.Run("vertical scaling hits capacity limit", func(t *testing.T) {
+		storagecluster := &ocsv1.StorageCluster{
+			Spec: ocsv1.StorageClusterSpec{
+				StorageDeviceSets: []ocsv1.StorageDeviceSet{
+					{
+						Count:   3,
+						Replica: 3,
+						DataPVCTemplate: v1.PersistentVolumeClaim{
+							Spec: v1.PersistentVolumeClaimSpec{
+								Resources: v1.VolumeResourceRequirements{
+									Requests: v1.ResourceList{
+										"storage": resource.MustParse("2Ti"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		storageautoscaler := &ocsv1.StorageAutoScaler{
+			Spec: ocsv1.StorageAutoScalerSpec{
+				DeviceClass:          "ssd",
+				MaxOsdSize:           resource.MustParse("8Ti"),
+				StorageCapacityLimit: resource.MustParse("20Ti"), // 3*3*2Ti = 18Ti, doubling would be 36Ti > 20Ti
+			},
+		}
+
+		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity, devicesToAdd, limitReached := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
+
+		testStartOsdSize := resource.MustParse("2Ti")
+		assert.True(t, testStartOsdSize.Cmp(startOsdSize) == 0, "Start OSD size should be 2Ti")
+		// Even though limit is reached, expectedOsdSize is still calculated (but won't be applied)
+		testExpectedOsdSize := resource.MustParse("4Ti")
+		assert.True(t, testExpectedOsdSize.Cmp(expectedOsdSize) == 0, "Expected OSD size should be 4Ti")
+		assert.Equal(t, 9, startOsdCount)
+		assert.Equal(t, 9, expectedOsdCount) // count doesn't change in vertical scaling
+		assert.Equal(t, 0, devicesToAdd)
+		assert.True(t, limitReached) // limit should be reached
+		// expectedStorageCapacity shows what it would be if we scaled
+		testExpectedStorageCapacity := resource.MustParse("36Ti")
+		assert.True(t, testExpectedStorageCapacity.Cmp(expectedStorageCapacity) == 0, "Expected capacity would be 36Ti")
+		testStartStorageCapacity := resource.MustParse("18Ti")
+		assert.True(t, testStartStorageCapacity.Cmp(startStorageCapacity) == 0, "Start capacity should be 18Ti")
+	})
+
+	// horizontal scaling with 10% calculation - large cluster
+	t.Run("horizontal scaling with 10% calculation - large cluster", func(t *testing.T) {
+		storagecluster := &ocsv1.StorageCluster{
+			Spec: ocsv1.StorageClusterSpec{
+				StorageDeviceSets: []ocsv1.StorageDeviceSet{
+					{
+						Count:   50, // large cluster
+						Replica: 3,
+						DataPVCTemplate: v1.PersistentVolumeClaim{
+							Spec: v1.PersistentVolumeClaimSpec{
+								Resources: v1.VolumeResourceRequirements{
+									Requests: v1.ResourceList{
+										"storage": resource.MustParse("8Ti"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		storageautoscaler := &ocsv1.StorageAutoScaler{
+			Spec: ocsv1.StorageAutoScalerSpec{
+				DeviceClass:          "ssd",
+				MaxOsdSize:           resource.MustParse("8Ti"), // already at max, so horizontal scaling
+				StorageCapacityLimit: resource.MustParse("2000Ti"),
+			},
+		}
+
+		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity, devicesToAdd, limitReached := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
+
+		assert.Equal(t, resource.MustParse("8Ti"), startOsdSize)
+		assert.Equal(t, resource.MustParse("8Ti"), expectedOsdSize)
+		assert.Equal(t, 150, startOsdCount) // 50*3
+		// 10% of 1200Ti (150*8Ti) = 120Ti, 120Ti/8Ti = 15 OSDs, 15/3 replicas = 5 device sets
+		// So expectedOsdCount = (50+5)*3 = 165
+		assert.Equal(t, 165, expectedOsdCount)
+		assert.Equal(t, 5, devicesToAdd) // should add 5 device sets
+		assert.False(t, limitReached)
+		testExpectedStorageCapacity := resource.MustParse("1320Ti")
+		assert.True(t, testExpectedStorageCapacity.Cmp(expectedStorageCapacity) == 0, "Expected capacity should be 1320Ti")
+		testStartStorageCapacity := resource.MustParse("1200Ti")
+		assert.True(t, testStartStorageCapacity.Cmp(startStorageCapacity) == 0, "Start capacity should be 1200Ti")
+	})
+
+	// horizontal scaling that partially hits capacity limit
+	t.Run("horizontal scaling partially hits capacity limit", func(t *testing.T) {
+		storagecluster := &ocsv1.StorageCluster{
+			Spec: ocsv1.StorageClusterSpec{
+				StorageDeviceSets: []ocsv1.StorageDeviceSet{
+					{
+						Count:   50,
+						Replica: 3,
+						DataPVCTemplate: v1.PersistentVolumeClaim{
+							Spec: v1.PersistentVolumeClaimSpec{
+								Resources: v1.VolumeResourceRequirements{
+									Requests: v1.ResourceList{
+										"storage": resource.MustParse("8Ti"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		storageautoscaler := &ocsv1.StorageAutoScaler{
+			Spec: ocsv1.StorageAutoScalerSpec{
+				DeviceClass:          "ssd",
+				MaxOsdSize:           resource.MustParse("8Ti"),
+				StorageCapacityLimit: resource.MustParse("1250Ti"), // can add some but not full 10%
+			},
+		}
+
+		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, _, expectedStorageCapacity, devicesToAdd, limitReached := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
+
+		assert.Equal(t, resource.MustParse("8Ti"), startOsdSize)
+		assert.Equal(t, resource.MustParse("8Ti"), expectedOsdSize)
+		assert.Equal(t, 150, startOsdCount)
+		// Can only add 50Ti (1250-1200), which is 50/8 = 6.25 OSDs, 6/(3 replicas) = 2 device sets
+		// So expectedOsdCount = (50+2)*3 = 156
+		assert.Equal(t, 156, expectedOsdCount)
+		assert.Equal(t, 2, devicesToAdd) // should add only 2 device sets due to limit
+		assert.False(t, limitReached)
+		testExpectedStorageCapacity := resource.MustParse("1248Ti")
+		assert.True(t, testExpectedStorageCapacity.Cmp(expectedStorageCapacity) == 0, "Expected capacity should be 1248Ti")
+	})
+
+	// horizontal scaling completely hits capacity limit
+	t.Run("horizontal scaling completely hits capacity limit", func(t *testing.T) {
+		storagecluster := &ocsv1.StorageCluster{
+			Spec: ocsv1.StorageClusterSpec{
+				StorageDeviceSets: []ocsv1.StorageDeviceSet{
+					{
+						Count:   50,
+						Replica: 3,
+						DataPVCTemplate: v1.PersistentVolumeClaim{
+							Spec: v1.PersistentVolumeClaimSpec{
+								Resources: v1.VolumeResourceRequirements{
+									Requests: v1.ResourceList{
+										"storage": resource.MustParse("8Ti"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		storageautoscaler := &ocsv1.StorageAutoScaler{
+			Spec: ocsv1.StorageAutoScalerSpec{
+				DeviceClass:          "ssd",
+				MaxOsdSize:           resource.MustParse("8Ti"),
+				StorageCapacityLimit: resource.MustParse("1200Ti"), // exactly at current capacity
+			},
+		}
+
+		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity, devicesToAdd, limitReached := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
+
+		assert.Equal(t, resource.MustParse("8Ti"), startOsdSize)
+		assert.Equal(t, resource.MustParse("8Ti"), expectedOsdSize)
+		assert.Equal(t, 150, startOsdCount)
+		// When limit is reached, devicesToAdd is still set to 1, so expectedOsdCount = (50+1)*3 = 153
+		assert.Equal(t, 153, expectedOsdCount)
+		assert.Equal(t, 1, devicesToAdd)                            // still set to 1 even when limit is reached
+		assert.True(t, limitReached)                                // limit should be reached
+		testExpectedStorageCapacity := resource.MustParse("1224Ti") // (51*3)*8Ti
+		assert.True(t, testExpectedStorageCapacity.Cmp(expectedStorageCapacity) == 0, "Expected capacity would be 1224Ti")
+		testStartStorageCapacity := resource.MustParse("1200Ti")
+		assert.True(t, testStartStorageCapacity.Cmp(startStorageCapacity) == 0, "Start capacity should be 1200Ti")
+	})
+
+	// horizontal scaling minimum 1 device set when 10% is less than 1
+	t.Run("horizontal scaling minimum 1 device set", func(t *testing.T) {
+		storagecluster := &ocsv1.StorageCluster{
+			Spec: ocsv1.StorageClusterSpec{
+				StorageDeviceSets: []ocsv1.StorageDeviceSet{
+					{
+						Count:   5, // small cluster
+						Replica: 3,
+						DataPVCTemplate: v1.PersistentVolumeClaim{
+							Spec: v1.PersistentVolumeClaimSpec{
+								Resources: v1.VolumeResourceRequirements{
+									Requests: v1.ResourceList{
+										"storage": resource.MustParse("8Ti"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		storageautoscaler := &ocsv1.StorageAutoScaler{
+			Spec: ocsv1.StorageAutoScalerSpec{
+				DeviceClass:          "ssd",
+				MaxOsdSize:           resource.MustParse("8Ti"),
+				StorageCapacityLimit: resource.MustParse("500Ti"),
+			},
+		}
+
+		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity, devicesToAdd, limitReached := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
+
+		assert.Equal(t, resource.MustParse("8Ti"), startOsdSize)
+		assert.Equal(t, resource.MustParse("8Ti"), expectedOsdSize)
+		assert.Equal(t, 15, startOsdCount) // 5*3
+		// 10% of 120Ti (15*8Ti) = 12Ti, 12Ti/8Ti = 1.5 OSDs, 1/3 replicas = 0 device sets
+		// But minimum should be 1 device set
+		assert.Equal(t, 18, expectedOsdCount) // (5+1)*3 = 18
+		assert.Equal(t, 1, devicesToAdd)      // minimum 1 device set
+		assert.False(t, limitReached)
+		testExpectedStorageCapacity := resource.MustParse("144Ti")
+		assert.True(t, testExpectedStorageCapacity.Cmp(expectedStorageCapacity) == 0, "Expected capacity should be 144Ti")
+		testStartStorageCapacity := resource.MustParse("120Ti")
+		assert.True(t, testStartStorageCapacity.Cmp(startStorageCapacity) == 0, "Start capacity should be 120Ti")
+	})
+
+	// edge case: exactly at maxOsdSize from the start
+	t.Run("already at maxOsdSize requires horizontal scaling", func(t *testing.T) {
+		storagecluster := &ocsv1.StorageCluster{
+			Spec: ocsv1.StorageClusterSpec{
+				StorageDeviceSets: []ocsv1.StorageDeviceSet{
+					{
+						Count:   10,
+						Replica: 3,
+						DataPVCTemplate: v1.PersistentVolumeClaim{
+							Spec: v1.PersistentVolumeClaimSpec{
+								Resources: v1.VolumeResourceRequirements{
+									Requests: v1.ResourceList{
+										"storage": resource.MustParse("8Ti"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		storageautoscaler := &ocsv1.StorageAutoScaler{
+			Spec: ocsv1.StorageAutoScalerSpec{
+				DeviceClass:          "ssd",
+				MaxOsdSize:           resource.MustParse("8Ti"),
+				StorageCapacityLimit: resource.MustParse("500Ti"),
+			},
+		}
+
+		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity, devicesToAdd, limitReached := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
+
+		assert.Equal(t, resource.MustParse("8Ti"), startOsdSize)
+		assert.Equal(t, resource.MustParse("8Ti"), expectedOsdSize)
+		assert.Equal(t, 30, startOsdCount) // 10*3
+		// 10% of 240Ti (30*8Ti) = 24Ti, 24Ti/8Ti = 3 OSDs, 3/3 replicas = 1 device set
+		assert.Equal(t, 33, expectedOsdCount) // (10+1)*3
+		assert.Equal(t, 1, devicesToAdd)
+		assert.False(t, limitReached)
+		testExpectedStorageCapacity := resource.MustParse("264Ti")
+		assert.True(t, testExpectedStorageCapacity.Cmp(expectedStorageCapacity) == 0, "Expected capacity should be 264Ti")
+		testStartStorageCapacity := resource.MustParse("240Ti")
+		assert.True(t, testStartStorageCapacity.Cmp(startStorageCapacity) == 0, "Start capacity should be 240Ti")
+	})
+
+	// horizontal scaling where 10% calculation results in 1.2 device sets
+	t.Run("horizontal scaling with 1.2 device sets calculation", func(t *testing.T) {
+		storagecluster := &ocsv1.StorageCluster{
+			Spec: ocsv1.StorageClusterSpec{
+				StorageDeviceSets: []ocsv1.StorageDeviceSet{
+					{
+						Count:   12,
+						Replica: 3,
+						DataPVCTemplate: v1.PersistentVolumeClaim{
+							Spec: v1.PersistentVolumeClaimSpec{
+								Resources: v1.VolumeResourceRequirements{
+									Requests: v1.ResourceList{
+										"storage": resource.MustParse("8Ti"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		storageautoscaler := &ocsv1.StorageAutoScaler{
+			Spec: ocsv1.StorageAutoScalerSpec{
+				DeviceClass:          "ssd",
+				MaxOsdSize:           resource.MustParse("8Ti"),
+				StorageCapacityLimit: resource.MustParse("800Ti"),
+			},
+		}
+
+		startOsdSize, expectedOsdSize, startOsdCount, expectedOsdCount, startStorageCapacity, expectedStorageCapacity, devicesToAdd, limitReached := calculateExpectedOsdSizeAndCount(storagecluster, storageautoscaler)
+
+		assert.Equal(t, resource.MustParse("8Ti"), startOsdSize)
+		assert.Equal(t, resource.MustParse("8Ti"), expectedOsdSize)
+		assert.Equal(t, 36, startOsdCount) // 12*3
+		// Current capacity: 36*8Ti = 288Ti
+		// 10% = 28.8Ti, 28.8Ti/8Ti = 3.6 OSDs, 3.6/3 replicas = 1.2 device sets
+		// Integer division rounds down to 2
+		assert.Equal(t, 42, expectedOsdCount) // (12+2)*3 = 92
+		assert.Equal(t, 2, devicesToAdd)      // should round down to 2
+		assert.False(t, limitReached)
+		testExpectedStorageCapacity := resource.MustParse("336Ti")
+		assert.True(t, testExpectedStorageCapacity.Cmp(expectedStorageCapacity) == 0, "Expected capacity should be 336Ti")
+		testStartStorageCapacity := resource.MustParse("288Ti")
+		assert.True(t, testStartStorageCapacity.Cmp(startStorageCapacity) == 0, "Start capacity should be 288Ti")
 	})
 }
 


### PR DESCRIPTION
during horizontal scaling after sometime,
we were just adding 3 more osd,
but in real use case we atleast need to scale the cluster by 10%, so atleast add 10% storage in the horizontal scaling