### PR TITLE
DFBUGS-7353: [release-4.21]exclude alerts for probe failed nodes

### DIFF
--- a/metrics/deploy/prometheus-ocs-rules.yaml
+++ b/metrics/deploy/prometheus-ocs-rules.yaml
@@ -526,12 +526,19 @@ spec:
     rules:
     - alert: ODFNodeLatencyHighOnOSDNodes
       expr: |
-        max_over_time(
-            probe_icmp_duration_seconds{phase="rtt",
+        count(
+          max_over_time(
+              probe_icmp_duration_seconds{phase="rtt",
+              job="odf-blackbox-exporter",
+              daemon_type="osd"
+              }[24h:]
+          ) > 0.010
+          and on(instance, job, daemon_type, namespace)
+          probe_success{
             job="odf-blackbox-exporter",
             daemon_type="osd"
-            }[24h:]
-        ) > 0.010
+          } == 1
+        ) > 0
       for: 10m
       labels:
         severity: warning
@@ -543,12 +550,19 @@ spec:
 
     - alert: ODFNodeLatencyHighOnNonOSDNodes
       expr: |
-        max_over_time(
-            probe_icmp_duration_seconds{phase="rtt",
+        count(
+          max_over_time(
+              probe_icmp_duration_seconds{phase="rtt",
+              job="odf-blackbox-exporter",
+              daemon_type="mon"
+              }[24h:]
+          ) > 0.100
+          and on(instance, job, daemon_type, namespace)
+          probe_success{
             job="odf-blackbox-exporter",
             daemon_type="mon"
-            }[24h:]
-        ) > 0.100
+          } == 1
+        ) > 0
       for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
Currently we are calculating node latency for all
ips from the cluster, but in case of multus
enabled cluster where we have more multiple ips
one in default network path and other in different path than blackbox-exporter.
In this case the alert is raised for the ips whose probe failed which is not our requirement.
This commit modifies the node latency to raise
alerts for the nodes or ips for which the
probes_success is 1


(cherry picked from commit 4471fd8d34a1910135560aa4fdb1deace8987b72)