### PR TITLE
remove createdAt annotation to prevent merge conflicts

### DIFF
--- a/deploy/csv-templates/ocs-operator.csv.yaml.in
+++ b/deploy/csv-templates/ocs-operator.csv.yaml.in
@@ -79,7 +79,6 @@ metadata:
           "spec": null
         }
       ]
-    createdAt: "2026-07-16T18:37:09Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     operators.operatorframework.io/builder: operator-sdk-v1.37.0

--- a/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
+++ b/deploy/ocs-operator/manifests/ocs-operator.clusterserviceversion.yaml
@@ -56,7 +56,6 @@ metadata:
     capabilities: Deep Insights
     categories: Storage
     containerImage: quay.io/ocs-dev/ocs-operator:latest
-    createdAt: "2026-07-16T18:37:09Z"
     description: Red Hat OpenShift Container Storage provides hyperconverged storage
       for applications within an OpenShift cluster.
     external.features.ocs.openshift.io/supported-platforms: '["BareMetal", "None",

--- a/hack/generate-unified-csv.sh
+++ b/hack/generate-unified-csv.sh
@@ -56,4 +56,3 @@ $CSV_MERGER \
 	--crds-directory="$OUTDIR_CRDS" \
 	--manifests-directory=$BUNDLEMANIFESTS_DIR \
 	--olm-bundle-directory="$OCS_FINAL_DIR" \
-	--timestamp="$TIMESTAMP" \

--- a/hack/source-manifests.sh
+++ b/hack/source-manifests.sh
@@ -45,6 +45,8 @@ function gen_ocs_csv() {
 	$KUSTOMIZE edit set image ocs-dev/ocs-operator="$OCS_IMAGE"
 	popd
 	$KUSTOMIZE build config/manifests/ocs-operator | $OPERATOR_SDK generate bundle -q --overwrite=false --output-dir deploy/ocs-operator --kustomize-dir config/manifests/ocs-operator --package ocs-operator --version "$CSV_VERSION" --extra-service-accounts=ocs-provider-server
+	# Remove createdAt annotation injected by operator-sdk to avoid merge conflicts
+	sed -i '/createdAt:/d' deploy/ocs-operator/manifests/*clusterserviceversion.yaml
 	mv deploy/ocs-operator/manifests/*clusterserviceversion.yaml $OCS_CSV
 	cp config/crd/bases/* $ocs_crds_outdir
 }

--- a/tools/csv-merger/csv-merger.go
+++ b/tools/csv-merger/csv-merger.go
@@ -12,7 +12,6 @@ import (
 	"regexp"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/blang/semver/v4"
 	"github.com/operator-framework/api/pkg/lib/version"
@@ -31,7 +30,6 @@ var (
 	replacesCsvVersion = flag.String("replaces-csv-version", "", "the unified CSV version this new CSV will replace")
 	skipRange          = flag.String("skip-range", "", "the CSV version skip range")
 	ocsCSVStr          = flag.String("ocs-csv-filepath", "", "path to ocs csv yaml file")
-	timestamp          = flag.String("timestamp", "false", "bool value to enable/disable timestamp changes in CSV")
 
 	rookContainerImage       = flag.String("rook-image", "", "rook operator container image")
 	cephContainerImage       = flag.String("ceph-image", "", "ceph daemon container image")
@@ -342,13 +340,6 @@ func generateUnifiedCSV() *csvv1.ClusterServiceVersion {
 	// Used by UI to validate user uploaded metadata
 	// Metadata is used to connect to an external cluster
 	ocsCSV.Annotations["external.features.ocs.openshift.io/validation"] = `{"secrets":["rook-ceph-operator-creds", "rook-csi-rbd-node", "rook-csi-rbd-provisioner"], "configMaps": ["rook-ceph-mon-endpoints", "rook-ceph-mon"], "storageClasses": ["ceph-rbd"], "cephClusters": ["monitoring-endpoint"]}`
-	if *timestamp == "true" {
-		loc, err := time.LoadLocation("UTC")
-		if err != nil {
-			panic(err)
-		}
-		ocsCSV.Annotations["createdAt"] = time.Now().In(loc).Format("2006-01-02 15:04:05")
-	}
 	ocsCSV.Annotations["containerImage"] = *ocsContainerImage
 	ocsCSV.Annotations["capabilities"] = "Deep Insights"
 	ocsCSV.Annotations["categories"] = "Storage"


### PR DESCRIPTION
The operator-sdk `generate bundle` command injects a dynamic `createdAt` timestamp into the CSV on every run, causing recurring merge conflicts across branches.
Remove the `createdAt` annotation entirely and strip it during generation, as it is non-functional OLM metadata. 
Also remove the unused `--timestamp` flag from csv-merger.