### PR TITLE
Bump Operator SDK from v1.34.1 to v1.37.0

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ocs-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.34.1
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.37.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v4
 

--- a/config/manifests/ocs-operator/bases/ocs-operator.clusterserviceversion.yaml
+++ b/config/manifests/ocs-operator/bases/ocs-operator.clusterserviceversion.yaml
@@ -5,8 +5,8 @@ metadata:
     alm-examples: '[]'
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
-    operators.operatorframework.io/builder: operator-sdk-v1.30.0
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    operators.operatorframework.io/builder: operator-sdk-v1.37.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/red-hat-storage/ocs-operator
     support: Red Hat
   name: ocs-operator.v0.0.0

--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -79,10 +79,10 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2026-06-23T06:51:14Z"
+    createdAt: "2026-07-10T07:15:34Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
-    operators.operatorframework.io/builder: operator-sdk-v1.34.1
+    operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/red-hat-storage/ocs-operator
     support: Red Hat

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,7 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2026-06-25T07:58:21Z"
+    createdAt: "2026-07-10T07:15:34Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",
@@ -93,7 +93,7 @@ metadata:
       \   }\n\t"
     operatorframework.io/suggested-namespace: openshift-storage
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.34.1
+    operators.operatorframework.io/builder: operator-sdk-v1.37.0
     operators.operatorframework.io/internal-objects: '["ocsinitializations.ocs.openshift.io","storageautoscalers.ocs.openshift.io","storageclusterpeers.ocs.openshift.io","storageconsumers.ocs.openshift.io"]'
     operators.operatorframework.io/operator-type: non-standalone
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/deploy/ocs-operator/metadata/annotations.yaml
+++ b/deploy/ocs-operator/metadata/annotations.yaml
@@ -5,6 +5,6 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: ocs-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.34.1
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.37.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -68,7 +68,7 @@ OCS_MUST_GATHER_DIR="${OCS_MUST_GATHER_DIR:-ocs-must-gather}"
 
 # Tools & binaries versions and locations
 LOCALBIN="$(pwd)/bin"
-OPERATOR_SDK_VERSION="v1.34.1"
+OPERATOR_SDK_VERSION="v1.37.0"
 OPERATOR_SDK="${LOCALBIN}/operator-sdk-${OPERATOR_SDK_VERSION}"
 GINKGO="${LOCALBIN}/ginkgo"
 GOLANGCI_LINT_VERSION="v2.12.2"


### PR DESCRIPTION
Upgrade the operator-sdk CLI used for bundle generation and validation. No Go-operator scaffold migrations are required through v1.37.0 (v1.35 and v1.37 affect Helm/Quarkus only; v1.36 dependency bumps do not apply since this project already uses newer Kubernetes and controller-runtime versions). Regenerate the operator bundle with the updated SDK.