### PR TITLE
[release-4.22] Bump go (stdlib) from 1.25.9 to 1.25.10

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/api/v4
 
 go 1.25.8
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.21.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/v4
 
 go 1.25.8
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 replace github.com/red-hat-storage/ocs-operator/api/v4 => ./api
 

--- a/metrics/go.mod
+++ b/metrics/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/metrics/v4
 
 go 1.25.8
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 replace github.com/red-hat-storage/ocs-operator/api/v4 => ../api
 

--- a/services/provider/api/go.mod
+++ b/services/provider/api/go.mod
@@ -2,7 +2,7 @@ module github.com/red-hat-storage/ocs-operator/services/provider/api/v4
 
 go 1.25.8
 
-toolchain go1.25.9
+toolchain go1.25.10
 
 require (
 	github.com/noobaa/noobaa-operator/v5 v5.21.0


### PR DESCRIPTION
### Changes
- **go (stdlib)**: `1.25.9` → `1.25.10` (in `metrics/go.mod`)
- **go (stdlib)**: `1.25.9` → `1.25.10` (in `services/provider/api/go.mod`)
- **go (stdlib)**: `1.25.9` → `1.25.10` (in `api/go.mod`)
- **go (stdlib)**: `1.25.9` → `1.25.10` (in `go.mod`)
