### PR TITLE
Fix dependabot refresh workflow Go version mismatch

### DIFF
--- a/.github/workflows/dependabot-refresh.yaml
+++ b/.github/workflows/dependabot-refresh.yaml
@@ -20,7 +20,8 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: "1.26"
+          cache: false
 
       - name: Refresh deps, vendor, CRDs, and CSV
         run: |


### PR DESCRIPTION
## Summary
- Pin `setup-go` to `1.26` in the Dependabot refresh workflow instead of reading the root `go.mod` toolchain version.
- Prevents `make deps-update` from failing when Dependabot bumps submodule `go.mod` files to a newer Go patch (e.g. `1.26.3`) while the root module still declares `go 1.26.0`.
- Aligns with the Go version setup used in `ocs-operator-ci.yaml`, so the refresh job can sync root `go.mod`, `go.work`, and `vendor/` after Dependabot PRs.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger the Dependabot refresh workflow on https://github.com/red-hat-storage/ocs-operator/pull/3971 (close/reopen or push an empty commit)
- [ ] Confirm the refresh job completes and commits synced dependency files to the Dependabot branch
- [ ] Verify CI passes on the updated Dependabot PR


Made with [Cursor](https://cursor.com)