### PR TITLE
[release-4.17] Bump go (stdlib: net/http) from 1.22.0 to 1.22.2

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/red-hat-storage/ocs-operator/api/v4
 
-go 1.22.0
+go 1.22.2
 
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.0.0-20240827070548-002966de315a

--- a/metrics/vendor/modules.txt
+++ b/metrics/vendor/modules.txt
@@ -295,7 +295,7 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240731064750-930a78b89d84 => ../api
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 github.com/red-hat-storage/ocs-operator/api/v4/v1
 github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1
 # github.com/red-hat-storage/ocs-operator/v4 v4.0.0-20240731064750-930a78b89d84 => ../

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -394,7 +394,7 @@ github.com/prometheus/procfs/internal/util
 ## explicit; go 1.22.0
 github.com/red-hat-storage/ocs-client-operator/api/v1alpha1
 # github.com/red-hat-storage/ocs-operator/api/v4 v4.0.0-20240731064750-930a78b89d84 => ./api
-## explicit; go 1.22.0
+## explicit; go 1.22.2
 github.com/red-hat-storage/ocs-operator/api/v4/v1
 github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1
 # github.com/rook/rook/pkg/apis v0.0.0-20240828225153-88eab510dd2b


### PR DESCRIPTION
### Changes
- **go (stdlib: net/http)**: `1.22.0` → `1.22.2` (in `api/go.mod`)
