### PR TITLE
csi: add NFS driver support for VolumeGroupSnapshotClass distribution

### DIFF
--- a/internal/controller/storagecluster/storageconsumer.go
+++ b/internal/controller/storagecluster/storageconsumer.go
@@ -333,6 +333,10 @@ func getLocalVolumeGroupSnapshotClassNames(ctx context.Context, kubeClient clien
 		volumeGroupSnapshotClassNames[util.GenerateNameForGroupSnapshotClass(storageCluster, util.CephfsGroupSnapshotter)] = true
 	}
 
+	if storageCluster.Spec.NFS != nil && storageCluster.Spec.NFS.Enable {
+		volumeGroupSnapshotClassNames[util.GenerateNameForGroupSnapshotClass(storageCluster, util.NfsGroupSnapshotter)] = true
+	}
+
 	crd := &metav1.PartialObjectMetadata{}
 	crd.SetGroupVersionKind(extv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
 	crd.Name = VolumeGroupSnapshotClassCrdName

--- a/pkg/util/groupsnapshotclasses.go
+++ b/pkg/util/groupsnapshotclasses.go
@@ -19,6 +19,7 @@ type GroupSnapshotterType string
 const (
 	RbdGroupSnapshotter    GroupSnapshotterType = "rbd"
 	CephfsGroupSnapshotter GroupSnapshotterType = "cephfs"
+	NfsGroupSnapshotter    GroupSnapshotterType = "nfs"
 )
 
 func GenerateNameForGroupSnapshotClass(initData *ocsv1.StorageCluster, groupSnapshotType GroupSnapshotterType) string {
@@ -75,6 +76,32 @@ func NewDefaultCephFsGroupSnapshotClass(
 			"csi.storage.k8s.io/group-snapshotter-secret-name":      provisionerSecret,
 			"csi.storage.k8s.io/group-snapshotter-secret-namespace": namespace,
 			"fsName": fsName,
+		},
+		DeletionPolicy: snapapi.VolumeSnapshotContentDelete,
+	}
+	if storageId != "" {
+		AddLabel(gsc, storageIdLabelKey, storageId)
+	}
+	return gsc
+}
+
+func NewDefaultNfsGroupSnapshotClass(
+	clusterID,
+	provisionerSecret,
+	namespace,
+	storageId string,
+) *groupsnapapi.VolumeGroupSnapshotClass {
+
+	gsc := &groupsnapapi.VolumeGroupSnapshotClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{},
+			Labels:      map[string]string{},
+		},
+		Driver: NfsDriverName,
+		Parameters: map[string]string{
+			"clusterID": clusterID,
+			"csi.storage.k8s.io/group-snapshotter-secret-name":      provisionerSecret,
+			"csi.storage.k8s.io/group-snapshotter-secret-namespace": namespace,
 		},
 		DeletionPolicy: snapapi.VolumeSnapshotContentDelete,
 	}

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -2082,6 +2082,16 @@ func (s *OCSProviderServer) appendVolumeGroupSnapshotClassKubeResources(
 			)
 		}
 	}
+	if consumerConfig.GetNfsClientProfileName() != "" {
+		vgscMap[util.GenerateNameForGroupSnapshotClass(storageCluster, util.NfsGroupSnapshotter)] = func() *groupsnapapi.VolumeGroupSnapshotClass {
+			return util.NewDefaultNfsGroupSnapshotClass(
+				consumerConfig.GetNfsClientProfileName(),
+				consumerConfig.GetCsiNfsProvisionerCephUserName(),
+				consumer.Status.Client.OperatorNamespace,
+				cephFsStorageId,
+			)
+		}
+	}
 
 	resources := getKubeResourcesForClass(
 		logger,


### PR DESCRIPTION
Extend VolumeGroupSnapshotClass creation and distribution to support
the NFS CSI driver alongside the existing RBD and CephFS drivers.