### PR TITLE
fix: VolumeSnapshotClass ensureDeleted using wrong name generator

### DIFF
--- a/internal/controller/storagecluster/volumesnapshotterclasses.go
+++ b/internal/controller/storagecluster/volumesnapshotterclasses.go
@@ -177,8 +177,8 @@ func (obj *ocsSnapshotClass) ensureCreated(r *StorageClusterReconciler, instance
 func (obj *ocsSnapshotClass) ensureDeleted(r *StorageClusterReconciler, instance *ocsv1.StorageCluster) (reconcile.Result, error) {
 
 	names := []string{
-		util.GenerateNameForGroupSnapshotClass(instance, util.RbdGroupSnapshotter),
-		util.GenerateNameForGroupSnapshotClass(instance, util.CephfsGroupSnapshotter),
+		util.GenerateNameForSnapshotClass(instance.Name, util.RbdSnapshotter),
+		util.GenerateNameForSnapshotClass(instance.Name, util.CephfsSnapshotter),
 	}
 	for _, name := range names {
 		vsc := &snapapi.VolumeSnapshotClass{}


### PR DESCRIPTION
### Summary

The ensureDeleted method for ocsSnapshotClass was using GenerateNameForGroupSnapshotClass with GroupSnapshotter types instead of GenerateNameForSnapshotClass with the standard Snapshotter types.

As a result, the uninstall flow attempted to delete GroupSnapshotClass resources instead of the corresponding VolumeSnapshotClass resources. Since the targeted GroupSnapshotClass objects did not exist, the resulting NotFound errors were silently ignored, leaving the VolumeSnapshotClass resources undeleted during uninstall.

This PR fixes the issue by using the correct naming function and snapshotter type, ensuring that VolumeSnapshotClass resources are properly cleaned up during uninstallation.

This needs to be backported @rewantsoni @leelavg