### PR TITLE
ec: if ec is enabled at day-2 for block pool the provider panics

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -202,7 +202,7 @@ func If[T any](cond bool, trueVal, falseVal T) T {
 func IsDefaultPoolErasureCodingEnabled(cephBlockpool ocsv1.ManageCephBlockPools) bool {
 	// if ec is enabled set the pool names differently
 	// Change the pool name for the default storageclass only if ec spec was chosen for default day-1 cephBlockpool
-	return cephBlockpool.ErasureCodedMetadataPool != "" && cephBlockpool.PoolSpec.IsErasureCoded()
+	return cephBlockpool.ErasureCodedMetadataPool != "" && cephBlockpool.PoolSpec != nil && cephBlockpool.PoolSpec.IsErasureCoded()
 }
 
 func IsForbiddenError(err error) bool {


### PR DESCRIPTION
the panic is because, at day-2 we set the meta-data replica pool, so the check move to see if the blockpool at day-1 is ec and as for default replica-3 install the pool spec is not set, we still try to access the pool spec pointer which result in panic


