### PR TITLE
exclude alerts for probe failed nodes

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -674,6 +674,11 @@ spec:
               daemon_type="osd"
               }[24h:]
           ) > 0.010
+          and on(instance, job, daemon_type, namespace)
+          probe_success{
+            job="odf-blackbox-exporter",
+            daemon_type="osd"
+          } == 1
         ) > 0
       for: 10m
       labels:
@@ -693,6 +698,11 @@ spec:
               daemon_type="mon"
               }[24h:]
           ) > 0.100
+          and on(instance, job, daemon_type, namespace)
+          probe_success{
+            job="odf-blackbox-exporter",
+            daemon_type="mon"
+          } == 1
         ) > 0
       for: 10m
       labels:


### PR DESCRIPTION
Currently we are calculating node latency for all
ips from the cluster, but in case of multus
enabled cluster where we have more multiple ips
one in default network path and other in different path than blackbox-exporter.
In this case the alert is raised for the ips whose probe failed which is not our requirement.
This commit modifies the node latency to raise
alerts for the nodes or ips for which the
probes_success is 1