### PR TITLE
preserve dbSpec values When rconciling noobaa

### DIFF
--- a/internal/controller/storagecluster/noobaa_system_reconciler.go
+++ b/internal/controller/storagecluster/noobaa_system_reconciler.go
@@ -149,10 +149,12 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 	// DBSpec is used for deploying a posgres client, while the DB fields were used for the single DB instance.
 	// The fields in NooBaaSpec should be left unmodified, to keep the old DB up until data is imported into the new DB cluster.
 	dbMinVolumeSize := dBVolumeResources.Requests.Storage().String()
-	nb.Spec.DBSpec = &nbv1.NooBaaDBSpec{
-		DBImage:         &r.images.NooBaaDB,
-		DBMinVolumeSize: dbMinVolumeSize,
+
+	if nb.Spec.DBSpec == nil {
+		nb.Spec.DBSpec = &nbv1.NooBaaDBSpec{}
 	}
+	nb.Spec.DBSpec.DBImage = &r.images.NooBaaDB
+	nb.Spec.DBSpec.DBMinVolumeSize = dbMinVolumeSize
 
 	if !r.IsNoobaaStandalone {
 		storageClassName := util.GenerateNameForCephBlockPoolStorageClass(sc)

--- a/internal/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/internal/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -398,6 +398,52 @@ func TestSetNooBaaDesiredState(t *testing.T) {
 	}
 }
 
+func TestSetNooBaaDesiredStatePreservesDBConf(t *testing.T) {
+	sc := v1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test_name",
+			Namespace: "openshift-storage",
+		},
+	}
+	wantDBConf := map[string]string{
+		"max_connections": "199",
+		"shared_buffers":  "128MB",
+	}
+
+	scheme := createFakeScheme(t)
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	reconciler := StorageClusterReconciler{
+		ctx:               context.TODO(),
+		Client:            client,
+		Scheme:            scheme,
+		OperatorNamespace: "openshift-storage",
+		OperatorCondition: newStubOperatorCondition(),
+		Log:               logf.Log.WithName("controller_storagecluster_test"),
+	}
+	_ = reconciler.initializeImageVars()
+
+	noobaa := nbv1.NooBaa{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "NooBaa",
+			APIVersion: "noobaa.io/v1alpha1'",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "noobaa",
+			Namespace: sc.Namespace,
+		},
+		Spec: nbv1.NooBaaSpec{
+			DBSpec: &nbv1.NooBaaDBSpec{
+				DBConf: wantDBConf,
+			},
+		},
+	}
+
+	err := reconciler.setNooBaaDesiredState(&noobaa, &sc, &ocstlsv1.TLSProfile{})
+	assert.NoError(t, err)
+	assert.NotNil(t, noobaa.Spec.DBSpec)
+	assert.Equal(t, wantDBConf, noobaa.Spec.DBSpec.DBConf)
+}
+
 func TestNoobaaSystemInExternalClusterMode(t *testing.T) {
 	request := reconcile.Request{
 		NamespacedName: types.NamespacedName{


### PR DESCRIPTION
Changed Noobaa reconciliation to avoid overriding existing values in Noobaa's dbSpec. This change allows modifying `dbSpec.dbCond` directly in noobaa CR if needed.