### PR TITLE
DFBUGS-6528: [release-4.20] mirroring: add in-maintenance-mode annotation to StorageCluster

### DIFF
--- a/controllers/mirroring/mirroring_controller.go
+++ b/controllers/mirroring/mirroring_controller.go
@@ -362,6 +362,24 @@ func (r *MirroringReconciler) reconcileRbdMirror(clientMappingConfig *corev1.Con
 		}
 	}
 
+	annotations := storageCluster.GetAnnotations()
+	if maintenanceModeRequested {
+		if util.AddAnnotation(storageCluster, util.InMaintenanceModeAnnotation, "true") {
+			r.log.Info("Adding maintenance mode annotation to StorageCluster", "StorageCluster", storageCluster.Name)
+			if err := r.update(storageCluster); err != nil {
+				r.log.Error(err, "failed to add maintenance mode annotation to StorageCluster", "StorageCluster", storageCluster.Name)
+				return true
+			}
+		}
+	} else if _, exists := annotations[util.InMaintenanceModeAnnotation]; exists {
+		r.log.Info("Removing maintenance mode annotation from StorageCluster", "StorageCluster", storageCluster.Name)
+		delete(annotations, util.InMaintenanceModeAnnotation)
+		if err := r.update(storageCluster); err != nil {
+			r.log.Error(err, "failed to remove maintenance mode annotation from StorageCluster", "StorageCluster", storageCluster.Name)
+			return true
+		}
+	}
+
 	return false
 }
 

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -68,6 +68,7 @@ const (
 	ForbidMirroringLabel                   = "ocs.openshift.io/forbid-mirroring"
 	BlockPoolMirroringTargetIDAnnotation   = "ocs.openshift.io/mirroring-target-id"
 	RequestMaintenanceModeAnnotation       = "ocs.openshift.io/request-maintenance-mode"
+	InMaintenanceModeAnnotation            = "ocs.openshift.io/in-maintenance-mode"
 	CephRBDMirrorName                      = "cephrbdmirror"
 	OcsClientTimeout                       = 10 * time.Second
 	StorageClientMappingConfigName         = "storage-client-mapping"

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
@@ -68,6 +68,7 @@ const (
 	ForbidMirroringLabel                   = "ocs.openshift.io/forbid-mirroring"
 	BlockPoolMirroringTargetIDAnnotation   = "ocs.openshift.io/mirroring-target-id"
 	RequestMaintenanceModeAnnotation       = "ocs.openshift.io/request-maintenance-mode"
+	InMaintenanceModeAnnotation            = "ocs.openshift.io/in-maintenance-mode"
 	CephRBDMirrorName                      = "cephrbdmirror"
 	OcsClientTimeout                       = 10 * time.Second
 	StorageClientMappingConfigName         = "storage-client-mapping"

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -1003,15 +1003,15 @@ func (s *OCSProviderServer) GetBlockPoolsInfo(ctx context.Context, req *pb.Block
 }
 
 func (s *OCSProviderServer) isSystemInMaintenanceMode(ctx context.Context) (bool, error) {
-	// found - false, not found - true
-	cephRBDMirrors := &rookCephv1.CephRBDMirror{}
-	cephRBDMirrors.Name = util.CephRBDMirrorName
-	cephRBDMirrors.Namespace = s.namespace
-	err := s.client.Get(ctx, client.ObjectKeyFromObject(cephRBDMirrors), cephRBDMirrors)
-	if client.IgnoreNotFound(err) != nil {
+	storageCluster, err := util.GetStorageClusterInNamespace(ctx, s.client, s.namespace)
+	if err != nil {
 		return false, err
 	}
-	return kerrors.IsNotFound(err), nil
+	val, exists := storageCluster.GetAnnotations()[util.InMaintenanceModeAnnotation]
+	if !exists {
+		return false, nil
+	}
+	return strconv.ParseBool(val)
 }
 
 func (s *OCSProviderServer) isConsumerMirrorEnabled(ctx context.Context, consumer *ocsv1alpha1.StorageConsumer) (bool, error) {


### PR DESCRIPTION
Add `InMaintenanceModeAnnotation` on the StorageCluster to indicate when the system has entered maintenance mode. The annotation is set after the CephRBDMirror is deleted upon a maintenance mode request, and removed when mirroring resumes normally. Update `isSystemInMaintenanceMode` to reflect the status by referring to the `InMaintenanceModeAnnotation`.

Manual backport of https://github.com/red-hat-storage/ocs-operator/pull/3723