### PR TITLE
[release-4.20] Bump go (stdlib) from 1.24.5 to 1.24.8

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/api/v4
 
 go 1.24.3
 
-toolchain go1.24.5
+toolchain go1.24.8
 
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.0.0-20250728100218-5f4046180bd7

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/v4
 
 go 1.24.3
 
-toolchain go1.24.5
+toolchain go1.24.8
 
 replace github.com/red-hat-storage/ocs-operator/api/v4 => ./api
 

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/metrics/v4
 
 go 1.24.3
 
-toolchain go1.24.5
+toolchain go1.24.8
 
 replace github.com/red-hat-storage/ocs-operator/api/v4 => ../api
 

--- a/services/provider/api/go.mod
+++ b/services/provider/api/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/services/provider/api/v4
 
 go 1.24.3
 
-toolchain go1.24.5
+toolchain go1.24.8
 
 require (
 	google.golang.org/grpc v1.74.2


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.24.5` → `1.24.8` (in `services/provider/api/go.mod`)
- **go (stdlib)**: `1.24.5` → `1.24.8` (in `api/go.mod`)
- **go (stdlib)**: `1.24.5` → `1.24.8` (in `go.mod`)
- **go (stdlib)**: `1.24.5` → `1.24.8` (in `metrics/go.mod`)
