### PR TITLE
DFBUGS-6852: logcollector: make resource request equal to limits

### DIFF
--- a/controllers/defaults/resources.go
+++ b/controllers/defaults/resources.go
@@ -96,8 +96,8 @@ var (
 		},
 		"crashcollector": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("50m"),
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -106,8 +106,8 @@ var (
 		},
 		"logcollector": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("50m"),
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("250Mi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),

--- a/controllers/storagecluster/resources_test.go
+++ b/controllers/storagecluster/resources_test.go
@@ -325,8 +325,8 @@ func TestGetDaemonResources(t *testing.T) {
 			specifiedResources: map[string]corev1.ResourceRequirements{},
 			expectedResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("50m"),
-					corev1.ResourceMemory: resource.MustParse("50Mi"),
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -347,7 +347,7 @@ func TestGetDaemonResources(t *testing.T) {
 			},
 			expectedResourceRequirements: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceMemory: resource.MustParse("50Mi"), // from daemon resources
+					corev1.ResourceMemory: resource.MustParse("250Mi"), // from daemon resources
 				},
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("200m"),

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/defaults/resources.go
@@ -96,8 +96,8 @@ var (
 		},
 		"crashcollector": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("50m"),
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -106,8 +106,8 @@ var (
 		},
 		"logcollector": {
 			Requests: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("50m"),
-				corev1.ResourceMemory: resource.MustParse("50Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("250Mi"),
 			},
 			Limits: corev1.ResourceList{
 				corev1.ResourceCPU:    resource.MustParse("100m"),


### PR DESCRIPTION
To satisfy the Guaranteed QoS criteria let's make
logcollector resource Requests==Limits.


(cherry picked from commit f47ed7490ea86fa6bc62c26a5b07816b2f876b2a)