### PR TITLE
DFBUGS-6671:[release-4.22] enable sts by default in StorageCluster yaml

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -302,6 +302,7 @@ type ManageCephObjectStores struct {
 	GatewayPort       int   `json:"gatewayPort,omitempty"`
 	GatewaySecurePort int   `json:"gatewaySecurePort,omitempty"`
 	// Enables STS authentication for RGW
+	// +kubebuilder:default=true
 	EnableSTS bool `json:"enableSTS,omitempty"`
 	// StorageClassName specifies the name of the storage class created for ceph obc's
 	// +kubebuilder:validation:MaxLength=253

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -3024,6 +3024,7 @@ spec:
                       disableRoute:
                         type: boolean
                       enableSTS:
+                        default: true
                         description: Enables STS authentication for RGW
                         type: boolean
                       gatewayInstances:

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -3024,6 +3024,7 @@ spec:
                       disableRoute:
                         type: boolean
                       enableSTS:
+                        default: true
                         description: Enables STS authentication for RGW
                         type: boolean
                       gatewayInstances:

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -3026,6 +3026,7 @@ spec:
                       disableRoute:
                         type: boolean
                       enableSTS:
+                        default: true
                         description: Enables STS authentication for RGW
                         type: boolean
                       gatewayInstances:

--- a/internal/controller/storagecluster/cephobjectstores.go
+++ b/internal/controller/storagecluster/cephobjectstores.go
@@ -302,7 +302,7 @@ func (r *StorageClusterReconciler) newCephObjectStoreInstances(initData *ocsv1.S
 			obj.Spec.Gateway.ReadAffinity = &cephv1.RgwReadAffinity{Type: "localize"}
 		}
 
-		// Enable STS for RGW via rgwConfig and rgwSecretConfig
+		// Enable STS for RGW via rgwCommandFlags and rgwSecretConfig
 		if initData.Spec.ManagedResources.CephObjectStores.EnableSTS {
 			if err := r.setSTSOptions(obj, initData); err != nil {
 				r.Log.Error(err, "Failed to set STS options for CephObjectStore.", "CephObjectStore", klog.KRef(obj.Namespace, obj.Name))
@@ -410,14 +410,14 @@ func generateRandomSTSKey() (string, error) {
 	return string(key), nil
 }
 
-// STS Options via rgwConfig and rgwSecretConfig
+// STS Options via rgwCommandFlags and rgwSecretConfig
 // Create k8s secret containing sts key
 func (r *StorageClusterReconciler) setSTSOptions(obj *cephv1.CephObjectStore, sc *ocsv1.StorageCluster) error {
-	// Set rgw_s3_auth_use_sts to true in rgwConfig
-	if obj.Spec.Gateway.RgwConfig == nil {
-		obj.Spec.Gateway.RgwConfig = make(map[string]string)
+	// Set rgw_s3_auth_use_sts to true in rgwCommandFlags
+	if obj.Spec.Gateway.RgwCommandFlags == nil {
+		obj.Spec.Gateway.RgwCommandFlags = make(map[string]string)
 	}
-	obj.Spec.Gateway.RgwConfig["rgw_s3_auth_use_sts"] = "true"
+	obj.Spec.Gateway.RgwCommandFlags["rgw_s3_auth_use_sts"] = "true"
 
 	// Create secret for STS key
 	secretName := fmt.Sprintf("sts-key-%s", obj.Name)

--- a/internal/controller/storagecluster/cephobjectstores_test.go
+++ b/internal/controller/storagecluster/cephobjectstores_test.go
@@ -285,10 +285,10 @@ func TestSetSTSOptions(t *testing.T) {
 				err := reconciler.setSTSOptions(cos, sc)
 				assert.NoError(t, err)
 
-				// Verify rgwConfig is set
+				// Verify rgwCommandFlags is set
 				if tc.expectRgwConfig {
-					assert.NotNil(t, cos.Spec.Gateway.RgwConfig)
-					assert.Equal(t, "true", cos.Spec.Gateway.RgwConfig["rgw_s3_auth_use_sts"])
+					assert.NotNil(t, cos.Spec.Gateway.RgwCommandFlags)
+					assert.Equal(t, "true", cos.Spec.Gateway.RgwCommandFlags["rgw_s3_auth_use_sts"])
 				}
 
 				// Verify secret was created
@@ -420,8 +420,8 @@ func TestNewCephObjectStoreInstancesWithSTS(t *testing.T) {
 
 	// Verify STS configuration is applied
 	cos := cephObjectStores[0]
-	assert.NotNil(t, cos.Spec.Gateway.RgwConfig)
-	assert.Equal(t, "true", cos.Spec.Gateway.RgwConfig["rgw_s3_auth_use_sts"])
+	assert.NotNil(t, cos.Spec.Gateway.RgwCommandFlags)
+	assert.Equal(t, "true", cos.Spec.Gateway.RgwCommandFlags["rgw_s3_auth_use_sts"])
 
 	assert.NotNil(t, cos.Spec.Gateway.RgwConfigFromSecret)
 	secretSelector, exists := cos.Spec.Gateway.RgwConfigFromSecret["rgw_sts_key"]


### PR DESCRIPTION
also changed `rgwConfig` to `rgwCommandFlags` for `rgw_s3_auth_use_sts` so that rgw pods will restart automatically

So the option will be showed in logs, not in mon config

Again the sts key option still will be shown in mon config even if we set this option to false. But functionality wise sts authentication will fail if we disable the option, so it partially fixes https://redhat.atlassian.net/browse/DFBUGS-6679 as well

Ref: https://redhat.atlassian.net/browse/DFBUGS-6671
(cherry picked from commit 97fb2cd03a1882c71b9a92ba79b329965b9434b5)