### PR TITLE
controllers: remove watch for VGSC CRD

### DIFF
--- a/internal/controller/storagecluster/reconcile.go
+++ b/internal/controller/storagecluster/reconcile.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/blang/semver/v4"
 	"github.com/go-logr/logr"
-	groupsnapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
+	// groupsnapapi "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumegroupsnapshot/v1beta1"
 	configv1 "github.com/openshift/api/config/v1"
 	conditionsv1 "github.com/openshift/custom-resource-status/conditions/v1"
 	"github.com/operator-framework/operator-lib/conditions"
@@ -296,9 +296,9 @@ func (r *StorageClusterReconciler) validateStorageClusterSpec(instance *ocsv1.St
 
 func (r *StorageClusterReconciler) reconcileDynamicWatches() error {
 
-	if err := r.reconcileCrdWatches(&groupsnapapi.VolumeGroupSnapshotClass{}, VolumeGroupSnapshotClassCrdName); err != nil {
-		return err
-	}
+	// if err := r.reconcileCrdWatches(&groupsnapapi.VolumeGroupSnapshotClass{}, VolumeGroupSnapshotClassCrdName); err != nil {
+	// 	return err
+	// }
 
 	if err := r.reconcileCrdWatches(&odfgsapiv1b1.VolumeGroupSnapshotClass{}, OdfVolumeGroupSnapshotClassCrdName); err != nil {
 		return err


### PR DESCRIPTION
In 4.23, the volumegroupsnapshotclass api is available as v1. However, the watch in ocs-operator is still configured for `v1beta1` api, resulting in error logs in the ocs-operator.

Fixes: https://redhat.atlassian.net/browse/DFBUGS-8890