### PR TITLE
Add concurrency control to Dependabot refresh workflow

### DIFF
--- a/.github/workflows/dependabot-refresh.yaml
+++ b/.github/workflows/dependabot-refresh.yaml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+concurrency:
+  group: dependabot-refresh-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
 


### PR DESCRIPTION
## Summary
- Add a workflow-level `concurrency` group keyed by PR number for the Dependabot refresh job.
- Cancel in-progress refresh runs when the same Dependabot PR is updated again, preventing overlapping `git push` operations from force-pushes or rapid synchronize events.