### PR TITLE
support annotations to force deploy rgw

### DIFF
--- a/internal/controller/storagecluster/cephobjectstores.go
+++ b/internal/controller/storagecluster/cephobjectstores.go
@@ -22,9 +22,23 @@ import (
 )
 
 const (
+	enableRGWAnnotation         = "ocs.openshift.io/enable-rgw"
 	enableRGWAutoscaleAnnotation = "ocs.openshift.io/enable-rgw-autoscale"
 	stsKeyLen                    = 16 // 16 alphanumeric characters for STS key
 )
+
+func shouldSkipObjectStore(sc *ocsv1.StorageCluster) (bool, error) {
+	skip, err := platform.PlatformsShouldSkipObjectStore()
+	if err != nil {
+		return false, err
+	}
+	if skip && sc.GetAnnotations()[enableRGWAnnotation] == "true" {
+		klog.Infof("Annotation %q overrides platform skip for ObjectStore on StorageCluster %s/%s",
+			enableRGWAnnotation, sc.Namespace, sc.Name)
+		return false, nil
+	}
+	return skip, nil
+}
 
 type ocsCephObjectStores struct {
 	tlsProfile *ocstlsv1.TLSProfile
@@ -38,7 +52,7 @@ func (obj *ocsCephObjectStores) ensureCreated(r *StorageClusterReconciler, insta
 		return reconcile.Result{}, nil
 	}
 
-	skip, err := platform.PlatformsShouldSkipObjectStore()
+	skip, err := shouldSkipObjectStore(instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/internal/controller/storagecluster/cephobjectstores_test.go
+++ b/internal/controller/storagecluster/cephobjectstores_test.go
@@ -547,3 +547,62 @@ func TestRGWTLSConfig(t *testing.T) {
 		assert.Contains(t, stores[0].Spec.Security.TlsGroups, "secp384r1")
 	})
 }
+
+func TestShouldSkipObjectStore(t *testing.T) {
+	cases := []struct {
+		label        string
+		platform     configv1.PlatformType
+		annotations  map[string]string
+		expectedSkip bool
+	}{
+		{
+			label:        "Cloud platform without annotation skips",
+			platform:     configv1.AWSPlatformType,
+			annotations:  nil,
+			expectedSkip: true,
+		},
+		{
+			label:        "Cloud platform with enable-rgw annotation does not skip",
+			platform:     configv1.AWSPlatformType,
+			annotations:  map[string]string{enableRGWAnnotation: "true"},
+			expectedSkip: false,
+		},
+		{
+			label:        "Bare metal without annotation does not skip",
+			platform:     configv1.BareMetalPlatformType,
+			annotations:  nil,
+			expectedSkip: false,
+		},
+		{
+			label:        "Bare metal with annotation does not skip",
+			platform:     configv1.BareMetalPlatformType,
+			annotations:  map[string]string{enableRGWAnnotation: "true"},
+			expectedSkip: false,
+		},
+		{
+			label:        "Cloud platform with annotation set to non-true value skips",
+			platform:     configv1.AWSPlatformType,
+			annotations:  map[string]string{enableRGWAnnotation: "false"},
+			expectedSkip: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			platform.SetFakePlatformInstanceForTesting(true, c.platform)
+			defer platform.UnsetFakePlatformInstanceForTesting()
+
+			sc := &api.StorageCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-sc",
+					Namespace:   "test-ns",
+					Annotations: c.annotations,
+				},
+			}
+
+			skip, err := shouldSkipObjectStore(sc)
+			assert.NoError(t, err)
+			assert.Equal(t, c.expectedSkip, skip)
+		})
+	}
+}

--- a/internal/controller/storagecluster/cephobjectstoreusers.go
+++ b/internal/controller/storagecluster/cephobjectstoreusers.go
@@ -68,7 +68,7 @@ func (obj *ocsCephObjectStoreUsers) ensureCreated(r *StorageClusterReconciler, i
 		return reconcile.Result{}, nil
 	}
 
-	skip, err := platform.PlatformsShouldSkipObjectStore()
+	skip, err := shouldSkipObjectStore(instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/internal/controller/storagecluster/console_configuration.go
+++ b/internal/controller/storagecluster/console_configuration.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
-	"github.com/red-hat-storage/ocs-operator/v4/pkg/platform"
 
 	consolev1 "github.com/openshift/api/console/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,7 +35,7 @@ func (obj *ocsConsoleConfiguration) ensureCreated(r *StorageClusterReconciler, i
 		return reconcile.Result{}, nil
 	}
 
-	skip, err := platform.PlatformsShouldSkipObjectStore()
+	skip, err := shouldSkipObjectStore(instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -118,7 +117,7 @@ func (obj *ocsConsoleConfiguration) ensureDeleted(r *StorageClusterReconciler, s
 		return reconcile.Result{}, nil
 	}
 
-	skip, err := platform.PlatformsShouldSkipObjectStore()
+	skip, err := shouldSkipObjectStore(sc)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/internal/controller/storagecluster/obcstorageclasses.go
+++ b/internal/controller/storagecluster/obcstorageclasses.go
@@ -2,7 +2,6 @@ package storagecluster
 
 import (
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
-	"github.com/red-hat-storage/ocs-operator/v4/pkg/platform"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	storagev1 "k8s.io/api/storage/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -19,7 +18,7 @@ func (s *obcStorageClasses) ensureCreated(r *StorageClusterReconciler, storageCl
 		return ctrl.Result{}, nil
 	}
 
-	if skip, err := platform.PlatformsShouldSkipObjectStore(); err != nil {
+	if skip, err := shouldSkipObjectStore(storageCluster); err != nil {
 		r.Log.Error(err, "failed to identify if ObjectStore SC should be created")
 	} else if skip || r.isTnfCluster {
 		return ctrl.Result{}, nil

--- a/internal/controller/storagecluster/resourceprofile.go
+++ b/internal/controller/storagecluster/resourceprofile.go
@@ -6,7 +6,6 @@ import (
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/defaults"
-	"github.com/red-hat-storage/ocs-operator/v4/pkg/platform"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -62,7 +61,7 @@ func (r *StorageClusterReconciler) ensureResourceProfileChangeApplied(sc *ocsv1.
 	}
 
 	// If rgw is not skipped, Verify if expected number of rgw pods with the current resource profile label are running
-	skiprgw, err := platform.PlatformsShouldSkipObjectStore()
+	skiprgw, err := shouldSkipObjectStore(sc)
 	if err != nil {
 		return err
 	}

--- a/internal/controller/storagecluster/routes.go
+++ b/internal/controller/storagecluster/routes.go
@@ -31,7 +31,7 @@ func (obj *ocsCephRGWRoutes) ensureCreated(r *StorageClusterReconciler, instance
 		return reconcile.Result{}, nil
 	}
 
-	skip, err := platform.PlatformsShouldSkipObjectStore()
+	skip, err := shouldSkipObjectStore(instance)
 	if err != nil {
 		return reconcile.Result{}, err
 	}


### PR DESCRIPTION
on cloud platforms, ocs operator skips RGW deployment. Add `ocs.openshift.io/enable-rgw: true` annotation on the storageCluster to override this and force deploy RGW.

This is 4.23 RGW Story - https://redhat.atlassian.net/browse/RHSTOR-8915 