### PR TITLE
DFBUGS-8798: fix: Update CephFS provisioner MDS caps to `allow *`

### DIFF
--- a/internal/controller/storageconsumer/storageconsumer_controller.go
+++ b/internal/controller/storageconsumer/storageconsumer_controller.go
@@ -233,7 +233,6 @@ func (r *StorageConsumerReconciler) reconcileEnabledPhases() (reconcile.Result, 
 		if availableServices.CephFs {
 			if err := r.reconcileCephClientCephFSProvisioner(
 				util.GenerateCsiCephFsProvisionerCephClientName(csiCephUserCurrGen, r.storageConsumer.UID),
-				consumerResources.GetSubVolumeGroupName(),
 				consumerConfigMap,
 				csiCephUserCurrGen,
 			); err != nil {
@@ -648,7 +647,6 @@ func (r *StorageConsumerReconciler) reconcileCephClientRBDNode(
 
 func (r *StorageConsumerReconciler) reconcileCephClientCephFSProvisioner(
 	cephClientName string,
-	subVolumeGroupName string,
 	additionalOwner client.Object,
 	csiCephUserGeneration int64,
 ) error {
@@ -668,7 +666,7 @@ func (r *StorageConsumerReconciler) reconcileCephClientCephFSProvisioner(
 			"mon": "allow r, allow command 'osd blocklist'",
 			"mgr": "allow rw",
 			"osd": "allow rw tag cephfs metadata=*",
-			"mds": fmt.Sprintf("allow rw path=/volumes/%s", subVolumeGroupName),
+			"mds": "allow *",
 		}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
### Summary

Prior to 4.22, only the RBD NFClass was available. Ramen created an RBD NetworkFence resource for fence/unfence operations, and everything worked as expected.

From 4.22 onwards, CephFS NFClass is created by default. Ramen now creates both RBD and CephFS NetworkFence resources during fence/unfence operations. And if any one of them fails (here cephfs) DRCluster status.state will not be “Fenced”.

While the RBD NetworkFence continues to work correctly, the CephFS NetworkFence fails.
The reason is that CephFS requires osd blocklist along with the MDS commands client ls and client evict.
The provisioner Ceph client currently has the necessary OSD blocklist permissions. However, it lacks the required MDS capabilities to execute client ls and client evict, causing the CephFS NetworkFence operation to fail.


https://redhat.atlassian.net/browse/DFBUGS-8798