### PR TITLE
DFBUGS-7326:[release-4.22] Mount keyring and config override as files in the toolbox deployment

### DIFF
--- a/internal/controller/storagecluster/cephobjectstores.go
+++ b/internal/controller/storagecluster/cephobjectstores.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	enableRGWAutoscaleAnnotation = "ocs.openshift.io/enable-rgw-autoscale"
-	stsKeyLen                    = 16 // 16 alphanumeric characters for STS key
+	stsKeyLen                    = 32 // 32 hex characters for STS key
 )
 
 type ocsCephObjectStores struct {
@@ -391,8 +391,8 @@ func getRGWSecurePort(sc *ocsv1.StorageCluster) int32 {
 // RGW requires the STS key to be alphanumeric (letters and numbers only)
 // Returns a 16-character alphanumeric string suitable for use as rgw_sts_key
 func generateRandomSTSKey() (string, error) {
-	// Character set: alphanumeric only (a-z, A-Z, 0-9)
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	// Character set: hexadecimal [a-f0-9]
+	const charset = "abcdef0123456789"
 	const charsetLen = len(charset)
 
 	// Generate random alphanumeric string
@@ -460,7 +460,19 @@ func (r *StorageClusterReconciler) setSTSOptions(obj *cephv1.CephObjectStore, sc
 			return fmt.Errorf("failed to get STS secret: %w", err)
 		}
 	} else {
-		r.Log.Info("STS secret already exists for CephObjectStore.", "Secret", klog.KRef(secret.Namespace, secret.Name), "CephObjectStore", klog.KRef(obj.Namespace, obj.Name))
+		existingKey, ok := existingSecret.Data[secretKeyName]
+		if !ok || len(existingKey) != len(stsKey) {
+			r.Log.Info("Rotating STS secret for CephObjectStore.",
+				"Secret", klog.KRef(secret.Namespace, secret.Name), "CephObjectStore", klog.KRef(obj.Namespace, obj.Name),
+				"CurrentKeyLength", len(existingKey), "NewKeyLength", len(stsKey),
+			)
+			existingSecret.Data[secretKeyName] = []byte(stsKey)
+			if err := r.Update(context.TODO(), existingSecret); err != nil {
+				return fmt.Errorf("failed to update STS secret with rotated key: %w", err)
+			}
+		} else {
+			r.Log.Info("STS secret already exists for CephObjectStore.", "Secret", klog.KRef(secret.Namespace, secret.Name), "CephObjectStore", klog.KRef(obj.Namespace, obj.Name))
+		}
 	}
 
 	// Set rgw_sts_key in RgwConfigFromSecret with SecretKeySelector

--- a/internal/controller/storagecluster/cephobjectstores_test.go
+++ b/internal/controller/storagecluster/cephobjectstores_test.go
@@ -12,6 +12,7 @@ import (
 	ocstlsv1 "github.com/red-hat-storage/ocs-tls-profiles/api/v1"
 	cephv1 "github.com/rook/rook/pkg/apis/ceph.rook.io/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -231,6 +232,17 @@ func TestGetCephObjectStoreGatewayInstances(t *testing.T) {
 	}
 }
 
+func Test_generateRandomSTSKey(t *testing.T) {
+	allowedChars := "abcdef0123456789"
+
+	for range 100 { // generate 100 random keys, and ensure they all meet key requirements
+		got, err := generateRandomSTSKey()
+		assert.NoError(t, err)
+		assert.Len(t, got, 32)
+		assert.Subset(t, []byte(allowedChars), []byte(got))
+	}
+}
+
 func TestSetSTSOptions(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -292,6 +304,7 @@ func TestSetSTSOptions(t *testing.T) {
 				}
 
 				// Verify secret was created
+				initialKey := []byte{}
 				if tc.expectSecret {
 					secretName := "sts-key-test-objectstore"
 					secret := &corev1.Secret{}
@@ -307,6 +320,7 @@ func TestSetSTSOptions(t *testing.T) {
 					stsKey, exists := secret.Data["rgw_sts_key"]
 					assert.True(t, exists)
 					assert.NotEmpty(t, stsKey)
+					initialKey = stsKey
 
 					// Verify the key is valid base64
 					_, err = base64.StdEncoding.DecodeString(string(stsKey))
@@ -325,9 +339,94 @@ func TestSetSTSOptions(t *testing.T) {
 					assert.Equal(t, "sts-key-test-objectstore", secretSelector.Name)
 					assert.Equal(t, "rgw_sts_key", secretSelector.Key)
 				}
+
+				if tc.expectSecret {
+					// Call setSTSOptions again, and ensure the key doesn't change on re-reconcile
+					err = reconciler.setSTSOptions(cos, sc)
+					require.NoError(t, err)
+
+					secretName := "sts-key-test-objectstore"
+					secret := &corev1.Secret{}
+					err := reconciler.Get(context.TODO(), types.NamespacedName{
+						Name:      secretName,
+						Namespace: sc.Namespace,
+					}, secret)
+					require.NoError(t, err)
+					require.NotNil(t, secret)
+
+					currentKey := secret.Data["rgw_sts_key"]
+					assert.Equal(t, initialKey, currentKey)
+				}
 			}
 		})
 	}
+
+	t.Run("rotate old 16-char key to new format", func(t *testing.T) {
+		// Setup test environment
+		var objects []runtime.Object
+		sc := &api.StorageCluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-storagecluster",
+				Namespace: "test-namespace",
+			},
+			Spec: api.StorageClusterSpec{
+				ManagedResources: api.ManagedResourcesSpec{
+					CephObjectStores: api.ManageCephObjectStores{
+						EnableSTS: true,
+					},
+				},
+			},
+		}
+		objects = append(objects, sc)
+
+		reconciler := createFakeStorageClusterReconciler(t, objects...)
+
+		// Create a CephObjectStore instance
+		cos := &cephv1.CephObjectStore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-objectstore",
+				Namespace: sc.Namespace,
+			},
+			Spec: cephv1.ObjectStoreSpec{
+				Gateway: cephv1.GatewaySpec{},
+			},
+		}
+
+		// create an STS key secret with latest requirements
+		err := reconciler.setSTSOptions(cos, sc)
+		require.NoError(t, err)
+
+		secret := &corev1.Secret{}
+		err = reconciler.Get(context.TODO(), types.NamespacedName{
+			Name:      "sts-key-test-objectstore",
+			Namespace: sc.Namespace,
+		}, secret)
+		require.NoError(t, err)
+		require.NotNil(t, secret)
+
+		// manually make changes to the secret to give it an older format
+		legacyKey := []byte("1234567890ZYXWVU") // 16 chars, non-hex, needs rotated
+		secret.Data["rgw_sts_key"] = legacyKey
+		err = reconciler.Update(context.TODO(), secret)
+		require.NoError(t, err)
+
+		// run again, which should rotate
+		err = reconciler.setSTSOptions(cos, sc)
+		require.NoError(t, err)
+
+		err = reconciler.Get(context.TODO(), types.NamespacedName{
+			Name:      "sts-key-test-objectstore",
+			Namespace: sc.Namespace,
+		}, secret)
+		require.NoError(t, err)
+		require.NotNil(t, secret)
+
+		rotatedKey := secret.Data["rgw_sts_key"]
+		assert.NotEqual(t, legacyKey, rotatedKey)
+		assert.Len(t, rotatedKey, 32)
+		// Test_generateRandomSTSKey() ensures the generated key charset is expected. We just need
+		// to ensure the key is rotated in this check, and length check ensures it's integrated.
+	})
 }
 
 func TestSetSTSOptionsIdempotency(t *testing.T) {

--- a/internal/controller/storagecluster/cephtoolbox.go
+++ b/internal/controller/storagecluster/cephtoolbox.go
@@ -140,15 +140,6 @@ func newToolsDeployment(namespace string, tolerations []corev1.Toleration, nodeA
 										},
 									},
 								},
-								{
-									Name: "ROOK_CEPH_SECRET",
-									ValueFrom: &corev1.EnvVarSource{
-										SecretKeyRef: &corev1.SecretKeySelector{
-											LocalObjectReference: corev1.LocalObjectReference{Name: "rook-ceph-mon"},
-											Key:                  "ceph-secret",
-										},
-									},
-								},
 							},
 							SecurityContext: &corev1.SecurityContext{
 								RunAsNonRoot: ptr.To(true),
@@ -158,6 +149,7 @@ func newToolsDeployment(namespace string, tolerations []corev1.Toleration, nodeA
 							VolumeMounts: []corev1.VolumeMount{
 								{Name: "ceph-config", MountPath: "/etc/ceph"},
 								{Name: "mon-endpoint-volume", MountPath: "/etc/rook"},
+								{Name: "ceph-admin-secret", MountPath: "/var/lib/rook-ceph-mon", ReadOnly: true},
 							},
 						},
 					},
@@ -174,6 +166,18 @@ func newToolsDeployment(namespace string, tolerations []corev1.Toleration, nodeA
 								},
 							},
 						},
+						},
+						{
+							Name: "ceph-admin-secret",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: "rook-ceph-mon",
+									Optional:   ptr.To(false),
+									Items: []corev1.KeyToPath{
+										{Key: "ceph-secret", Path: "secret.keyring"},
+									},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
The OCS operator provides the keyring via ROOK_CEPH_SECRET env var instead of file mount. This PR mounts the keyring secret and config overeide as files and drops  the env var, so that toolbox can detect the change in the keyring.

This also merges Blaine's PR about STS keys. More details here - https://github.com/red-hat-storage/ocs-operator/pull/4038 