### PR TITLE
Set system-cluster-critical priority class on Noobaa pods

### DIFF
--- a/internal/controller/storagecluster/noobaa_system_reconciler.go
+++ b/internal/controller/storagecluster/noobaa_system_reconciler.go
@@ -165,6 +165,11 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 	nb.Spec.CoreResources = &coreResources
 	nb.Spec.DBSpec.DBResources = &dbResources
 
+	// Set "system-cluster-critical" priority class for noobaa core, db, and endpoint pods
+	nb.Spec.CorePriorityClassName = systemClusterCritical
+	nb.Spec.DBPriorityClassName = systemClusterCritical
+	nb.Spec.EndpointPriorityClassName = systemClusterCritical
+
 	component := "noobaa-standalone"
 	// fallback to 'noobaa-core' if either the cluster is not standalone or if "noobaa-standalone" placement is not found
 	_, ok := sc.Spec.Placement[rookCephv1.KeyType(component)]

--- a/internal/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/internal/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -412,6 +412,9 @@ func TestSetNooBaaDesiredState(t *testing.T) {
 		} else {
 			assert.Equal(t, nbv1.AutoscalerTypeHPAV2, noobaa.Spec.Autoscaler.AutoscalerType)
 		}
+		assert.Equalf(t, systemClusterCritical, noobaa.Spec.CorePriorityClassName, "[%s] noobaa core priority class not set correctly", c.label)
+		assert.Equalf(t, systemClusterCritical, noobaa.Spec.DBPriorityClassName, "[%s] noobaa db priority class not set correctly", c.label)
+		assert.Equalf(t, systemClusterCritical, noobaa.Spec.EndpointPriorityClassName, "[%s] noobaa endpoint priority class not set correctly", c.label)
 	}
 }
 


### PR DESCRIPTION
Configure core, database, and endpoint priority classes on the NooBaa CR so MCG workloads are scheduled with the same critical priority as other storage components during node pressure.

Ref-https://redhat.atlassian.net/browse/RHSTOR-9066