### PR TITLE
Configure Dependabot for all Go modules in the workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "gomod"
-    directory: "/"
+    directories:
+      - "/"
+      - "/api"
+      - "/metrics"
+      - "/services/provider/api"
     schedule:
       interval: daily
     open-pull-requests-limit: 10
@@ -15,4 +19,4 @@ updates:
         applies-to: security-updates
         group-by: dependency-name
         patterns:
-          - "*"    
+          - "*"

--- a/.github/workflows/dependabot-refresh.yaml
+++ b/.github/workflows/dependabot-refresh.yaml
@@ -11,6 +11,8 @@ jobs:
   refresh:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    env:
+      GOTOOLCHAIN: auto
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Restore Dependabot `directories` for `/`, `/api`, `/metrics`, and `/services/provider/api` so version and security updates are grouped across the full `go.work` workspace.
- Set `GOTOOLCHAIN=auto` in the Dependabot refresh workflow so `make deps-update` can use a consistent Go toolchain when submodule `go.mod` files require a newer patch than the root module.