### PR TITLE
Expose NooBaa autoscaler type on StorageCluster & propagate it to Noobaa CR

### DIFF
--- a/api/v1/storagecluster_types.go
+++ b/api/v1/storagecluster_types.go
@@ -447,6 +447,10 @@ type MultiCloudGatewaySpec struct {
 	// +optional
 	Endpoints *nbv1.EndpointsSpec `json:"endpoints,omitempty"`
 
+	// Autoscaler (optional) sets configuration for NooBaa endpoint autoscaling.
+	// +optional
+	Autoscaler *nbv1.AutoscalerSpec `json:"autoscaler,omitempty"`
+
 	// DisableLoadBalancerService (optional) sets the service type to ClusterIP instead of LoadBalancer
 	// +nullable
 	// +optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -614,6 +614,11 @@ func (in *MultiCloudGatewaySpec) DeepCopyInto(out *MultiCloudGatewaySpec) {
 		*out = new(v1alpha1.EndpointsSpec)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Autoscaler != nil {
+		in, out := &in.Autoscaler, &out.Autoscaler
+		*out = new(v1alpha1.AutoscalerSpec)
+		**out = **in
+	}
 	if in.ExternalPgConfig != nil {
 		in, out := &in.ExternalPgConfig, &out.ExternalPgConfig
 		*out = new(ExternalPGSpec)

--- a/config/crd/bases/ocs.openshift.io_storageclusters.yaml
+++ b/config/crd/bases/ocs.openshift.io_storageclusters.yaml
@@ -3785,6 +3785,22 @@ spec:
                 description: MultiCloudGatewaySpec defines specific multi-cloud gateway
                   configuration options
                 properties:
+                  autoscaler:
+                    description: Autoscaler (optional) sets configuration for NooBaa
+                      endpoint autoscaling.
+                    properties:
+                      autoscalerType:
+                        description: Type of autoscaling (optional) for noobaa-endpoint,
+                          hpav2(default) and keda - Prometheus metrics based
+                        enum:
+                        - hpav2
+                        - keda
+                        type: string
+                      prometheusNamespace:
+                        description: Prometheus namespace that scrap metrics from
+                          noobaa
+                        type: string
+                    type: object
                   dbBackup:
                     description: DBBackup (optional) configure automatic scheduled
                       backups of noobaa database volume.

--- a/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
+++ b/deploy/csv-templates/crds/ocs/ocs.openshift.io_storageclusters.yaml
@@ -3785,6 +3785,22 @@ spec:
                 description: MultiCloudGatewaySpec defines specific multi-cloud gateway
                   configuration options
                 properties:
+                  autoscaler:
+                    description: Autoscaler (optional) sets configuration for NooBaa
+                      endpoint autoscaling.
+                    properties:
+                      autoscalerType:
+                        description: Type of autoscaling (optional) for noobaa-endpoint,
+                          hpav2(default) and keda - Prometheus metrics based
+                        enum:
+                        - hpav2
+                        - keda
+                        type: string
+                      prometheusNamespace:
+                        description: Prometheus namespace that scrap metrics from
+                          noobaa
+                        type: string
+                    type: object
                   dbBackup:
                     description: DBBackup (optional) configure automatic scheduled
                       backups of noobaa database volume.

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -79,7 +79,7 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2026-05-29T05:31:37Z"
+    createdAt: "2026-06-09T12:43:38Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.34.1

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2026-05-29T05:31:37Z"
+    createdAt: "2026-06-09T12:43:38Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",

--- a/deploy/ocs-operator/manifests/storagecluster.crd.yaml
+++ b/deploy/ocs-operator/manifests/storagecluster.crd.yaml
@@ -3787,6 +3787,22 @@ spec:
                 description: MultiCloudGatewaySpec defines specific multi-cloud gateway
                   configuration options
                 properties:
+                  autoscaler:
+                    description: Autoscaler (optional) sets configuration for NooBaa
+                      endpoint autoscaling.
+                    properties:
+                      autoscalerType:
+                        description: Type of autoscaling (optional) for noobaa-endpoint,
+                          hpav2(default) and keda - Prometheus metrics based
+                        enum:
+                        - hpav2
+                        - keda
+                        type: string
+                      prometheusNamespace:
+                        description: Prometheus namespace that scrap metrics from
+                          noobaa
+                        type: string
+                    type: object
                   dbBackup:
                     description: DBBackup (optional) configure automatic scheduled
                       backups of noobaa database volume.

--- a/internal/controller/storagecluster/noobaa_system_reconciler.go
+++ b/internal/controller/storagecluster/noobaa_system_reconciler.go
@@ -224,6 +224,14 @@ func (r *StorageClusterReconciler) setNooBaaDesiredState(nb *nbv1.NooBaa, sc *oc
 				nb.Spec.Endpoints.Resources = epSpec.Resources
 			}
 		}
+		if sc.Spec.MultiCloudGateway.Autoscaler != nil {
+			if sc.Spec.MultiCloudGateway.Autoscaler.AutoscalerType != "" {
+				nb.Spec.Autoscaler.AutoscalerType = sc.Spec.MultiCloudGateway.Autoscaler.AutoscalerType
+			}
+			if sc.Spec.MultiCloudGateway.Autoscaler.PrometheusNamespace != "" {
+				nb.Spec.Autoscaler.PrometheusNamespace = sc.Spec.MultiCloudGateway.Autoscaler.PrometheusNamespace
+			}
+		}
 		nb.Spec.DisableLoadBalancerService = sc.Spec.MultiCloudGateway.DisableLoadBalancerService
 
 		nb.Spec.DisableRoutes = sc.Spec.MultiCloudGateway.DisableRoutes

--- a/internal/controller/storagecluster/noobaa_system_reconciler_test.go
+++ b/internal/controller/storagecluster/noobaa_system_reconciler_test.go
@@ -330,6 +330,18 @@ func TestSetNooBaaDesiredState(t *testing.T) {
 			},
 			dbStorageClassName: noobaDbDefaultStorageClass,
 		},
+		{
+			label: "case 7", // autoscalerType should reflect Autoscaler in noobaa spec
+			sc: v1.StorageCluster{
+				Spec: v1.StorageClusterSpec{
+					MultiCloudGateway: &v1.MultiCloudGatewaySpec{
+						Autoscaler: &nbv1.AutoscalerSpec{
+							AutoscalerType: nbv1.AutoscalerTypeKeda,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {
@@ -394,6 +406,11 @@ func TestSetNooBaaDesiredState(t *testing.T) {
 		}
 		if c.envDB != "" {
 			assert.Equalf(t, *noobaa.Spec.DBSpec.DBImage, c.envDB, "[%s] db envVar not applied to noobaa spec", c.label)
+		}
+		if c.label == "case 7" {
+			assert.Equal(t, nbv1.AutoscalerTypeKeda, noobaa.Spec.Autoscaler.AutoscalerType)
+		} else {
+			assert.Equal(t, nbv1.AutoscalerTypeHPAV2, noobaa.Spec.Autoscaler.AutoscalerType)
 		}
 	}
 }


### PR DESCRIPTION
- Add `spec.multiCloudGateway.autoscaler` to the `StorageCluster` API, mapping to NooBaa's `AutoscalerSpec` (`autoscalerType`, `prometheusNamespace`)
- Propagate the configured autoscaler type through the NooBaa reconciler instead of unconditionally hardcoding `hpav2`
- Fixes [DFBUGS-7347](https://redhat.atlassian.net/browse/DFBUGS-7347), where patching the NooBaa CR directly to `keda` was immediately reverted on every StorageCluster reconcile