### PR TITLE
Scope Dependabot refresh git add to known paths

### DIFF
--- a/.github/workflows/dependabot-refresh.yaml
+++ b/.github/workflows/dependabot-refresh.yaml
@@ -36,7 +36,15 @@ jobs:
           git config user.name "${GIT_AUTHOR_NAME}"
           git config user.email "${GIT_AUTHOR_EMAIL}"
 
-          git add .
+          paths=(
+            go.mod go.sum go.work go.work.sum
+            api/go.mod api/go.sum
+            metrics/go.mod metrics/go.sum
+            services/provider/api/go.mod services/provider/api/go.sum
+            vendor/
+            api config/crd/bases deploy/csv-templates deploy/ocs-operator
+          )
+          git add "${paths[@]}"
 
           if git diff --staged --quiet; then
             echo "Nothing to commit"


### PR DESCRIPTION
## Summary
- Replace `git add .` in the Dependabot refresh workflow with explicit paths for dependency files (`go.mod`, `go.sum`, `go.work`, submodule modules, `vendor/`) and generated assets (`api`, `config/crd/bases`, `deploy/csv-templates`, `deploy/ocs-operator`).
- Keeps the existing single-step refresh and commit flow.

## Test plan
- [ ] Merge https://github.com/red-hat-storage/ocs-operator/pull/3995 first so the refresh workflow uses a compatible Go toolchain
- [ ] Re-trigger the Dependabot refresh workflow on a Dependabot PR
- [ ] Confirm only expected dependency and generated files are committed


Made with [Cursor](https://cursor.com)