### PR TITLE
ci: drop commitlint body-max-line-length rule

### DIFF
--- a/.github/workflows/conf/commitlintrc.json
+++ b/.github/workflows/conf/commitlintrc.json
@@ -14,10 +14,9 @@
             2,
             "always"
         ],
-        "body-max-line-length": [
+        "footer-leading-blank": [
             2,
-            "always",
-            72
+            "always"
         ]
     }
 }


### PR DESCRIPTION
## Summary
- Remove the `body-max-line-length` (72 char) rule from commitlint config
- Dependabot commit bodies include long URLs and dependency metadata that routinely exceed that limit
- Header length limits are unchanged
- Enforce a blank line before footer in commit