### PR TITLE
osd_memory_target_cgroup_limit_ratio to 0.6 for Performance mode

### DIFF
--- a/internal/controller/storagecluster/cephcluster.go
+++ b/internal/controller/storagecluster/cephcluster.go
@@ -1571,7 +1571,7 @@ func getCephClusterCephConfig(r *StorageClusterReconciler, sc *ocsv1.StorageClus
 			"rbd_default_pool":                   util.GenerateNameForCephBlockPool(sc.Name),
 		},
 		"osd": {
-			"osd_memory_target_cgroup_limit_ratio": "0.8",
+			"osd_memory_target_cgroup_limit_ratio": getOsdMemoryTargetCgroupLimitRatio(sc.Spec.ResourceProfile),
 		},
 	}
 
@@ -1656,6 +1656,13 @@ func getCephClusterCephConfig(r *StorageClusterReconciler, sc *ocsv1.StorageClus
 		}
 	}
 	return cephConfig
+}
+
+func getOsdMemoryTargetCgroupLimitRatio(resourceProfile string) string {
+	if resourceProfile == "performance" {
+		return "0.6"
+	}
+	return "0.8"
 }
 
 // getNearFullRatio returns the specified NearFullRatio or the default value

--- a/internal/controller/storagecluster/cephcluster_test.go
+++ b/internal/controller/storagecluster/cephcluster_test.go
@@ -2242,7 +2242,7 @@ func TestGetCephClusterCephConfig(t *testing.T) {
 			},
 		},
 		{
-			description: "case 5: ResourceProfile 'performance' should set mon_target_pg_per_osd to 400",
+			description: "case 5: ResourceProfile 'performance' should set mon_target_pg_per_osd to 400 and osd_memory_target_cgroup_limit_ratio to 0.6",
 			storageCluster: &ocsv1.StorageCluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: scName,
@@ -2263,7 +2263,7 @@ func TestGetCephClusterCephConfig(t *testing.T) {
 					"rbd_default_pool":                   ocsutil.GenerateNameForCephBlockPool(scName),
 				},
 				"osd": {
-					"osd_memory_target_cgroup_limit_ratio": "0.8",
+					"osd_memory_target_cgroup_limit_ratio": "0.6",
 				},
 			},
 		},


### PR DESCRIPTION
Performance profile sets 8GiB memory limit for the OSD containers. With the current osd_memory_target_cgroup_limit_ratio of 0.8 ceph targets around 6.4 GiB for OSD cache, leaving only ~1.6 GB headroom for non cache allocations. Under heavy EC/replica 3 sequential reads, the headroom is insufficient and the OSDs get OOMKilled.

Changing the ratio to 0.6 for the perfomrnace profile sets the cache target to 4.8 GB, giving 3.2 GB headroom. This should be enough to abosrb the memory skipes during high IO workload.

https://redhat.atlassian.net/browse/DFBUGS-6312