### PR TITLE
controllers: fix mirroring controller for failover scenarios

### DIFF
--- a/internal/controller/mirroring/mirroring_controller.go
+++ b/internal/controller/mirroring/mirroring_controller.go
@@ -247,11 +247,24 @@ func (r *MirroringReconciler) reconcilePhases(clientMappingConfig *corev1.Config
 		return ctrl.Result{}, err
 	}
 
-	remoteClientInfoById := map[string]*pb.ClientInfo{}
-	remoteBlockPoolInfoByName := map[string]*pb.BlockPoolInfo{}
+	shouldMirror := clientMappingConfig.DeletionTimestamp.IsZero() && len(clientMappingConfig.Data) > 0
+	ocsClient := &providerClient.OCSProviderClient{}
+	var err error
 	errorOccurred := false
 
-	shouldMirror := clientMappingConfig.DeletionTimestamp.IsZero() && len(clientMappingConfig.Data) > 0
+	/*
+		reconcileRBDMirror
+		If shouldMirror
+			If the remote cluster is reachable
+			- get blockPool and clientInfo
+			- reconcile blockpools, radosnamespaces and storageconsumer (to enable mirroring)
+		Else
+		- reconcile blockpools, radosnamespaces and storageconsumer (to disable mirroring)
+	*/
+
+	if errored := r.reconcileRbdMirror(clientMappingConfig, shouldMirror); errored {
+		errorOccurred = true
+	}
 
 	if shouldMirror {
 		if controllerutil.AddFinalizer(clientMappingConfig, mirroringFinalizer) {
@@ -273,40 +286,50 @@ func (r *MirroringReconciler) reconcilePhases(clientMappingConfig *corev1.Config
 			return ctrl.Result{}, fmt.Errorf("waiting for StorageClusterPeer %s to be in Peered state", storageClusterPeer.Name)
 		}
 
-		ocsClient, err := providerClient.NewProviderClient(r.ctx, storageClusterPeer.Spec.ApiEndpoint, util.OcsClientTimeout)
+		ocsClient, err = providerClient.NewProviderClient(r.ctx, storageClusterPeer.Spec.ApiEndpoint, util.OcsClientTimeout)
 		if err != nil {
 			r.log.Error(err, "failed to create a new provider client")
-			return ctrl.Result{}, fmt.Errorf("failed to reconcile StorageClientMapping")
-		}
-
-		defer ocsClient.Close()
-
-		if errored := r.getBlockPoolsInfo(ocsClient, storageClusterPeer, cephBlockPoolsList, remoteBlockPoolInfoByName); errored {
 			errorOccurred = true
 		}
 
-		if errored := r.getStorageClientsInfo(ocsClient, storageClusterPeer, remoteClientIds, remoteClientInfoById); errored {
+		if ocsClient != nil {
+			defer ocsClient.Close()
+			remoteClientInfoById := map[string]*pb.ClientInfo{}
+			remoteBlockPoolInfoByName := map[string]*pb.BlockPoolInfo{}
+
+			if errored := r.getBlockPoolsInfo(ocsClient, storageClusterPeer, cephBlockPoolsList, remoteBlockPoolInfoByName); errored {
+				errorOccurred = true
+			}
+
+			if errored := r.getStorageClientsInfo(ocsClient, storageClusterPeer, remoteClientIds, remoteClientInfoById); errored {
+				errorOccurred = true
+			}
+
+			if errored := r.reconcileBlockPoolMirroring(clientMappingConfig, cephBlockPoolsList, remoteBlockPoolInfoByName); errored {
+				errorOccurred = true
+			}
+
+			if errored := r.reconcileRadosNamespaceMirroring(clientMappingConfig, storageConsumerByName, remoteClientInfoById); errored {
+				errorOccurred = true
+			}
+
+			if errored := r.reconcileStorageConsumer(storageConsumerList, clientMappingConfig, remoteClientInfoById); errored {
+				errorOccurred = true
+			}
+		}
+	} else {
+		if errored := r.reconcileBlockPoolMirroring(clientMappingConfig, cephBlockPoolsList, nil); errored {
 			errorOccurred = true
 		}
-	}
 
-	if errored := r.reconcileRbdMirror(clientMappingConfig, shouldMirror); errored {
-		errorOccurred = true
-	}
+		if errored := r.reconcileRadosNamespaceMirroring(clientMappingConfig, storageConsumerByName, nil); errored {
+			errorOccurred = true
+		}
 
-	if errored := r.reconcileBlockPoolMirroring(clientMappingConfig, cephBlockPoolsList, remoteBlockPoolInfoByName); errored {
-		errorOccurred = true
-	}
+		if errored := r.reconcileStorageConsumer(storageConsumerList, clientMappingConfig, nil); errored {
+			errorOccurred = true
+		}
 
-	if errored := r.reconcileRadosNamespaceMirroring(clientMappingConfig, storageConsumerByName, remoteClientInfoById); errored {
-		errorOccurred = true
-	}
-
-	if errored := r.reconcileStorageConsumer(storageConsumerList, clientMappingConfig, remoteClientInfoById); errored {
-		errorOccurred = true
-	}
-
-	if !shouldMirror {
 		if controllerutil.RemoveFinalizer(storageClusterPeer, mirroringFinalizer) {
 			r.log.Info("removing finalizer from StorageClusterPeer.")
 			if err := r.update(storageClusterPeer); err != nil {


### PR DESCRIPTION
When the PR https://github.com/red-hat-storage/ocs-operator/pull/3379 got merged, a bug was introduced where the Failover wasn't working. Failover happens when the other cluster isn't reachable. Instead of failing the reconcile there, we should continue to reconcile only the rbdMirror.

The flow can be broken into:
1. reconcileRBDMirror
2. If shouldMirror
    - If the remote cluster is reachable
       - get blockPool and clientInfo
       - reconcile blockpools, radosnamespaces and storageconsumer (to enable mirroring)
3. If I don't want to mirror
    - reconcile blockpools, radosnamespaces ans storageconsumer (to disable mirroring)

Fixes: [DFBUGS-6949](https://redhat.atlassian.net/browse/DFBUGS-6949)