### PR TITLE
DFBUGS-4768: alerts: remove duplicate PVC usage alerts from local ceph rules

### DIFF
--- a/controllers/storagecluster/cephcluster_test.go
+++ b/controllers/storagecluster/cephcluster_test.go
@@ -1040,7 +1040,7 @@ func TestNewCephDaemonResources(t *testing.T) {
 func TestParsePrometheusRules(t *testing.T) {
 	prometheusRules, err := parsePrometheusRule(localPrometheusRules)
 	assert.NilError(t, err)
-	assert.Equal(t, 11, len(prometheusRules.Spec.Groups))
+	assert.Equal(t, 10, len(prometheusRules.Spec.Groups))
 
 	prometheusRules, err = parsePrometheusRule(externalPrometheusRules)
 	assert.NilError(t, err)

--- a/controllers/storagecluster/prometheus/localcephrules.yaml
+++ b/controllers/storagecluster/prometheus/localcephrules.yaml
@@ -235,36 +235,6 @@ spec:
       for: 1h
       labels:
         severity: warning
-  - name: persistent-volume-alert.rules
-    rules:
-    - alert: PersistentVolumeUsageNearFull
-      annotations:
-        description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed 90%. Free up some space or expand the PVC.
-        message: PVC {{ $labels.persistentvolumeclaim }} is nearing full. Data deletion or PVC expansion is required.
-        severity_level: warning
-        storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/PersistentVolumeUsageNearFull.md
-      expr: |
-        max by (namespace, persistentvolumeclaim) (
-          (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"}))
-        ) > 0.90
-      for: 5s
-      labels:
-        severity: warning
-    - alert: PersistentVolumeUsageCritical
-      annotations:
-        description: PVC {{ $labels.persistentvolumeclaim }} utilization has crossed 95%. Free up some space or expand the PVC immediately.
-        message: PVC {{ $labels.persistentvolumeclaim }} is critically full. Data deletion or PVC expansion is required.
-        severity_level: error
-        storage_type: ceph
-        runbook_url: https://github.com/openshift/runbooks/blob/master/alerts/openshift-container-storage-operator/PersistentVolumeUsageCritical.md
-      expr: |
-        max by (namespace, persistentvolumeclaim) (
-          (kubelet_volume_stats_used_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"})) / (kubelet_volume_stats_capacity_bytes * on (namespace,persistentvolumeclaim) group_left(storageclass, provisioner) (kube_persistentvolumeclaim_info * on (storageclass)  group_left(provisioner) kube_storageclass_info {provisioner=~"(.*rbd.csi.ceph.com)|(.*cephfs.csi.ceph.com)"}))
-        ) > 0.95
-      for: 5s
-      labels:
-        severity: critical
   - name: cluster-state-alert.rules
     rules:
     - alert: CephClusterErrorState


### PR DESCRIPTION
These alerts are now owned by ocs-client-operator's prometheus-pvc-rules. Removing the duplicate from
prometheus-ceph-rules avoids two PrometheusRules defining the same alert at different thresholds on internal mode clusters.

cherry pick of https://github.com/red-hat-storage/ocs-operator/pull/3809