### PR TITLE
rbac: Add ValidatingAdmissionPolicy to prevent accidental StorageCluster deletion

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -44,6 +44,17 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingadmissionpolicies
+  - validatingadmissionpolicybindings
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -79,7 +79,7 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2026-06-09T12:43:38Z"
+    createdAt: "2026-06-23T06:51:14Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.34.1
@@ -200,6 +200,17 @@ spec:
           - namespaces
           verbs:
           - get
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingadmissionpolicies
+          - validatingadmissionpolicybindings
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - apiextensions.k8s.io
           resources:

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2026-06-09T12:43:38Z"
+    createdAt: "2026-06-23T06:51:14Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",
@@ -219,6 +219,17 @@ spec:
           - namespaces
           verbs:
           - get
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingadmissionpolicies
+          - validatingadmissionpolicybindings
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - apiextensions.k8s.io
           resources:

--- a/functests/ocs/storagecluster_creation_test.go
+++ b/functests/ocs/storagecluster_creation_test.go
@@ -57,7 +57,19 @@ func StorageClusterCreationTest() {
 		})
 
 		ginkgo.AfterEach(func() {
-			err := sccObj.client.Delete(context.TODO(), sccObj.duplicateStorageCluster)
+			sc := &ocsv1.StorageCluster{}
+			err := sccObj.client.Get(context.TODO(), client.ObjectKey{
+				Name:      sccObj.duplicateStorageCluster.Name,
+				Namespace: sccObj.duplicateStorageCluster.Namespace,
+			}, sc)
+			gomega.Expect(err).To(gomega.BeNil())
+			if sc.Annotations == nil {
+				sc.Annotations = map[string]string{}
+			}
+			sc.Annotations["uninstall.ocs.openshift.io/confirm-deletion"] = "true"
+			err = sccObj.client.Update(context.TODO(), sc)
+			gomega.Expect(err).To(gomega.BeNil())
+			err = sccObj.client.Delete(context.TODO(), sc)
 			gomega.Expect(err).To(gomega.BeNil())
 		})
 

--- a/internal/controller/ocsinitialization/ocsinitialization_controller.go
+++ b/internal/controller/ocsinitialization/ocsinitialization_controller.go
@@ -19,6 +19,7 @@ import (
 	secv1client "github.com/openshift/client-go/security/clientset/versioned/typed/security/v1"
 	opv1a1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -81,6 +82,7 @@ type OCSInitializationReconciler struct {
 // +kubebuilder:rbac:groups="monitoring.coreos.com",resources=servicemonitors,verbs=get;list;watch;update;patch;create;delete
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;list;watch;delete;update;patch
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=get;list;watch;create;update
+// +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingadmissionpolicies;validatingadmissionpolicybindings,verbs=get;list;watch;create;update
 
 // Reconcile reads that state of the cluster for a OCSInitialization object and makes changes based on the state read
 // and what is in the OCSInitialization.Spec
@@ -197,6 +199,12 @@ func (r *OCSInitializationReconciler) Reconcile(ctx context.Context, request rec
 	err = r.ensureOcsOperatorConfigExists(instance)
 	if err != nil {
 		r.Log.Error(err, "Failed to ensure ocs-operator-config ConfigMap")
+		return reconcile.Result{}, err
+	}
+
+	err = r.reconcileValidatingAdmissionPolicy()
+	if err != nil {
+		r.Log.Error(err, "Failed to reconcile ValidatingAdmissionPolicy for StorageCluster deletion protection")
 		return reconcile.Result{}, err
 	}
 
@@ -360,6 +368,16 @@ func (r *OCSInitializationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				util.EventTypePredicate(true, false, false, false),
 			),
 			builder.OnlyMetadata,
+		).
+		Watches(
+			&admissionv1.ValidatingAdmissionPolicy{},
+			enqueueOCSInit,
+			builder.WithPredicates(util.NamePredicate(storageClusterDeletePolicyName)),
+		).
+		Watches(
+			&admissionv1.ValidatingAdmissionPolicyBinding{},
+			enqueueOCSInit,
+			builder.WithPredicates(util.NamePredicate(storageClusterDeletePolicyBindingName)),
 		).
 		Build(r)
 

--- a/internal/controller/ocsinitialization/ocsinitialization_controller_test.go
+++ b/internal/controller/ocsinitialization/ocsinitialization_controller_test.go
@@ -14,6 +14,7 @@ import (
 	v1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/platform"
 	"github.com/stretchr/testify/assert"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -126,6 +127,11 @@ func createFakeScheme(t *testing.T) *runtime.Scheme {
 	err = storagev1.AddToScheme(scheme)
 	if err != nil {
 		assert.Fail(t, "failed to add storagev1 scheme")
+	}
+
+	err = admissionv1.AddToScheme(scheme)
+	if err != nil {
+		assert.Fail(t, "failed to add admissionregistration/v1 scheme")
 	}
 
 	return scheme
@@ -304,6 +310,43 @@ func TestReconcileCompleteConditions(t *testing.T) {
 			assert.Fail(t, "expected status condition not found")
 		}
 	}
+}
+
+func TestReconcileCreatesVAPAndBinding(t *testing.T) {
+	platform.SetFakePlatformInstanceForTesting(true, "")
+	defer platform.UnsetFakePlatformInstanceForTesting()
+
+	_, request, reconciler := getTestParams(false, t)
+
+	_, err := reconciler.Reconcile(context.TODO(), request)
+	assert.NoError(t, err)
+
+	vap := &admissionv1.ValidatingAdmissionPolicy{}
+	err = reconciler.Get(context.TODO(), types.NamespacedName{Name: storageClusterDeletePolicyName}, vap)
+	assert.NoError(t, err)
+
+	assert.NotNil(t, vap.Spec.FailurePolicy)
+	assert.Equal(t, admissionv1.Fail, *vap.Spec.FailurePolicy)
+
+	assert.NotNil(t, vap.Spec.MatchConstraints)
+	assert.Len(t, vap.Spec.MatchConstraints.ResourceRules, 1)
+	rule := vap.Spec.MatchConstraints.ResourceRules[0]
+	assert.Equal(t, []admissionv1.OperationType{admissionv1.Delete}, rule.Operations)
+	assert.Equal(t, []string{"ocs.openshift.io"}, rule.APIGroups)
+	assert.Equal(t, []string{"v1"}, rule.APIVersions)
+	assert.Equal(t, []string{"storageclusters"}, rule.Resources)
+
+	assert.Len(t, vap.Spec.Validations, 1)
+	assert.Contains(t, vap.Spec.Validations[0].Expression, "uninstall.ocs.openshift.io/confirm-deletion")
+	assert.NotEmpty(t, vap.Spec.Validations[0].MessageExpression)
+	assert.Equal(t, metav1.StatusReasonForbidden, *vap.Spec.Validations[0].Reason)
+
+	vapBinding := &admissionv1.ValidatingAdmissionPolicyBinding{}
+	err = reconciler.Get(context.TODO(), types.NamespacedName{Name: storageClusterDeletePolicyBindingName}, vapBinding)
+	assert.NoError(t, err)
+
+	assert.Equal(t, storageClusterDeletePolicyName, vapBinding.Spec.PolicyName)
+	assert.Equal(t, []admissionv1.ValidationAction{admissionv1.Deny}, vapBinding.Spec.ValidationActions)
 }
 
 func assertCondition(ocs v1.OCSInitialization, conditionType conditionsv1.ConditionType, status corev1.ConditionStatus) bool {

--- a/internal/controller/ocsinitialization/validatingadmissionpolicy.go
+++ b/internal/controller/ocsinitialization/validatingadmissionpolicy.go
@@ -1,0 +1,69 @@
+package ocsinitialization
+
+import (
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	storageClusterDeletePolicyName        = "storagecluster-delete-protection.ocs.openshift.io"
+	storageClusterDeletePolicyBindingName = "storagecluster-delete-protection-binding.ocs.openshift.io"
+)
+
+// The deletion of StorageCluster must only be permitted when the annotation "uninstall.ocs.openshift.io/confirm-deletion: true" is set on the StorageCluster.
+// This is to prevent accidental deletion of the StorageCluster and ensure that the user has explicitly confirmed the deletion.
+func (r *OCSInitializationReconciler) reconcileValidatingAdmissionPolicy() error {
+	vap := &admissionv1.ValidatingAdmissionPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: storageClusterDeletePolicyName,
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, vap, func() error {
+		vap.Spec = admissionv1.ValidatingAdmissionPolicySpec{
+			FailurePolicy: ptr.To(admissionv1.Fail),
+			MatchConstraints: &admissionv1.MatchResources{
+				ResourceRules: []admissionv1.NamedRuleWithOperations{
+					{
+						RuleWithOperations: admissionv1.RuleWithOperations{
+							Operations: []admissionv1.OperationType{admissionv1.Delete},
+							Rule: admissionv1.Rule{
+								APIGroups:   []string{"ocs.openshift.io"},
+								APIVersions: []string{"v1"},
+								Resources:   []string{"storageclusters"},
+							},
+						},
+					},
+				},
+			},
+			Validations: []admissionv1.Validation{
+				{
+					Expression:        `oldObject.metadata.?annotations['uninstall.ocs.openshift.io/confirm-deletion'].orValue('') == 'true'`,
+					MessageExpression: `"WARNING: StorageCluster deletion is IRREVERSIBLE and will permanently destroy all stored data. To confirm you accept this risk, run: kubectl annotate storagecluster " + oldObject.metadata.name + " uninstall.ocs.openshift.io/confirm-deletion=true -- then retry deletion."`,
+					Reason:     ptr.To(metav1.StatusReasonForbidden),
+				},
+			},
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	vapBinding := &admissionv1.ValidatingAdmissionPolicyBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: storageClusterDeletePolicyBindingName,
+		},
+	}
+	if _, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, vapBinding, func() error {
+		vapBinding.Spec = admissionv1.ValidatingAdmissionPolicyBindingSpec{
+			PolicyName:        storageClusterDeletePolicyName,
+			ValidationActions: []admissionv1.ValidationAction{admissionv1.Deny},
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/deploy-manager/storagecluster.go
+++ b/pkg/deploy-manager/storagecluster.go
@@ -172,8 +172,15 @@ func (t *DeployManager) deleteStorageCluster() error {
 		return err
 	}
 
-	err = t.Client.Delete(context.TODO(), sc)
-	return err
+	if sc.Annotations == nil {
+		sc.Annotations = map[string]string{}
+	}
+	sc.Annotations["uninstall.ocs.openshift.io/confirm-deletion"] = "true"
+	if err := t.Client.Update(context.TODO(), sc); err != nil {
+		return err
+	}
+
+	return t.Client.Delete(context.TODO(), sc)
 }
 
 // WaitOnStorageCluster waits for storage cluster to come online


### PR DESCRIPTION
This commit adds the ValidatingAdmissionPolicy to StorageCluster CR which rejects the deletion of StorageCluster unless the annotation `uninstall.ocs.openshift.io/confirm-deletion: true` exists. This helps prevent accidental deletion of StorageCluster CR.

### Testing Results:

```
home@Shravanis-MacBook-Pro ~ % oc get storagecluster -n openshift-storage
NAME                 AGE   PHASE   EXTERNAL   CREATED AT             VERSION
ocs-storagecluster   14h   Ready              2026-06-04T15:39:52Z   4.22.0
home@Shravanis-MacBook-Pro ~ % oc delete storagecluster ocs-storagecluster -n openshift-storage
Error from server (Forbidden): storageclusters.ocs.openshift.io "ocs-storagecluster" is forbidden: ValidatingAdmissionPolicy 'storagecluster-delete-protection.ocs.openshift.io' with binding 'storagecluster-delete-protection-binding.ocs.openshift.io' denied request: StorageCluster deletion is blocked. Set the annotation "uninstall.ocs.openshift.io/confirm-deletion: true" on the StorageCluster to allow deletion.
```

Resolves: [RHSTOR-8981](https://redhat.atlassian.net/browse/RHSTOR-8981)