### PR TITLE
DFBUGS-6529: [release-4.19] mirroring: add in-maintenance-mode annotation to StorageCluster

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -267,6 +267,7 @@ rules:
   verbs:
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - ocs.openshift.io

--- a/controllers/mirroring/mirroring_controller.go
+++ b/controllers/mirroring/mirroring_controller.go
@@ -142,6 +142,7 @@ func (r *MirroringReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 //+kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclusterpeers;storageconsumers,verbs=get;list;watch
+//+kubebuilder:rbac:groups=ocs.openshift.io,resources=storageclusters,verbs=get;update
 //+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups=core,resources=configmaps/finalizers,verbs=update
 //+kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;delete
@@ -322,6 +323,30 @@ func (r *MirroringReconciler) reconcileRbdMirror(clientMappingConfig *corev1.Con
 	} else {
 		if err := r.delete(rbdMirror); err != nil {
 			r.log.Error(err, "failed to delete CephRBDMirror", "CephRBDMirror", rbdMirror.Name)
+			return true
+		}
+	}
+
+	storageCluster, err := util.GetStorageClusterInNamespace(r.ctx, r.Client, clientMappingConfig.Namespace)
+	if err != nil {
+		r.log.Error(err, "failed to get StorageCluster")
+		return true
+	}
+
+	annotations := storageCluster.GetAnnotations()
+	if maintenanceModeRequested {
+		if util.AddAnnotation(storageCluster, util.InMaintenanceModeAnnotation, "true") {
+			r.log.Info("Adding maintenance mode annotation to StorageCluster", "StorageCluster", storageCluster.Name)
+			if err := r.update(storageCluster); err != nil {
+				r.log.Error(err, "failed to add maintenance mode annotation to StorageCluster", "StorageCluster", storageCluster.Name)
+				return true
+			}
+		}
+	} else if _, exists := annotations[util.InMaintenanceModeAnnotation]; exists {
+		r.log.Info("Removing maintenance mode annotation from StorageCluster", "StorageCluster", storageCluster.Name)
+		delete(annotations, util.InMaintenanceModeAnnotation)
+		if err := r.update(storageCluster); err != nil {
+			r.log.Error(err, "failed to remove maintenance mode annotation from StorageCluster", "StorageCluster", storageCluster.Name)
 			return true
 		}
 	}

--- a/controllers/util/k8sutil.go
+++ b/controllers/util/k8sutil.go
@@ -68,6 +68,7 @@ const (
 	ForbidMirroringLabel                   = "ocs.openshift.io/forbid-mirroring"
 	BlockPoolMirroringTargetIDAnnotation   = "ocs.openshift.io/mirroring-target-id"
 	RequestMaintenanceModeAnnotation       = "ocs.openshift.io/request-maintenance-mode"
+	InMaintenanceModeAnnotation            = "ocs.openshift.io/in-maintenance-mode"
 	CephRBDMirrorName                      = "cephrbdmirror"
 	OcsClientTimeout                       = 10 * time.Second
 	StorageClientMappingConfigName         = "storage-client-mapping"

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -424,6 +424,7 @@ spec:
           verbs:
           - get
           - list
+          - update
           - watch
         - apiGroups:
           - ocs.openshift.io

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -443,6 +443,7 @@ spec:
           verbs:
           - get
           - list
+          - update
           - watch
         - apiGroups:
           - ocs.openshift.io

--- a/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
+++ b/metrics/vendor/github.com/red-hat-storage/ocs-operator/v4/controllers/util/k8sutil.go
@@ -68,6 +68,7 @@ const (
 	ForbidMirroringLabel                   = "ocs.openshift.io/forbid-mirroring"
 	BlockPoolMirroringTargetIDAnnotation   = "ocs.openshift.io/mirroring-target-id"
 	RequestMaintenanceModeAnnotation       = "ocs.openshift.io/request-maintenance-mode"
+	InMaintenanceModeAnnotation            = "ocs.openshift.io/in-maintenance-mode"
 	CephRBDMirrorName                      = "cephrbdmirror"
 	OcsClientTimeout                       = 10 * time.Second
 	StorageClientMappingConfigName         = "storage-client-mapping"

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -1115,15 +1115,15 @@ func (s *OCSProviderServer) GetBlockPoolsInfo(ctx context.Context, req *pb.Block
 }
 
 func (s *OCSProviderServer) isSystemInMaintenanceMode(ctx context.Context) (bool, error) {
-	// found - false, not found - true
-	cephRBDMirrors := &rookCephv1.CephRBDMirror{}
-	cephRBDMirrors.Name = util.CephRBDMirrorName
-	cephRBDMirrors.Namespace = s.namespace
-	err := s.client.Get(ctx, client.ObjectKeyFromObject(cephRBDMirrors), cephRBDMirrors)
-	if client.IgnoreNotFound(err) != nil {
+	storageCluster, err := util.GetStorageClusterInNamespace(ctx, s.client, s.namespace)
+	if err != nil {
 		return false, err
 	}
-	return kerrors.IsNotFound(err), nil
+	val, exists := storageCluster.GetAnnotations()[util.InMaintenanceModeAnnotation]
+	if !exists {
+		return false, nil
+	}
+	return strconv.ParseBool(val)
 }
 
 func (s *OCSProviderServer) isConsumerMirrorEnabled(ctx context.Context, consumer *ocsv1alpha1.StorageConsumer) (bool, error) {


### PR DESCRIPTION
Add `InMaintenanceModeAnnotation` on the StorageCluster to indicate when the system has entered maintenance mode. The annotation is set after the CephRBDMirror is deleted upon a maintenance mode request, and removed when mirroring resumes normally. Update isSystemInMaintenanceMode to reflect the status by referring to the `InMaintenanceModeAnnotation`.

Manual backport of https://github.com/red-hat-storage/ocs-operator/pull/3723