### PR TITLE
Create rgw account and root user

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -107,6 +107,7 @@ rules:
   resources:
   - cephblockpoolradosnamespaces
   - cephfilesystemsubvolumegroups
+  - cephobjectstoreaccounts
   verbs:
   - create
   - delete

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -264,6 +264,7 @@ spec:
           resources:
           - cephblockpoolradosnamespaces
           - cephfilesystemsubvolumegroups
+          - cephobjectstoreaccounts
           verbs:
           - create
           - delete

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -283,6 +283,7 @@ spec:
           resources:
           - cephblockpoolradosnamespaces
           - cephfilesystemsubvolumegroups
+          - cephobjectstoreaccounts
           verbs:
           - create
           - delete

--- a/deploy/ocs-operator/manifests/provider-role.yaml
+++ b/deploy/ocs-operator/manifests/provider-role.yaml
@@ -23,6 +23,9 @@ rules:
       - cephrbdmirrors
       - cephclusters
       - cephnfses
+      - cephobjectstores
+      - cephobjectstoreaccounts
+      - cephobjectstoreusers
     verbs:
       - get
       - list

--- a/docs/design/rgw-accounts.md
+++ b/docs/design/rgw-accounts.md
@@ -6,7 +6,7 @@ RGW Accounts (Ceph Squid / v19) group users and roles under shared ownership whe
 
 OBCs cannot fill this role because they provision one bucket with one credential and have no support for creating additional buckets, managing IAM users, or attaching policies.
 
-This feature provisions per-spoke RGW Accounts on the hub, delivers admin credentials to spokes via the existing gRPC channel and handles spoke offboarding with Account cleanup.
+This feature provisions per-spoke RGW Accounts on the hub, delivers root user credentials to spokes via the existing gRPC channel and handles spoke offboarding with Account cleanup.
 
 ## Feature Gating
 
@@ -16,7 +16,7 @@ Account creation requires two gates. One at the cluster level and one at the spo
 
 Two annotations on StorageCluster control RGW deployment and advanced features independently.
 
-- **`ocs.openshift.io/enable-advanced-rgw-features`** — enables advanced RGW features (Accounts, STS and any future capabilities). On platforms where RGW is already deployed (bare metal), this enables the features on the existing RGW.
+- **`ocs.openshift.io/enable-advanced-rgw-features: "true"`** — enables advanced RGW features (Accounts, STS and any future capabilities). On platforms where RGW is already deployed (bare metal), this enables the features on the existing RGW.
 - **`ocs.openshift.io/enable-rgw: "true"`** — forces RGW deployment on platforms where it is not normally deployed (e.g., cloud). Not needed on bare metal.
 - The deploying operator sets these annotations.
 
@@ -39,11 +39,11 @@ Not all spokes need an RGW Account. The hub admin must be able to control which 
 The internal consumer (hub itself) can also receive an RGW Account. Both annotations are required: `enable-advanced-rgw-features` on StorageCluster and `enable-rgw-account` on the internal StorageConsumer. The `enable-rgw-account` annotation is not auto-propagated. The hub admin or deploying operator must explicitly set it on the internal StorageConsumer. The use case is running S3-consuming applications directly on the hub.
 
 
-## Create RGW Account and Admin User per Spoke
+## Create RGW Account per Spoke
 
-Each spoke (StorageConsumer CR) needs an isolated RGW Account and an admin-capable user whose credentials can be delivered to the spoke.
+Each spoke (StorageConsumer CR) needs an isolated RGW Account whose root user credentials can be delivered to the spoke.
 
-When RGW is running (natively or via `enable-rgw`), `enable-advanced-rgw-features` is set on StorageCluster and `enable-rgw-account` is set on StorageConsumer, OCS Operator creates a `CephObjectStoreAccount` and a `CephObjectStoreUser` (with admin capabilities) for the spoke.
+When RGW is running (natively or via `enable-rgw`), `enable-advanced-rgw-features` is set on StorageCluster and `enable-rgw-account` is set on StorageConsumer, OCS Operator creates a `CephObjectStoreAccount` for the spoke. Rook creates the Account's root user and generates a credentials Secret.
 
 ### Account CR
 
@@ -57,20 +57,11 @@ Note: RGW account names (`spec.name`) must match `^[a-zA-Z0-9 ._-]+$` (max 2048 
 
 #### Root User
 
-- Root User creation is skipped (`spec.rootUser.skipCreate: true`). Rook uses the Admin Ops API to create the admin user, not the Root User, so there is no dependency on it.
-- Skipping root user creations ensures that no unused credentials are sitting on the hub.
+- Root User creation is **not** skipped. Rook creates the root user and stores its credentials in a Kubernetes Secret whose name is published in `CephObjectStoreAccount.status.rootAccountSecretName`.
+- The root user has default S3 access and full IAM management permissions on all resources within the account. This allows the spoke to self-manage its IAM users, policies and S3 access without hub intervention.
+- Account users (non-root) start with zero permissions and require IAM policies for any S3 or IAM operation. Only the root user can use the IAM API by default. Delivering root user credentials is the intended Ceph Account model for delegating account management.
+- Account owners are encouraged to use the root user for management only and create users and roles with fine-grained permissions for specific applications.
 - For recovery, the hub admin can use `radosgw-admin` via the toolbox.
-
-### Admin User CR
-
-The Admin User CR is per-consumer. Each consumer with the `enable-rgw-account` annotation gets its own Admin User with distinct access keys. When multiple consumers share a ConfigMap (and thus an Account), each consumer still has its own Admin User for audit traceability.
-
-- `metadata.name`: derived from the consumer's identity at runtime (e.g. `rgw-admin-<consumer-name>`), not stored in the shared ConfigMap. This follows the CephClient pattern where the CR name is derived from the consumer's UID rather than read from the ConfigMap. The gRPC layer uses the same derivation to look up the correct User CR per consumer.
-- `spec.displayName`: `<consumer-UID>-admin`. Must match IAM-compatible pattern (`[\w+=,.@-]+`).
-- `spec.accountRef.name`: references the Account CR's `metadata.name` (immutable after creation)
-- Capabilities: `user: "*"`, `buckets: "*"`, `usage: "*"`, `metadata: "*"` — covers IAM user management, bucket operations, usage stats and metadata access
-- OwnerRefs: StorageConsumer (controller reference) and the consumer's resource mapping ConfigMap (owner reference), matching the dual-owner pattern used for CephClient and other per-consumer sub-resources.
-- Rook derives the RGW user UID from `metadata.name` and generates a credentials Secret whose reference (name, namespace, resourceVersion) is published in `CephObjectStoreUser.status.keys[]`. OCS reads the secret name from status rather than constructing it.
 
 
 ### Resource Name Mapping
@@ -80,16 +71,14 @@ The consumer's resource mapping ConfigMap is extended with two new keys for shar
 - `rgw-account-name`: name of the `CephObjectStoreAccount` CR
 - `rgw-credentials-secret-name`: name of the credentials Secret advertised to the spoke
 
-The Admin User CR name is NOT stored in the ConfigMap because it is per-consumer. When multiple consumers share a ConfigMap, each needs its own Admin User with a distinct name. The name is derived at runtime from the consumer's identity (e.g. `rgw-admin-<consumer-name>`), following the CephClient pattern where CR names are derived from the consumer's UID.
-
-The gRPC layer uses the ConfigMap keys to look up the Account and spoke Secret name, and derives the Admin User name from the consumer's identity. Storing shared resource names in the ConfigMap ensures MDR scenarios work without discrepancies.
+The gRPC layer uses the ConfigMap keys to look up the Account and spoke Secret name. The root user credentials are read from the Secret referenced by `CephObjectStoreAccount.status.rootAccountSecretName`.
 
 **Note:** The Account CR name (`rgw-account-name`) must be deterministically derived from immutable StorageConsumer properties. This ensures that if the ConfigMap is deleted and recreated, the regenerated defaults match the existing CRs. Only admin-overridden values (e.g. a custom `rgw-credentials-secret-name` for multi-hub) would be lost on ConfigMap deletion.
 
 
 ## Advertise Credentials via gRPC
 
-The spoke needs the Account ID, admin user credentials and RGW endpoint to connect to the hub's RGW.
+The spoke needs the Account ID, root user credentials and RGW endpoint to connect to the hub's RGW.
 
 Extend the existing gRPC response to include a fully-formed Secret as a KubeObject payload.
 
@@ -103,12 +92,12 @@ The hub constructs the credentials Secret containing:
 |-------|--------|
 | `AWS_ENDPOINT_URL` | RGW HTTPS Route endpoint |
 | `AWS_ACCOUNT_ID` | `CephObjectStoreAccount.status.accountID` |
-| `AWS_ACCESS_KEY_ID` | Admin user's Rook-generated Secret (`AccessKey` field) |
-| `AWS_SECRET_ACCESS_KEY` | Admin user's Rook-generated Secret (`SecretKey` field) |
+| `AWS_ACCESS_KEY_ID` | Root user's Rook-generated Secret (`AccessKey` field), referenced by `CephObjectStoreAccount.status.rootAccountSecretName` |
+| `AWS_SECRET_ACCESS_KEY` | Root user's Rook-generated Secret (`SecretKey` field), referenced by `CephObjectStoreAccount.status.rootAccountSecretName` |
 
-- Credentials are only advertised after both the Account and User CRs report `status.phase == "Ready"`. 
-- If either is not ready, the Secret is omitted from the response. The spoke gets it on the next reconciliation cycle.
-- The `resourceVersion` of the Rook-generated credentials Secret is read from `CephObjectStoreUser.status.keys[]` and included in the `desiredClientConfigHash` computed in `ReportStatus`. This ensures the spoke detects credential changes and triggers a re-sync.
+- Credentials are only advertised after the Account CR reports `status.phase == "Ready"` and `status.rootAccountSecretName` is populated.
+- If the Account is not ready, the Secret is omitted from the response. The spoke gets it on the next reconciliation cycle.
+- The `resourceVersion` of the Rook-generated credentials Secret is included in the `desiredClientConfigHash` computed in `ReportStatus`. This ensures the spoke detects credential changes and triggers a re-sync.
 
 **Note:** ODF does not pass a CA certificate for the RGW endpoint. The endpoint is an OCP Route. It is the hub admin's responsibility to ensure the Route's TLS certificate is trusted by spoke applications.
 
@@ -121,11 +110,15 @@ The hub constructs the credentials Secret containing:
 
 ## Spoke-Side RBAC for Credentials Secret
 
-The credentials Secret contains Account admin credentials. This Secret lives in the `openshift-storage` namespace on the spoke. The consuming application, running in its own namespace, won't be able to access it by default.
+The credentials Secret contains Account root user credentials. This Secret lives in the `openshift-storage` namespace on the spoke. The consuming application, running in its own namespace, won't be able to access it by default.
 
 ODF does not manage RBAC for this Secret. The consuming application is responsible for creating whatever RBAC it needs (e.g., Role/RoleBinding granting its ServiceAccount cross-namespace read access to the Secret).
 
 The Secret is labeled with `ocs.openshift.io/storageclient=<name>`, so consumers can discover the correct Secret in multi-hub scenarios (e.g., `oc get secret -n openshift-storage -l ocs.openshift.io/storageclient=<name>`).
+
+## S3 Access and IAM Policies
+
+The root user has default permissions on all resources within the account, including S3 data operations and IAM management. Non-root account users start with zero permissions and require IAM policies attached via the IAM API. Only the root user can use the IAM API by default. The spoke uses the root user credentials to create IAM users with fine-grained S3 policies tailored to each application's needs.
 
 ## Spoke Offboarding
 
@@ -135,9 +128,8 @@ When a spoke is offboarded, credentials are revoked and all associated resources
 2. Client Operator performs checks and initiates offboard (calls `OffboardConsumer()`)
 3. On success, the finalizer on StorageClient is removed
 4. Kubernetes garbage-collects all StorageClient dependents, including the credentials Secret on the spoke
-5. On the hub, StorageConsumer controller removes its finalizer and Kubernetes garbage-collects dependents. The ConfigMap is GC'd only if no other consumer co-owns it. The Account and User CRs are GC'd only when both their ownerRefs (StorageConsumer and ConfigMap) are gone:
-   - `CephObjectStoreUser` (admin): Rook deletes the admin user and invalidates its access keys at the RGW level
-   - `CephObjectStoreAccount`: Rook deletes the Account
+5. On the hub, StorageConsumer controller removes its finalizer and Kubernetes garbage-collects dependents. The ConfigMap is GC'd only if no other consumer co-owns it. The Account CR is GC'd only when both its ownerRefs (StorageConsumer and ConfigMap) are gone:
+   - `CephObjectStoreAccount`: Rook deletes the Account, its root user and invalidates the root user's access keys at the RGW level
 
 After this, the spoke has no credentials, the access keys are invalid in RGW and the Account is removed.
 
@@ -145,28 +137,25 @@ After this, the spoke has no credentials, the access keys are invalid in RGW and
 
 When the `ocs.openshift.io/force-deletion` annotation is set on StorageConsumer, the controller propagates the `rook.io/force-deletion` annotation to the `CephObjectStoreAccount` CR. This follows the same pattern used for RadosNamespace and SubVolumeGroup force-deletion. Rook's Account controller will handle the annotation by purging the Account's contents (users, buckets) before deleting the Account. This is new upstream Rook work. `CephObjectStoreAccount` does not support the force-deletion annotation today.
 
-The `CephObjectStoreUser` CR does not need the force-deletion annotation. Deleting a User removes the RGW user and invalidates its keys unconditionally since users do not contain child resources.
-
 ## Multiple Consumers Sharing a ConfigMap
 
 Multiple StorageConsumers can reference the same resource mapping ConfigMap. Today, shared sub-resources like RadosNamespace and SubVolumeGroup are created by the primary consumer (the one that created the ConfigMap) and used by all consumers sharing it.
 
-RGW Account creation follows the same `isPrimaryConsumer` gate. The Account is a shared resource created by the primary consumer. Each consumer with the `enable-rgw-account` annotation gets its own Admin User CR with distinct access keys for audit traceability.
+RGW Account creation follows the same `isPrimaryConsumer` gate. The Account is a shared resource created by the primary consumer.
 
 ### Behavior
 
 **Case 1: Primary has annotation, secondary has annotation**
-- Primary creates the Account CR and its own Admin User CR
-- Secondary creates its own Admin User CR (referencing the same Account)
-- Each consumer's gRPC response includes credentials from its own Admin User only
+- Primary creates the Account CR (with root user)
+- Both consumers' gRPC responses include the same root user credentials (same Account, same root user)
 
 **Case 2: Primary has annotation, secondary does not**
-- Primary creates Account + its own Admin User, gets credentials
-- Secondary is unaffected. No Admin User created, no credentials shared
+- Primary creates Account, gets root user credentials
+- Secondary is unaffected. No credentials shared
 
 ### Credential Isolation
 
-Each consumer's Admin User has its own access keys. The gRPC layer derives the Admin User name from the consumer's identity and looks up that specific User's credentials. Two consumers sharing an Account never share the same access keys.
+When multiple consumers share an Account, they share the same root user credentials. Credential isolation between consumers sharing an Account is managed at the IAM level — each spoke can create its own IAM users with distinct access keys using the root user's IAM management capabilities.
 
 ## Limitations and Future Work
 
@@ -181,10 +170,8 @@ Each consumer's Admin User has its own access keys. The gRPC layer derives the A
 
 - **Non-primary consumer triggering Account creation:** Account creation is gated on `isPrimaryConsumer`, matching the existing pattern for RadosNamespace and SubVolumeGroup. If the primary consumer does not have `enable-rgw-account` but a non-primary consumer does, the Account will not be created. Supporting this would require changing the Account's ownership model (using `SetOwnerReference` instead of `SetControllerReference` so any consumer can create it without controller conflicts).
 
-- **Stale Admin User after non-primary consumer offboarding:** Per-consumer Admin Users use the dual-owner pattern (`SetControllerReference` from consumer + `SetOwnerReference` from ConfigMap). If a non-primary consumer is offboarded while the shared ConfigMap survives (primary still owns it), the Admin User is not GC'd because the ConfigMap ownerRef keeps it alive. The same issue exists today with per-consumer CephClients using the same dual-owner pattern. Possible fix: skip the ConfigMap ownerRef on per-consumer resources so they are GC'd with their consumer alone.
-
 - **Force-deletion with shared Accounts:** For shared Accounts, multiple ownerRefs keep the Account alive until the last owner is deleted. Force-deletion of one consumer won't GC the Account but leaves a stale force-deletion annotation that could cause unintended purge when the last consumer is removed.
 
-- **S3 credential rotation:** Rook does not support declarative S3 key rotation for `CephObjectStoreUser`. Rotation currently requires manual intervention via `radosgw-admin key create` from the toolbox. If keys are rotated this way, the propagation pipeline handles it. Rook updates the credentials Secret, `status.keys[]` resourceVersion changes, `desiredClientConfigHash` changes and the spoke re-syncs. A CR-level rotation mechanism would be an upstream Rook enhancement.
+- **Root user credential rotation:** Rook does not support declarative key rotation for the Account root user. Rotation currently requires manual intervention via `radosgw-admin key create` from the toolbox. If keys are rotated this way, the propagation pipeline handles it. Rook updates the root user credentials Secret, the `resourceVersion` changes, `desiredClientConfigHash` changes and the spoke re-syncs.
 
 - **Internal consumer migration to Accounts:** The internal consumer (hub) can receive an RGW Account under this design if both annotations are set. This gives the hub a new Account-based access path to RGW. Existing OBC-based workloads on the hub continue as-is. Migration of those workloads to use Account credentials is not planned for this feature. The hub admin could do it manually since Account credentials are delivered to the hub the same way as to any spoke.

--- a/internal/controller/storagecluster/routes.go
+++ b/internal/controller/storagecluster/routes.go
@@ -176,7 +176,7 @@ func (r *StorageClusterReconciler) newCephRGWRoutes(initData *ocsv1.StorageClust
 
 	var secureRoute = routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      util.GenerateNameForCephObjectStore(initData) + "-secure",
+			Name:      util.GenerateNameForCephObjectStoreSecureRoute(initData),
 			Namespace: initData.Namespace,
 		},
 		Spec: routev1.RouteSpec{

--- a/internal/controller/storagecluster/s3_endpoints_config.go
+++ b/internal/controller/storagecluster/s3_endpoints_config.go
@@ -83,20 +83,8 @@ func getNoobaaS3Endpoint(r *StorageClusterReconciler, namespace string, s3Endpoi
 		return nil
 	}
 
-	var host string
-outerLoop:
-	for i := range s3Route.Status.Ingress {
-		ing := &s3Route.Status.Ingress[i]
-		for c := range ing.Conditions {
-			if ing.Conditions[c].Type == routev1.RouteAdmitted &&
-				ing.Conditions[c].Status == corev1.ConditionTrue &&
-				ing.Host != "" {
-				host = ing.Host
-				break outerLoop
-			}
-		}
-	}
-	if host == "" {
+	host, found := util.GetAdmittedRouteHost(s3Route)
+	if !found {
 		return nil
 	}
 

--- a/internal/controller/storageconsumer/storageconsumer_controller.go
+++ b/internal/controller/storageconsumer/storageconsumer_controller.go
@@ -79,7 +79,8 @@ type StorageConsumerReconciler struct {
 // +kubebuilder:rbac:groups=ocs.openshift.io,resources=storageconsumers/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=ceph.rook.io,resources=cephclients,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=ceph.rook.io,resources=cephfilesystemsubvolumegroups;cephblockpoolradosnamespaces,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=ceph.rook.io,resources=cephblockpools;cephfilesystems;cephnfses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ceph.rook.io,resources=cephblockpools;cephfilesystems;cephnfses;cephobjectstores,verbs=get;list;watch
+// +kubebuilder:rbac:groups=ceph.rook.io,resources=cephobjectstoreaccounts,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;delete
 
@@ -288,6 +289,17 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 					return reconcile.Result{}, err
 				}
 			}
+			if availableServices.Rgw &&
+				storageCluster.GetAnnotations()[util.EnableAdvancedRGWFeaturesAnnotation] == "true" &&
+				r.storageConsumer.GetAnnotations()[util.EnableRGWAccountAnnotation] == "true" {
+				if err := r.reconcileRGWAccount(
+					util.GenerateNameForCephObjectStore(storageCluster),
+					consumerResources.GetRGWAccountName(),
+					consumerConfigMap,
+				); err != nil {
+					return reconcile.Result{}, err
+				}
+			}
 		}
 
 		r.storageConsumer.Status.State = ocsv1alpha1.StorageConsumerStateReady
@@ -343,6 +355,13 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 			svg.Namespace = r.namespace
 			if err := r.Patch(r.ctx, svg, annotationPatch); client.IgnoreNotFound(err) != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to annotate CephFilesystemSubVolumeGroup: %v", err)
+			}
+
+			account := &rookCephv1.CephObjectStoreAccount{}
+			account.Name = consumerResources.GetRGWAccountName()
+			account.Namespace = r.namespace
+			if err := r.Patch(r.ctx, account, annotationPatch); client.IgnoreNotFound(err) != nil {
+				return reconcile.Result{}, fmt.Errorf("failed to annotate CephObjectStoreAccount: %v", err)
 			}
 		}
 
@@ -573,6 +592,31 @@ func (r *StorageConsumerReconciler) reconcileCephFilesystemSubVolumeGroup(
 		}
 		svg.Spec.FilesystemName = cephFs.Name
 		svg.Spec.Name = subVolumeGroupName
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *StorageConsumerReconciler) reconcileRGWAccount(
+	objectStoreName string,
+	accountName string,
+	additionalOwner client.Object,
+) error {
+	account := &rookCephv1.CephObjectStoreAccount{}
+	account.Name = accountName
+	account.Namespace = r.namespace
+
+	if _, err := ctrl.CreateOrUpdate(r.ctx, r.Client, account, func() error {
+		if err := controllerutil.SetControllerReference(r.storageConsumer, account, r.Scheme); err != nil {
+			return err
+		}
+		if err := controllerutil.SetOwnerReference(additionalOwner, account, r.Scheme); err != nil {
+			return err
+		}
+		account.Spec.Store = objectStoreName
+		account.Spec.Name = accountName
 		return nil
 	}); err != nil {
 		return err
@@ -848,10 +892,18 @@ func (r *StorageConsumerReconciler) SetupWithManager(mgr ctrl.Manager) error {
 				predicate.GenerationChangedPredicate{},
 			),
 		).
+		Owns(
+			&rookCephv1.CephObjectStoreAccount{},
+			builder.MatchEveryOwner,
+			builder.WithPredicates(
+				predicate.GenerationChangedPredicate{},
+			),
+		).
 		Owns(&corev1.Secret{}).
 		// Watch non-owned resources
 		Watches(&rookCephv1.CephBlockPool{}, enqueueForAllStorageConsumers).
 		Watches(&rookCephv1.CephFilesystem{}, enqueueForAllStorageConsumers).
 		Watches(&rookCephv1.CephNFS{}, enqueueForAllStorageConsumers).
+		Watches(&rookCephv1.CephObjectStore{}, enqueueForAllStorageConsumers).
 		Complete(r)
 }

--- a/pkg/util/generate.go
+++ b/pkg/util/generate.go
@@ -58,6 +58,10 @@ func GenerateNameForCephObjectStore(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-%s", initData.Name, "cephobjectstore")
 }
 
+func GenerateNameForCephObjectStoreSecureRoute(initData *ocsv1.StorageCluster) string {
+	return GenerateNameForCephObjectStore(initData) + "-secure"
+}
+
 func GenerateNameForCephRbdMirror(initData *ocsv1.StorageCluster) string {
 	return fmt.Sprintf("%s-cephrbdmirror", initData.Name)
 }

--- a/pkg/util/routes.go
+++ b/pkg/util/routes.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	routev1 "github.com/openshift/api/route/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func GetAdmittedRouteHost(route *routev1.Route) (string, bool) {
+	for i := range route.Status.Ingress {
+		ing := &route.Status.Ingress[i]
+		for c := range ing.Conditions {
+			if ing.Conditions[c].Type == routev1.RouteAdmitted &&
+				ing.Conditions[c].Status == corev1.ConditionTrue &&
+				ing.Host != "" {
+				return ing.Host, true
+			}
+		}
+	}
+	return "", false
+}

--- a/pkg/util/routes_test.go
+++ b/pkg/util/routes_test.go
@@ -1,0 +1,96 @@
+package util
+
+import (
+	"testing"
+
+	routev1 "github.com/openshift/api/route/v1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestGetAdmittedRouteHost(t *testing.T) {
+	tests := []struct {
+		name          string
+		route         *routev1.Route
+		expectedHost  string
+		expectedFound bool
+	}{
+		{
+			name:          "no ingress",
+			route:         &routev1.Route{},
+			expectedHost:  "",
+			expectedFound: false,
+		},
+		{
+			name: "ingress with no conditions",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{Host: "example.com"},
+					},
+				},
+			},
+			expectedHost:  "",
+			expectedFound: false,
+		},
+		{
+			name: "ingress not admitted",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							Host: "example.com",
+							Conditions: []routev1.RouteIngressCondition{
+								{Type: routev1.RouteAdmitted, Status: corev1.ConditionFalse},
+							},
+						},
+					},
+				},
+			},
+			expectedHost:  "",
+			expectedFound: false,
+		},
+		{
+			name: "admitted with empty host",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							Host: "",
+							Conditions: []routev1.RouteIngressCondition{
+								{Type: routev1.RouteAdmitted, Status: corev1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			expectedHost:  "",
+			expectedFound: false,
+		},
+		{
+			name: "admitted with host",
+			route: &routev1.Route{
+				Status: routev1.RouteStatus{
+					Ingress: []routev1.RouteIngress{
+						{
+							Host: "rgw.apps.example.com",
+							Conditions: []routev1.RouteIngressCondition{
+								{Type: routev1.RouteAdmitted, Status: corev1.ConditionTrue},
+							},
+						},
+					},
+				},
+			},
+			expectedHost:  "rgw.apps.example.com",
+			expectedFound: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			host, found := GetAdmittedRouteHost(tt.route)
+			assert.Equal(t, tt.expectedHost, host)
+			assert.Equal(t, tt.expectedFound, found)
+		})
+	}
+}

--- a/pkg/util/storageconsumer.go
+++ b/pkg/util/storageconsumer.go
@@ -19,6 +19,9 @@ const (
 	ImplicitRbdRadosNamespaceName          = "<implicit>"
 	TicketAnnotation                       = "ocs.openshift.io/provider-onboarding-ticket"
 	AnnotationNonResilientPoolsTopologyKey = "ocs.openshift.io/non-resilient-pools-topology-key"
+	EnableAdvancedRGWFeaturesAnnotation    = "ocs.openshift.io/enable-advanced-rgw-features"
+	EnableRGWAccountAnnotation             = "ocs.openshift.io/enable-rgw-account"
+	StorageClientLabelKey                  = "ocs.openshift.io/storageclient"
 
 	// Constants for ConfigMap keys
 	rbdRadosNamespaceKey            = "rbd-rados-ns"
@@ -33,6 +36,8 @@ const (
 	rbdClientProfileKey             = "csiop-rbd-client-profile"
 	cephFsClientProfileKey          = "csiop-cephfs-client-profile"
 	nfsClientProfileKey             = "csiop-nfs-client-profile"
+	rgwAccountNameKey               = "rgw-account-name"
+	rgwCredentialsSecretNameKey     = "rgw-credentials-secret-name"
 )
 
 type AvailableServices struct {
@@ -40,6 +45,7 @@ type AvailableServices struct {
 	CephFs bool
 	Nfs    bool
 	Mcg    bool
+	Rgw    bool
 }
 
 type StorageConsumerResources interface {
@@ -56,6 +62,8 @@ type StorageConsumerResources interface {
 	GetRbdClientProfileName() string
 	GetCephFsClientProfileName() string
 	GetNfsClientProfileName() string
+	GetRGWAccountName() string
+	GetRGWCredentialsSecretName() string
 
 	// Setters
 	SetRbdRadosNamespaceName(string)
@@ -70,6 +78,8 @@ type StorageConsumerResources interface {
 	SetRbdClientProfileName(string)
 	SetCephFsClientProfileName(string)
 	SetNfsClientProfileName(string)
+	SetRGWAccountName(string)
+	SetRGWCredentialsSecretName(string)
 
 	ReplaceRbdRadosNamespaceName(string)
 	ReplaceSubVolumeGroupName(string)
@@ -142,6 +152,14 @@ func (wrapper storageConsumerResourceMapWrapper) GetNfsClientProfileName() strin
 	return wrapper.data[nfsClientProfileKey]
 }
 
+func (wrapper storageConsumerResourceMapWrapper) GetRGWAccountName() string {
+	return wrapper.data[rgwAccountNameKey]
+}
+
+func (wrapper storageConsumerResourceMapWrapper) GetRGWCredentialsSecretName() string {
+	return wrapper.data[rgwCredentialsSecretNameKey]
+}
+
 // Setters
 func (wrapper storageConsumerResourceMapWrapper) SetRbdRadosNamespaceName(name string) {
 	wrapper.data[rbdRadosNamespaceKey] = name
@@ -189,6 +207,14 @@ func (wrapper storageConsumerResourceMapWrapper) SetCephFsClientProfileName(name
 
 func (wrapper storageConsumerResourceMapWrapper) SetNfsClientProfileName(name string) {
 	wrapper.data[nfsClientProfileKey] = name
+}
+
+func (wrapper storageConsumerResourceMapWrapper) SetRGWAccountName(name string) {
+	wrapper.data[rgwAccountNameKey] = name
+}
+
+func (wrapper storageConsumerResourceMapWrapper) SetRGWCredentialsSecretName(name string) {
+	wrapper.data[rgwCredentialsSecretNameKey] = name
 }
 
 func (wrapper storageConsumerResourceMapWrapper) replaceIfExist(key, value string) {
@@ -278,6 +304,15 @@ func GetAvailableServices(ctx context.Context, kubeClient client.Client, storage
 	}
 	availableServices.Mcg = noobaa.UID != ""
 
+	// rgw - get the default object store
+	objectStore := &rookCephv1.CephObjectStore{}
+	objectStore.Name = GenerateNameForCephObjectStore(storageCluster)
+	objectStore.Namespace = storageCluster.Namespace
+	if err := kubeClient.Get(ctx, client.ObjectKeyFromObject(objectStore), objectStore); client.IgnoreNotFound(err) != nil {
+		return nil, fmt.Errorf("failed to get CephObjectStore: %v", err)
+	}
+	availableServices.Rgw = objectStore.UID != ""
+
 	return availableServices, nil
 }
 
@@ -305,6 +340,10 @@ func GetStorageConsumerDefaultResourceNames(
 		resourceNamesMap.SetNfsClientProfileName(storageConsumerUid)
 		resourceNamesMap.SetCsiNfsNodeCephUserName(fmt.Sprintf("csi-nfs-node-%s", storageConsumerUid))
 		resourceNamesMap.SetCsiNfsProvisionerCephUserName(fmt.Sprintf("csi-nfs-provisioner-%s", storageConsumerUid))
+	}
+	if availableServices.Rgw {
+		resourceNamesMap.SetRGWAccountName(storageConsumerName)
+		resourceNamesMap.SetRGWCredentialsSecretName("spoke-account-iam-credentials")
 	}
 	return defaults
 }

--- a/rbac/provider-role.yaml
+++ b/rbac/provider-role.yaml
@@ -23,6 +23,9 @@ rules:
       - cephrbdmirrors
       - cephclusters
       - cephnfses
+      - cephobjectstores
+      - cephobjectstoreaccounts
+      - cephobjectstoreusers
     verbs:
       - get
       - list

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -473,6 +473,15 @@ func (s *OCSProviderServer) GetDesiredClientState(ctx context.Context, req *pb.G
 			return nil, status.Errorf(codes.Internal, "failed to produce client state")
 		}
 
+		var rgwCredentialsResourceVersion string
+		if isRGWAccountEnabled(consumer, storageCluster) {
+			rgwCredentialsResourceVersion, err = s.getRGWCredentialsResourceVersion(ctx, consumer)
+			if err != nil {
+				logger.Error(err, "failed to get RGW credentials resource version")
+				return nil, status.Errorf(codes.Internal, "failed to produce client state")
+			}
+		}
+
 		desiredClientConfigHash := getDesiredClientConfigHash(
 			channelName,
 			zerodNonHashableFields(consumer),
@@ -494,6 +503,7 @@ func (s *OCSProviderServer) GetDesiredClientState(ctx context.Context, req *pb.G
 			useHostNetworkForCtrlPlugin,
 			obcResourceVersions,
 			s3EndpointsListResourceVersion,
+			rgwCredentialsResourceVersion,
 		)
 		response.DesiredStateHash = desiredClientConfigHash
 
@@ -786,6 +796,15 @@ func (s *OCSProviderServer) ReportStatus(ctx context.Context, req *pb.ReportStat
 		return nil, status.Errorf(codes.Internal, "failed to produce client state")
 	}
 
+	var rgwCredentialsResourceVersion string
+	if isRGWAccountEnabled(storageConsumer, storageCluster) {
+		rgwCredentialsResourceVersion, err = s.getRGWCredentialsResourceVersion(ctx, storageConsumer)
+		if err != nil {
+			logger.Error(err, "failed to get RGW credentials resource version")
+			return nil, status.Errorf(codes.Internal, "failed to produce client state")
+		}
+	}
+
 	desiredClientConfigHash := getDesiredClientConfigHash(
 		channelName,
 		zerodNonHashableFields(storageConsumer),
@@ -807,6 +826,7 @@ func (s *OCSProviderServer) ReportStatus(ctx context.Context, req *pb.ReportStat
 		util.ShouldUseHostNetworking(storageCluster),
 		obcResourceVersions,
 		s3EndpointsListResourceVersion,
+		rgwCredentialsResourceVersion,
 	)
 
 	logger.Info("Successfully processed status report")
@@ -1292,22 +1312,28 @@ func (s *OCSProviderServer) isConsumerMirrorEnabled(ctx context.Context, consume
 	return clientMappingConfig.Data[consumer.Status.Client.ID] != "", nil
 }
 
-func (s *OCSProviderServer) getKubeResources(ctx context.Context, logger logr.Logger, consumer *ocsv1alpha1.StorageConsumer) ([]kubeObjectWithOpRecord, error) {
-
-	consumerConfigMap := &corev1.ConfigMap{}
+func (s *OCSProviderServer) getConsumerConfig(ctx context.Context, consumer *ocsv1alpha1.StorageConsumer) (util.StorageConsumerResources, error) {
 	if consumer.Status.ResourceNameMappingConfigMap.Name == "" {
 		return nil, fmt.Errorf("waiting for ResourceNameMappingConfig to be generated")
 	}
+	consumerConfigMap := &corev1.ConfigMap{}
 	consumerConfigMap.Name = consumer.Status.ResourceNameMappingConfigMap.Name
 	consumerConfigMap.Namespace = consumer.Namespace
-	err := s.client.Get(ctx, client.ObjectKeyFromObject(consumerConfigMap), consumerConfigMap)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get %s configMap. %v", consumerConfigMap.Name, err)
+	if err := s.client.Get(ctx, client.ObjectKeyFromObject(consumerConfigMap), consumerConfigMap); err != nil {
+		return nil, fmt.Errorf("failed to get %s configMap: %w", consumerConfigMap.Name, err)
 	}
 	if consumerConfigMap.Data == nil {
-		return nil, fmt.Errorf("waiting StorageConsumer ResourceNameMappingConfig to be generated")
+		return nil, fmt.Errorf("waiting for StorageConsumer ResourceNameMappingConfig to be generated")
 	}
-	consumerConfig := util.WrapStorageConsumerResourceMap(consumerConfigMap.Data)
+	return util.WrapStorageConsumerResourceMap(consumerConfigMap.Data), nil
+}
+
+func (s *OCSProviderServer) getKubeResources(ctx context.Context, logger logr.Logger, consumer *ocsv1alpha1.StorageConsumer) ([]kubeObjectWithOpRecord, error) {
+
+	consumerConfig, err := s.getConsumerConfig(ctx, consumer)
+	if err != nil {
+		return nil, err
+	}
 
 	storageCluster, err := util.GetStorageClusterInNamespace(ctx, s.client, s.namespace)
 	if err != nil {
@@ -1517,6 +1543,19 @@ func (s *OCSProviderServer) getKubeResources(ctx context.Context, logger logr.Lo
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if isRGWAccountEnabled(consumer, storageCluster) {
+		records, err = s.appendRGWAccountCredentialsKubeResources(
+			ctx,
+			records,
+			consumer,
+			consumerConfig,
+			storageCluster,
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return records, nil
@@ -2595,6 +2634,127 @@ func (s *OCSProviderServer) appendS3EndpointsListKubeResources(
 		kubeObject: clientConfigMap,
 		clientOp:   pb.KubeClientOp_CREATE_OR_UPDATE,
 	}), nil
+}
+
+func isRGWAccountEnabled(consumer *ocsv1alpha1.StorageConsumer, storageCluster *ocsv1.StorageCluster) bool {
+	return storageCluster.GetAnnotations()[util.EnableAdvancedRGWFeaturesAnnotation] == "true" &&
+		consumer.GetAnnotations()[util.EnableRGWAccountAnnotation] == "true"
+}
+
+func (s *OCSProviderServer) getRGWRootUserCredentialsSecret(
+	ctx context.Context,
+	consumer *ocsv1alpha1.StorageConsumer,
+	consumerConfig util.StorageConsumerResources,
+) (*corev1.Secret, error) {
+	logger := klog.FromContext(ctx).WithName("getRGWRootUserCredentialsSecret").WithValues("consumer", consumer.Name)
+
+	account := &rookCephv1.CephObjectStoreAccount{}
+	account.Name = consumerConfig.GetRGWAccountName()
+	account.Namespace = s.namespace
+	if err := s.client.Get(ctx, client.ObjectKeyFromObject(account), account); err != nil {
+		return nil, fmt.Errorf("failed to get CephObjectStoreAccount %s: %w", account.Name, err)
+	}
+	if account.Status == nil || account.Status.Phase != "Ready" ||
+		account.Status.RootAccountSecretName == "" {
+		logger.Info("CephObjectStoreAccount not ready, skipping credentials", "account", account.Name)
+		return nil, nil
+	}
+
+	rookSecret := &corev1.Secret{}
+	rookSecret.Name = account.Status.RootAccountSecretName
+	rookSecret.Namespace = s.namespace
+	if err := s.client.Get(ctx, client.ObjectKeyFromObject(rookSecret), rookSecret); err != nil {
+		return nil, fmt.Errorf("failed to get root user credentials Secret %s: %w", rookSecret.Name, err)
+	}
+
+	logger.Info("found root user credentials Secret", "account", account.Name, "secret", rookSecret.Name)
+	return rookSecret, nil
+}
+
+func (s *OCSProviderServer) appendRGWAccountCredentialsKubeResources(
+	ctx context.Context,
+	records []kubeObjectWithOpRecord,
+	consumer *ocsv1alpha1.StorageConsumer,
+	consumerConfig util.StorageConsumerResources,
+	storageCluster *ocsv1.StorageCluster,
+) ([]kubeObjectWithOpRecord, error) {
+	logger := klog.FromContext(ctx).WithName("appendRGWAccountCredentialsKubeResources").WithValues("consumer", consumer.Name)
+
+	rookSecret, err := s.getRGWRootUserCredentialsSecret(ctx, consumer, consumerConfig)
+	if err != nil {
+		return records, err
+	}
+	if rookSecret == nil {
+		return records, nil
+	}
+
+	account := &rookCephv1.CephObjectStoreAccount{}
+	account.Name = consumerConfig.GetRGWAccountName()
+	account.Namespace = s.namespace
+	if err := s.client.Get(ctx, client.ObjectKeyFromObject(account), account); err != nil {
+		return records, fmt.Errorf("failed to get CephObjectStoreAccount %s: %w", account.Name, err)
+	}
+
+	rgwRoute := &routev1.Route{}
+	rgwRoute.Name = util.GenerateNameForCephObjectStoreSecureRoute(storageCluster)
+	rgwRoute.Namespace = s.namespace
+	if err := s.client.Get(ctx, client.ObjectKeyFromObject(rgwRoute), rgwRoute); err != nil {
+		return records, fmt.Errorf("failed to get RGW secure Route %s: %w", rgwRoute.Name, err)
+	}
+	host, found := util.GetAdmittedRouteHost(rgwRoute)
+	if !found {
+		return records, fmt.Errorf("RGW secure Route %s has no admitted host", rgwRoute.Name)
+	}
+
+	spokeSecretName := consumerConfig.GetRGWCredentialsSecretName()
+	spokeSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      spokeSecretName,
+			Namespace: consumer.Status.Client.OperatorNamespace,
+			Labels: map[string]string{
+				util.StorageClientLabelKey: consumer.Status.Client.ID,
+			},
+		},
+		// No CA cert is included. The endpoint is an OCP Route and the hub admin
+		// is responsible for ensuring the TLS certificate is trusted by spokes.
+		StringData: map[string]string{
+			"AWS_ENDPOINT_URL":      "https://" + host,
+			"AWS_ACCOUNT_ID":        account.Status.AccountID,
+			"AWS_ACCESS_KEY_ID":     string(rookSecret.Data["AccessKey"]),
+			"AWS_SECRET_ACCESS_KEY": string(rookSecret.Data["SecretKey"]),
+		},
+	}
+
+	logger.Info("appending RGW account credentials for spoke", "spokeSecret", spokeSecretName, "endpoint", host)
+	return append(records, kubeObjectWithOpRecord{
+		kubeObject: spokeSecret,
+		clientOp:   pb.KubeClientOp_CREATE_OR_UPDATE,
+	}), nil
+}
+
+func (s *OCSProviderServer) getRGWCredentialsResourceVersion(
+	ctx context.Context,
+	consumer *ocsv1alpha1.StorageConsumer,
+) (string, error) {
+	logger := klog.FromContext(ctx).WithName("getRGWCredentialsResourceVersion").WithValues("consumer", consumer.Name)
+
+	consumerConfig, err := s.getConsumerConfig(ctx, consumer)
+	if err != nil {
+		return "", err
+	}
+	if consumerConfig.GetRGWAccountName() == "" {
+		return "", nil
+	}
+
+	rookSecret, err := s.getRGWRootUserCredentialsSecret(ctx, consumer, consumerConfig)
+	if err != nil {
+		return "", err
+	}
+	if rookSecret == nil {
+		return "", nil
+	}
+	logger.Info("resolved RGW credentials resource version", "resourceVersion", rookSecret.ResourceVersion)
+	return rookSecret.ResourceVersion, nil
 }
 
 func sanitizeKubeResource(obj client.Object, sanitizeFlags sanitizeFlags) {

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 
 	nbv1 "github.com/noobaa/noobaa-operator/v5/pkg/apis/noobaa/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
 	rookCephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
@@ -200,11 +202,11 @@ func TestAppendVolumeAttributesClassKubeResources(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		clusterObjs    []client.Object
-		consumerVACs   []ocsv1a1.VolumeAttributesClassesSpec
-		expectedCount  int
-		expectedNames  []string
+		name          string
+		clusterObjs   []client.Object
+		consumerVACs  []ocsv1a1.VolumeAttributesClassesSpec
+		expectedCount int
+		expectedNames []string
 	}{
 		{
 			name:          "no VACs in consumer spec",
@@ -469,12 +471,12 @@ func TestGetDesiredClientStateReady(t *testing.T) {
 			Namespace: testNamespace,
 		},
 		Data: map[string]string{
-			"rbd-rados-ns":                  "test-rados-ns",
-			"cephfs-subvolumegroup":         "test-svg",
+			"rbd-rados-ns":                   "test-rados-ns",
+			"cephfs-subvolumegroup":          "test-svg",
 			"cephfs-subvolumegroup-rados-ns": "test-svg-rados-ns",
-			"csiop-rbd-client-profile":      "rbd-profile",
-			"csi-rbd-provisioner-ceph-user": "rbd-provisioner-secret",
-			"csi-rbd-node-ceph-user":        "rbd-node-secret",
+			"csiop-rbd-client-profile":       "rbd-profile",
+			"csi-rbd-provisioner-ceph-user":  "rbd-provisioner-secret",
+			"csi-rbd-node-ceph-user":         "rbd-node-secret",
 		},
 	}
 
@@ -1245,4 +1247,389 @@ func TestAlertCacheConcurrentReads(t *testing.T) {
 			t.Errorf("read %d failed: %v", i, err)
 		}
 	}
+}
+
+func newRGWTestObjects() (
+	*ocsv1.StorageCluster,
+	*ocsv1a1.StorageConsumer,
+	*rookCephv1.CephObjectStoreAccount,
+	*corev1.ConfigMap,
+	*corev1.Secret,
+	*routev1.Route,
+) {
+	storageCluster := &ocsv1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ocs-storagecluster",
+			Namespace: testNamespace,
+			Annotations: map[string]string{
+				util.EnableAdvancedRGWFeaturesAnnotation: "true",
+			},
+		},
+	}
+
+	consumerConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-consumer-config",
+			Namespace: testNamespace,
+		},
+		Data: map[string]string{
+			"rgw-account-name":            "test-rgw-account",
+			"rgw-credentials-secret-name": "spoke-account-iam-credentials",
+		},
+	}
+
+	consumer := &ocsv1a1.StorageConsumer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-consumer",
+			Namespace: testNamespace,
+			UID:       "consumer-uid-123",
+			Annotations: map[string]string{
+				util.EnableRGWAccountAnnotation: "true",
+			},
+		},
+		Status: ocsv1a1.StorageConsumerStatus{
+			Client: &ocsv1a1.ClientStatus{
+				ID:                "client-id-abc",
+				OperatorNamespace: "spoke-ns",
+			},
+			ResourceNameMappingConfigMap: corev1.LocalObjectReference{
+				Name: consumerConfigMap.Name,
+			},
+		},
+	}
+
+	account := &rookCephv1.CephObjectStoreAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-rgw-account",
+			Namespace: testNamespace,
+		},
+		Status: &rookCephv1.ObjectStoreAccountStatus{
+			Phase:                 "Ready",
+			AccountID:             "RGW12345678901234567",
+			RootAccountSecretName: "rook-ceph-root-user-test-secret",
+		},
+	}
+
+	rookSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "rook-ceph-root-user-test-secret",
+			Namespace:       testNamespace,
+			ResourceVersion: "12345",
+		},
+		Data: map[string][]byte{
+			"AccessKey": []byte("TESTACCESSKEY123"),
+			"SecretKey": []byte("TESTSecretKey456"),
+		},
+	}
+
+	rgwRoute := &routev1.Route{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      util.GenerateNameForCephObjectStoreSecureRoute(storageCluster),
+			Namespace: testNamespace,
+		},
+		Status: routev1.RouteStatus{
+			Ingress: []routev1.RouteIngress{
+				{
+					Host: "rgw.apps.example.com",
+					Conditions: []routev1.RouteIngressCondition{
+						{
+							Type:   routev1.RouteAdmitted,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return storageCluster, consumer, account, consumerConfigMap, rookSecret, rgwRoute
+}
+
+func TestGetRGWRootUserCredentialsSecret(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		objs         func() []client.Object
+		expectSecret bool
+		expectError  bool
+	}{
+		{
+			name:        "Account not found",
+			expectError: true,
+			objs: func() []client.Object {
+				_, consumer, _, consumerCM, rookSecret, _ := newRGWTestObjects()
+				return []client.Object{consumer, consumerCM, rookSecret}
+			},
+		},
+		{
+			name: "Account not Ready",
+			objs: func() []client.Object {
+				_, consumer, account, consumerCM, rookSecret, _ := newRGWTestObjects()
+				account.Status.Phase = "Pending"
+				return []client.Object{consumer, consumerCM, account, rookSecret}
+			},
+		},
+		{
+			name: "Account missing rootAccountSecretName",
+			objs: func() []client.Object {
+				_, consumer, account, consumerCM, rookSecret, _ := newRGWTestObjects()
+				account.Status.RootAccountSecretName = ""
+				return []client.Object{consumer, consumerCM, account, rookSecret}
+			},
+		},
+		{
+			name:        "Root user Secret not found",
+			expectError: true,
+			objs: func() []client.Object {
+				_, consumer, account, consumerCM, _, _ := newRGWTestObjects()
+				return []client.Object{consumer, consumerCM, account}
+			},
+		},
+		{
+			name:         "success",
+			expectSecret: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, consumer, account, consumerCM, rookSecret, _ := newRGWTestObjects()
+
+			consumerConfig := util.WrapStorageConsumerResourceMap(consumerCM.Data)
+
+			var objs []client.Object
+			if tt.objs != nil {
+				objs = tt.objs()
+			} else {
+				objs = []client.Object{consumer, consumerCM, account, rookSecret}
+			}
+
+			srv := newNotifyTestServer(t, objs...)
+			secret, err := srv.getRGWRootUserCredentialsSecret(ctx, consumer, consumerConfig)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, secret)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tt.expectSecret {
+				assert.NotNil(t, secret)
+				assert.Equal(t, "TESTACCESSKEY123", string(secret.Data["AccessKey"]))
+				assert.Equal(t, "12345", secret.ResourceVersion)
+			}
+		})
+	}
+}
+
+func TestAppendRGWAccountCredentialsKubeResources(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		objs        func() []client.Object
+		expectAdded bool
+		expectError bool
+	}{
+		{
+			name:        "Account CR not found",
+			expectError: true,
+			objs: func() []client.Object {
+				_, consumer, _, consumerCM, rookSecret, rgwRoute := newRGWTestObjects()
+				return []client.Object{consumer, consumerCM, rookSecret, rgwRoute}
+			},
+		},
+		{
+			name: "Account CR not Ready",
+			objs: func() []client.Object {
+				_, consumer, account, consumerCM, rookSecret, rgwRoute := newRGWTestObjects()
+				account.Status.Phase = "Pending"
+				return []client.Object{consumer, account, consumerCM, rookSecret, rgwRoute}
+			},
+		},
+		{
+			name:        "Route not found",
+			expectError: true,
+			objs: func() []client.Object {
+				_, consumer, account, consumerCM, rookSecret, _ := newRGWTestObjects()
+				return []client.Object{consumer, account, consumerCM, rookSecret}
+			},
+		},
+		{
+			name:        "Route has no admitted host",
+			expectError: true,
+			objs: func() []client.Object {
+				_, consumer, account, consumerCM, rookSecret, rgwRoute := newRGWTestObjects()
+				rgwRoute.Status.Ingress = nil
+				return []client.Object{consumer, account, consumerCM, rookSecret, rgwRoute}
+			},
+		},
+		{
+			name:        "success",
+			expectAdded: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sc, consumer, account, consumerCM, rookSecret, rgwRoute := newRGWTestObjects()
+
+			var objs []client.Object
+			if tt.objs != nil {
+				objs = tt.objs()
+			} else {
+				objs = []client.Object{consumer, account, consumerCM, rookSecret, rgwRoute}
+			}
+
+			srv := newNotifyTestServer(t, objs...)
+			consumerConfig := util.WrapStorageConsumerResourceMap(consumerCM.Data)
+
+			records, err := srv.appendRGWAccountCredentialsKubeResources(ctx, nil, consumer, consumerConfig, sc)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, records)
+				return
+			}
+			assert.NoError(t, err)
+
+			if !tt.expectAdded {
+				assert.Empty(t, records)
+				return
+			}
+
+			assert.Len(t, records, 1)
+			assert.Equal(t, pb.KubeClientOp_CREATE_OR_UPDATE, records[0].clientOp)
+
+			secret, ok := records[0].kubeObject.(*corev1.Secret)
+			assert.True(t, ok)
+			assert.Equal(t, "spoke-account-iam-credentials", secret.Name)
+			assert.Equal(t, "spoke-ns", secret.Namespace)
+			assert.Equal(t, "client-id-abc", secret.Labels[util.StorageClientLabelKey])
+			assert.Equal(t, "https://rgw.apps.example.com", secret.StringData["AWS_ENDPOINT_URL"])
+			assert.Equal(t, "RGW12345678901234567", secret.StringData["AWS_ACCOUNT_ID"])
+			assert.Equal(t, "TESTACCESSKEY123", secret.StringData["AWS_ACCESS_KEY_ID"])
+			assert.Equal(t, "TESTSecretKey456", secret.StringData["AWS_SECRET_ACCESS_KEY"])
+		})
+	}
+}
+
+func TestGetConsumerConfig(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty ConfigMap name", func(t *testing.T) {
+		consumer := &ocsv1a1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace},
+		}
+		srv := newTestProviderServer(t, consumer)
+		cfg, err := srv.getConsumerConfig(ctx, consumer)
+		assert.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("ConfigMap not found", func(t *testing.T) {
+		consumer := &ocsv1a1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace},
+			Status: ocsv1a1.StorageConsumerStatus{
+				ResourceNameMappingConfigMap: corev1.LocalObjectReference{Name: "missing-cm"},
+			},
+		}
+		srv := newTestProviderServer(t, consumer)
+		cfg, err := srv.getConsumerConfig(ctx, consumer)
+		assert.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err))
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("ConfigMap with nil data", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "empty-cm", Namespace: testNamespace},
+		}
+		consumer := &ocsv1a1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace},
+			Status: ocsv1a1.StorageConsumerStatus{
+				ResourceNameMappingConfigMap: corev1.LocalObjectReference{Name: cm.Name},
+			},
+		}
+		srv := newTestProviderServer(t, consumer, cm)
+		cfg, err := srv.getConsumerConfig(ctx, consumer)
+		assert.Error(t, err)
+		assert.Nil(t, cfg)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		_, consumer, _, consumerCM, _, _ := newRGWTestObjects()
+		srv := newTestProviderServer(t, consumer, consumerCM)
+		cfg, err := srv.getConsumerConfig(ctx, consumer)
+		assert.NoError(t, err)
+		assert.NotNil(t, cfg)
+		assert.Equal(t, "test-rgw-account", cfg.GetRGWAccountName())
+	})
+}
+
+func TestGetRGWCredentialsResourceVersion(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		_, consumer, account, consumerCM, rookSecret, _ := newRGWTestObjects()
+		srv := newNotifyTestServer(t, consumer, consumerCM, account, rookSecret)
+		version, err := srv.getRGWCredentialsResourceVersion(ctx, consumer)
+		assert.NoError(t, err)
+		assert.Equal(t, "12345", version)
+	})
+
+	t.Run("no ConfigMap name returns error", func(t *testing.T) {
+		consumer := &ocsv1a1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace},
+		}
+		srv := newNotifyTestServer(t, consumer)
+		version, err := srv.getRGWCredentialsResourceVersion(ctx, consumer)
+		assert.Error(t, err)
+		assert.Empty(t, version)
+	})
+
+	t.Run("ConfigMap not found returns error", func(t *testing.T) {
+		consumer := &ocsv1a1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace},
+			Status: ocsv1a1.StorageConsumerStatus{
+				ResourceNameMappingConfigMap: corev1.LocalObjectReference{Name: "missing-cm"},
+			},
+		}
+		srv := newNotifyTestServer(t, consumer)
+		version, err := srv.getRGWCredentialsResourceVersion(ctx, consumer)
+		assert.Error(t, err)
+		assert.Empty(t, version)
+	})
+
+	t.Run("no RGW account name returns empty", func(t *testing.T) {
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: "no-rgw-cm", Namespace: testNamespace},
+			Data:       map[string]string{"some-key": "some-value"},
+		}
+		consumer := &ocsv1a1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: testNamespace},
+			Status: ocsv1a1.StorageConsumerStatus{
+				ResourceNameMappingConfigMap: corev1.LocalObjectReference{Name: cm.Name},
+			},
+		}
+		srv := newNotifyTestServer(t, consumer, cm)
+		version, err := srv.getRGWCredentialsResourceVersion(ctx, consumer)
+		assert.NoError(t, err)
+		assert.Empty(t, version)
+	})
+}
+
+func TestIsRGWAccountEnabled(t *testing.T) {
+	sc, consumer, _, _, _, _ := newRGWTestObjects()
+
+	assert.True(t, isRGWAccountEnabled(consumer, sc))
+
+	scNoAnnotation := sc.DeepCopy()
+	scNoAnnotation.Annotations = nil
+	assert.False(t, isRGWAccountEnabled(consumer, scNoAnnotation))
+
+	consumerNoAnnotation := consumer.DeepCopy()
+	consumerNoAnnotation.Annotations = nil
+	assert.False(t, isRGWAccountEnabled(consumerNoAnnotation, sc))
 }


### PR DESCRIPTION
PR adds RGW Acount support for per-consumer object storage isolation:

  1. Creates RGW Account per StorageConsumer when both enable-advanced-rgw-features (on StorageCluster) and enable-rgw-account (on consumer) annotations are set
  2. Advertises RGW credentials of the account Root user via gRPC  which incldues `spoke-account-iam-credentials` Secret containing `AWS_ENDPOINT_URL`, `AWS_ACCOUNT_ID`, `AWS_ACCESS_KEY_ID`
  and `AWS_SECRET_ACCESS_KEY` for the spoke to consume. 
  3. Adds necessary RBACs for managing cephObjectStoreAccount resource.

This covers following stories. 
https://redhat.atlassian.net/browse/RHSTOR-8848
https://redhat.atlassian.net/browse/RHSTOR-8850 
https://redhat.atlassian.net/browse/RHSTOR-9104



Testing: 

Annotated `consumer-bm3-c2` consumer. 
```
oc get storageconsumer                                                                                                                                                                                          ─╯
NAME              AGE
consumer-bm3-c2   12h
internal          19h
```

Account got created. 
```
oc get cephobjectstoreaccount                                                                                                                                                                                   ─╯
NAME              PHASE   AGE
consumer-bm3-c2   Ready   2m37s
```

Root user got created. 

Root user credentials got stored in provider cluster 

Credentials got advertised over GRPC call. 

A new secret with the credentials go created in the spoke cluster. 

```
export KUBECONFIG=/Users/santoshpillai/dev/scripts/ocp/spoke-kc.yaml && oc get secret spoke-account-iam-credentials -n openshift-storage                                                                        ─╯
NAME                            TYPE     DATA   AGE
spoke-account-iam-credentials   Opaque   4      4m37s
```

```
export KUBECONFIG=/Users/santoshpillai/dev/scripts/ocp/spoke-kc.yaml && oc get secret spoke-account-iam-credentials -n openshift-storage -o yaml                                                                ─╯
apiVersion: v1
data:
  AWS_ACCESS_KEY_ID: VlBOMElUSEtTRUIwOTIzSFRUTlA=
  AWS_ACCOUNT_ID: UkdXMjk3MTE1NDcxNjkzMTU1ODk=
  AWS_ENDPOINT_URL: aHR0cHM6Ly9vY3Mtc3RvcmFnZWNsdXN0ZXItY2VwaG9iamVjdHN0b3JlLXNlY3VyZS1vcGVuc2hpZnQtc3RvcmFnZS5hcHBzLmRuZC1qaWpveS1ibTMucWUucmgtb2NzLmNvbQ==
  AWS_SECRET_ACCESS_KEY: NG9YamJoM1BVWjkyczAxM3JJOVZBQUJzd1dSQUhZS1dhT3JlcVA2SQ==
```



Offboarding test: 
- Deleted StorageClient on spoke which triggered the offboarding and cleared the consumer's client status. 
- Spoke credentials secret (`spoke-account-iam-credentials`) was garbage collected via StorageClient owner reference.
- Then deleted StorageConsumer on hub with `force-deletion` annotation which cascaded deletion to the CephObjectStoreAccount CR. 
- Rook's account controller cleaned up the RGW account and root user from the Ceph
  cluster before removing the finalizer. 
- The consumer ConfigMap was also garbage collected.

Note: offboard testing was done with RGW Account with no data. Rook does not have the cleanup logic for accounts with data, yet. 
