### PR TITLE
fix: single-node topology support for deploying DF on microshift

### DIFF
--- a/api/v1/topologymap.go
+++ b/api/v1/topologymap.go
@@ -71,6 +71,9 @@ func (m *NodeTopologyMap) GetKeyValues(topologyKey string) (string, []string) {
 		"rack": "topology.rook.io/rack",
 		"host": corev1.LabelHostname,
 		"zone": corev1.LabelZoneFailureDomainStable,
+
+		// osd failure domain uses host label, used during single node dev/test
+		"osd": corev1.LabelHostname,
 	}
 
 	// Get the specific label based on the topologyKey

--- a/internal/controller/storagecluster/cephcluster.go
+++ b/internal/controller/storagecluster/cephcluster.go
@@ -755,6 +755,11 @@ func getCephPoolReplicatedSize(sc *ocsv1.StorageCluster) uint {
 
 // getMinimumNodes returns the minimum number of nodes that are required for the Storage Cluster of various configurations
 func getMinimumNodes(sc *ocsv1.StorageCluster, isTnfCluster bool) int {
+	// For single-node deployments, only 1 node is required regardless of replica count
+	// This allows multiple OSDs on a single node with failureDomain: osd
+	if util.IsSingleNodeDeployment() {
+		return 1
+	}
 	// Case 1: When replicasPerFailureDomain is 1.
 	// A node is the smallest failure domain that is possible. We definitely
 	// want the devices in the same device set to be in different failure

--- a/internal/controller/storagecluster/topology.go
+++ b/internal/controller/storagecluster/topology.go
@@ -85,8 +85,7 @@ func setFailureDomain(sc *ocsv1.StorageCluster) {
 
 	if statusutil.IsSingleNodeDeployment() {
 		sc.Status.FailureDomain = "osd"
-		// Since nodes do not have a label for "osd" as a failure domain, setting it to "host".
-		sc.Status.FailureDomainKey, sc.Status.FailureDomainValues = sc.Status.NodeTopologies.GetKeyValues("host")
+		sc.Status.FailureDomainKey, sc.Status.FailureDomainValues = sc.Status.NodeTopologies.GetKeyValues(sc.Status.FailureDomain)
 		return
 	}
 


### PR DESCRIPTION
1) fix: allow single-node deployment with multiple OSDs

Allow getMinimumNodes to return 1 for single-node deployments, enabling multiple OSDs on a single node with failureDomain set to 'osd'. Previously, the function would require nodes equal to the replica count even in single-node scenarios.

2) fix: use correct topology key for single-node failure domain

Added 'osd' to topology key mapping in topologymap.go. Prevents empty FailureDomainKey and FailureDomainValues for single-node deployments.

When "osd" was not in supported labels:

When the first reconciliation happens FailureDomain is not set yet. IsSingleNodeDeployment() is true,FailureDomain is set to "osd", and FailureDomainKey/FailureDomainValues are correctly populated by calling GetKeyValues("host") 

Every subsequent reconciliation, FailureDomain != "" is already true , so that block of code at runs and it calls
GetKeyValues("osd"). Since "osd" is not in supportedLabels, it returns empty FailureDomainKey.

