### PR TITLE
alert: update NodeLatencyHighonNodes alert

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -665,36 +665,40 @@ spec:
     rules:
     - alert: ODFNodeLatencyHighOnOSDNodes
       expr: |
-        max_over_time(
-            probe_icmp_duration_seconds{phase="rtt",
-            job="odf-blackbox-exporter",
-            daemon_type="osd"
-            }[24h:]
-        ) > 0.010
+        count(
+          max_over_time(
+              probe_icmp_duration_seconds{phase="rtt",
+              job="odf-blackbox-exporter",
+              daemon_type="osd"
+              }[24h:]
+          ) > 0.010
+        ) > 0
       for: 10m
       labels:
         severity: warning
         component: odf
       annotations:
-        summary: "High ICMP latency (>10ms) detected on ODF OSD node(s)"
-        description: "Node {{ $labels.instance }} has max ICMP RTT latency > 10ms over the last 24h. This may impact Ceph performance."
+        summary: "High ICMP latency (>10ms) detected on {{ $value }} ODF OSD node(s)"
+        description: "{{ $value }} OSD node(s) have max ICMP RTT latency > 10ms over the last 24h. This may impact Ceph performance. Query 'max_over_time(probe_icmp_duration_seconds{phase=\"rtt\",job=\"odf-blackbox-exporter\",daemon_type=\"osd\"}[24h:]) > 0.010' to see affected nodes."
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFNodeLatencyHighOnOSDNodes.md
 
     - alert: ODFNodeLatencyHighOnNonOSDNodes
       expr: |
-        max_over_time(
-            probe_icmp_duration_seconds{phase="rtt",
-            job="odf-blackbox-exporter",
-            daemon_type="mon"
-            }[24h:]
-        ) > 0.100
+        count(
+          max_over_time(
+              probe_icmp_duration_seconds{phase="rtt",
+              job="odf-blackbox-exporter",
+              daemon_type="mon"
+              }[24h:]
+          ) > 0.100
+        ) > 0
       for: 10m
       labels:
         severity: warning
         component: odf
       annotations:
-        summary: "High ICMP latency (>100ms) detected on ODF non-OSD node(s)"
-        description: "Node {{ $labels.instance }} has max ICMP RTT latency > 100ms over the last 24h. Investigate network health."
+        summary: "High ICMP latency (>100ms) detected on {{ $value }} ODF non-OSD node(s)"
+        description: "{{ $value }} non-OSD node(s) have max ICMP RTT latency > 100ms over the last 24h. Investigate network health. Query 'max_over_time(probe_icmp_duration_seconds{phase=\"rtt\",job=\"odf-blackbox-exporter\",daemon_type=\"mon\"}[24h:]) > 0.100' to see affected nodes."
         runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/ODFNodeLatencyHighOnNonOSDNodes.md
 
     - alert: ODFNodeMTULessThan9000


### PR DESCRIPTION
update ODFNodeLatencyHighOnOSDNodes and
ODFNodeLatencyHighOnNonOSDNodes alert
to trigger if count is greater than 0
instead of showing all individual alert