### PR TITLE
mirroring: improve mirroring logic

### DIFF
--- a/internal/controller/mirroring/mirroring_controller.go
+++ b/internal/controller/mirroring/mirroring_controller.go
@@ -309,7 +309,7 @@ func (r *MirroringReconciler) reconcilePhases(clientMappingConfig *corev1.Config
 				errorOccurred = true
 			}
 
-			if errored := r.reconcileRadosNamespaceMirroring(clientMappingConfig, storageConsumerByName, remoteClientInfoById); errored {
+			if errored := r.reconcileRadosNamespaceMirroring(clientMappingConfig, storageConsumerByName, remoteClientInfoById, remoteBlockPoolInfoByName); errored {
 				errorOccurred = true
 			}
 
@@ -322,7 +322,7 @@ func (r *MirroringReconciler) reconcilePhases(clientMappingConfig *corev1.Config
 			errorOccurred = true
 		}
 
-		if errored := r.reconcileRadosNamespaceMirroring(clientMappingConfig, storageConsumerByName, nil); errored {
+		if errored := r.reconcileRadosNamespaceMirroring(clientMappingConfig, storageConsumerByName, nil, nil); errored {
 			errorOccurred = true
 		}
 
@@ -602,6 +602,7 @@ func (r *MirroringReconciler) reconcileRadosNamespaceMirroring(
 	clientMappingConfig *corev1.ConfigMap,
 	storageConsumerByName map[string]*ocsv1alpha1.StorageConsumer,
 	remoteClientInfoById map[string]*pb.ClientInfo,
+	remoteBlockPoolInfoByName map[string]*pb.BlockPoolInfo,
 ) bool {
 	errorOccurred := false
 
@@ -630,7 +631,9 @@ func (r *MirroringReconciler) reconcileRadosNamespaceMirroring(
 			}
 		}
 		_, err := controllerutil.CreateOrUpdate(r.ctx, r.Client, rns, func() error {
-			if remoteNamespace != "" {
+			// If cephBlockPool information for remote cluster isn't known/not present in remoteBlockPoolInfoByName map
+			// we shouldn't enable mirroring on the rns.
+			if remoteNamespace != "" && remoteBlockPoolInfoByName[rns.Spec.BlockPoolName] != nil {
 				rns.Spec.Mirroring = &rookCephv1.RadosNamespaceMirroring{
 					RemoteNamespace: ptr.To(remoteNamespace),
 					Mode:            "image",

--- a/internal/controller/mirroring/mirroring_controller_test.go
+++ b/internal/controller/mirroring/mirroring_controller_test.go
@@ -2,10 +2,12 @@ package mirroring
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	ocsv1 "github.com/red-hat-storage/ocs-operator/api/v4/v1"
 	ocsv1alpha1 "github.com/red-hat-storage/ocs-operator/api/v4/v1alpha1"
+	pb "github.com/red-hat-storage/ocs-operator/services/provider/api/v4"
 	storageclusterctrl "github.com/red-hat-storage/ocs-operator/v4/internal/controller/storagecluster"
 	"github.com/red-hat-storage/ocs-operator/v4/pkg/util"
 
@@ -15,71 +17,717 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func TestReconcileRbdMirror_UsesGetPlacement(t *testing.T) {
+const testNamespace = "test-namespace"
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
 	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
+	for _, add := range []func(*runtime.Scheme) error{
+		corev1.AddToScheme,
+		rookCephv1.AddToScheme,
+		ocsv1alpha1.AddToScheme,
+		ocsv1.AddToScheme,
+	} {
+		if err := add(scheme); err != nil {
+			t.Fatal(err)
+		}
 	}
-	if err := rookCephv1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	if err := ocsv1alpha1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
-	if err := ocsv1.AddToScheme(scheme); err != nil {
-		t.Fatal(err)
-	}
+	return scheme
+}
 
-	namespace := "test-namespace"
-	storageCluster := &ocsv1.StorageCluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-storagecluster",
-			Namespace: namespace,
-		},
-	}
-
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-configmap",
-			Namespace: namespace,
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(configMap, storageCluster).
-		WithIndex(&ocsv1alpha1.StorageConsumer{}, util.AnnotationIndexName, func(obj client.Object) []string {
-			consumer := obj.(*ocsv1alpha1.StorageConsumer)
-			if val, ok := consumer.Annotations[util.RequestMaintenanceModeAnnotation]; ok {
-				return []string{val}
-			}
-			return []string{}
-		}).
-		Build()
-
-	reconciler := &MirroringReconciler{
+func newReconciler(fakeClient client.Client, scheme *runtime.Scheme) *MirroringReconciler {
+	return &MirroringReconciler{
 		Client: fakeClient,
 		Scheme: scheme,
 		ctx:    context.TODO(),
-		log:    logf.Log.WithName("controller_mirroring_test"),
+		log:    logf.Log.WithName("mirroring_test"),
 	}
+}
 
-	errorOccurred := reconciler.reconcileRbdMirror(configMap, true)
-	assert.False(t, errorOccurred)
+func newConfigMap(name string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			UID:       types.UID("configmap-uid"),
+		},
+	}
+}
 
-	rbdMirror := &rookCephv1.CephRBDMirror{}
-	err := fakeClient.Get(context.TODO(), types.NamespacedName{
-		Name:      util.CephRBDMirrorName,
-		Namespace: namespace,
-	}, rbdMirror)
-	assert.NoError(t, err)
+func newStorageCluster(name string) *ocsv1.StorageCluster {
+	return &ocsv1.StorageCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+	}
+}
 
-	expectedPlacement := storageclusterctrl.GetPlacement(storageCluster, "rbd-mirror")
-	assert.Equal(t, expectedPlacement, rbdMirror.Spec.Placement,
-		"RBDMirror placement should match GetPlacement(storageCluster, 'rbd-mirror')")
+func newCephBlockPool(name string, labels map[string]string) *rookCephv1.CephBlockPool {
+	return &rookCephv1.CephBlockPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			Labels:    labels,
+		},
+	}
+}
+
+func annotationIndexer(obj client.Object) []string {
+	consumer := obj.(*ocsv1alpha1.StorageConsumer)
+	keys := make([]string, 0, len(consumer.Annotations))
+	for k := range consumer.Annotations {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func buildFakeClient(scheme *runtime.Scheme, objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithIndex(&ocsv1alpha1.StorageConsumer{}, util.AnnotationIndexName, annotationIndexer).
+		Build()
+}
+
+func TestReconcileRbdMirror(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("creates CephRBDMirror with correct placement", func(t *testing.T) {
+		scheme := newScheme(t)
+		sc := newStorageCluster("test-sc")
+		cm := newConfigMap("test-cm")
+
+		r := newReconciler(buildFakeClient(scheme, cm, sc), scheme)
+		errored := r.reconcileRbdMirror(cm, true)
+		assert.False(t, errored)
+
+		rbdMirror := &rookCephv1.CephRBDMirror{}
+		err := r.Get(ctx, types.NamespacedName{Name: util.CephRBDMirrorName, Namespace: testNamespace}, rbdMirror)
+		assert.NoError(t, err)
+		assert.Equal(t, 1, rbdMirror.Spec.Count)
+		assert.Equal(t, storageclusterctrl.GetPlacement(sc, "rbd-mirror"), rbdMirror.Spec.Placement)
+	})
+
+	t.Run("deletes CephRBDMirror when shouldMirror is false", func(t *testing.T) {
+		scheme := newScheme(t)
+		sc := newStorageCluster("test-sc")
+		cm := newConfigMap("test-cm")
+		existingMirror := &rookCephv1.CephRBDMirror{
+			ObjectMeta: metav1.ObjectMeta{Name: util.CephRBDMirrorName, Namespace: testNamespace},
+			Spec:       rookCephv1.RBDMirroringSpec{Count: 1},
+		}
+
+		r := newReconciler(buildFakeClient(scheme, cm, sc, existingMirror), scheme)
+		errored := r.reconcileRbdMirror(cm, false)
+		assert.False(t, errored)
+
+		rbdMirror := &rookCephv1.CephRBDMirror{}
+		err := r.Get(ctx, types.NamespacedName{Name: util.CephRBDMirrorName, Namespace: testNamespace}, rbdMirror)
+		assert.Error(t, err, "CephRBDMirror should be deleted")
+	})
+
+	t.Run("deletes CephRBDMirror when maintenance mode requested", func(t *testing.T) {
+		scheme := newScheme(t)
+		sc := newStorageCluster("test-sc")
+		cm := newConfigMap("test-cm")
+		existingMirror := &rookCephv1.CephRBDMirror{
+			ObjectMeta: metav1.ObjectMeta{Name: util.CephRBDMirrorName, Namespace: testNamespace},
+			Spec:       rookCephv1.RBDMirroringSpec{Count: 1},
+		}
+		consumer := &ocsv1alpha1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "consumer-1",
+				Namespace: testNamespace,
+				Annotations: map[string]string{
+					util.RequestMaintenanceModeAnnotation: "true",
+				},
+			},
+		}
+
+		r := newReconciler(buildFakeClient(scheme, cm, sc, existingMirror, consumer), scheme)
+		errored := r.reconcileRbdMirror(cm, true)
+		assert.False(t, errored)
+
+		rbdMirror := &rookCephv1.CephRBDMirror{}
+		err := r.Get(ctx, types.NamespacedName{Name: util.CephRBDMirrorName, Namespace: testNamespace}, rbdMirror)
+		assert.Error(t, err, "CephRBDMirror should be deleted when maintenance mode requested")
+	})
+
+	t.Run("errors when multiple CephRBDMirrors exist", func(t *testing.T) {
+		scheme := newScheme(t)
+		sc := newStorageCluster("test-sc")
+		cm := newConfigMap("test-cm")
+		mirror1 := &rookCephv1.CephRBDMirror{
+			ObjectMeta: metav1.ObjectMeta{Name: util.CephRBDMirrorName, Namespace: testNamespace},
+		}
+		mirror2 := &rookCephv1.CephRBDMirror{
+			ObjectMeta: metav1.ObjectMeta{Name: "other-mirror", Namespace: testNamespace},
+		}
+
+		r := newReconciler(buildFakeClient(scheme, cm, sc, mirror1, mirror2), scheme)
+		errored := r.reconcileRbdMirror(cm, true)
+		assert.True(t, errored)
+	})
+
+	t.Run("errors when CephRBDMirror name does not match", func(t *testing.T) {
+		scheme := newScheme(t)
+		sc := newStorageCluster("test-sc")
+		cm := newConfigMap("test-cm")
+		wrongNameMirror := &rookCephv1.CephRBDMirror{
+			ObjectMeta: metav1.ObjectMeta{Name: "wrong-name", Namespace: testNamespace},
+		}
+
+		r := newReconciler(buildFakeClient(scheme, cm, sc, wrongNameMirror), scheme)
+		errored := r.reconcileRbdMirror(cm, true)
+		assert.True(t, errored)
+	})
+
+	t.Run("adds maintenance mode annotation to StorageCluster", func(t *testing.T) {
+		scheme := newScheme(t)
+		sc := newStorageCluster("test-sc")
+		cm := newConfigMap("test-cm")
+		existingMirror := &rookCephv1.CephRBDMirror{
+			ObjectMeta: metav1.ObjectMeta{Name: util.CephRBDMirrorName, Namespace: testNamespace},
+			Spec:       rookCephv1.RBDMirroringSpec{Count: 1},
+		}
+		consumer := &ocsv1alpha1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "consumer-1",
+				Namespace: testNamespace,
+				Annotations: map[string]string{
+					util.RequestMaintenanceModeAnnotation: "true",
+				},
+			},
+		}
+
+		r := newReconciler(buildFakeClient(scheme, cm, sc, existingMirror, consumer), scheme)
+		errored := r.reconcileRbdMirror(cm, true)
+		assert.False(t, errored)
+
+		updatedSC := &ocsv1.StorageCluster{}
+		err := r.Get(ctx, types.NamespacedName{Name: sc.Name, Namespace: testNamespace}, updatedSC)
+		assert.NoError(t, err)
+		assert.Equal(t, "true", updatedSC.GetAnnotations()[util.InMaintenanceModeAnnotation])
+	})
+
+	t.Run("removes maintenance mode annotation from StorageCluster", func(t *testing.T) {
+		scheme := newScheme(t)
+		sc := newStorageCluster("test-sc")
+		sc.Annotations = map[string]string{util.InMaintenanceModeAnnotation: "true"}
+		cm := newConfigMap("test-cm")
+
+		r := newReconciler(buildFakeClient(scheme, cm, sc), scheme)
+		errored := r.reconcileRbdMirror(cm, true)
+		assert.False(t, errored)
+
+		updatedSC := &ocsv1.StorageCluster{}
+		err := r.Get(ctx, types.NamespacedName{Name: sc.Name, Namespace: testNamespace}, updatedSC)
+		assert.NoError(t, err)
+		_, exists := updatedSC.GetAnnotations()[util.InMaintenanceModeAnnotation]
+		assert.False(t, exists)
+	})
+}
+
+func TestReconcileBlockPoolMirroring(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("enables mirroring with token and secret", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		pool := newCephBlockPool("pool-1", nil)
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, pool).Build()
+		r := newReconciler(fc, scheme)
+
+		blockPoolList := &rookCephv1.CephBlockPoolList{Items: []rookCephv1.CephBlockPool{*pool}}
+		remoteInfo := map[string]*pb.BlockPoolInfo{
+			"pool-1": {BlockPoolName: "pool-1", MirroringToken: "test-token", BlockPoolID: "bp-id-1"},
+		}
+
+		errored := r.reconcileBlockPoolMirroring(cm, blockPoolList, remoteInfo)
+		assert.False(t, errored)
+
+		updatedPool := &rookCephv1.CephBlockPool{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "pool-1", Namespace: testNamespace}, updatedPool)
+		assert.NoError(t, err)
+		assert.True(t, updatedPool.Spec.Mirroring.Enabled)
+		assert.Equal(t, "init-only", updatedPool.Spec.Mirroring.Mode)
+		assert.Equal(t, "bp-id-1", updatedPool.GetAnnotations()[util.BlockPoolMirroringTargetIDAnnotation])
+
+		secretName := GetMirroringSecretName("pool-1")
+		assert.NotNil(t, updatedPool.Spec.Mirroring.Peers)
+		assert.Contains(t, updatedPool.Spec.Mirroring.Peers.SecretNames, secretName)
+
+		secret := &corev1.Secret{}
+		err = fc.Get(ctx, types.NamespacedName{Name: secretName, Namespace: testNamespace}, secret)
+		assert.NoError(t, err)
+		assert.Equal(t, []byte("pool-1"), secret.Data["pool"])
+		assert.Equal(t, []byte("test-token"), secret.Data["token"])
+	})
+
+	t.Run("disables mirroring when remote info is nil", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		pool := newCephBlockPool("pool-1", nil)
+		pool.Spec.Mirroring = rookCephv1.MirroringSpec{Enabled: true, Mode: "init-only"}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, pool).Build()
+		r := newReconciler(fc, scheme)
+
+		blockPoolList := &rookCephv1.CephBlockPoolList{Items: []rookCephv1.CephBlockPool{*pool}}
+		errored := r.reconcileBlockPoolMirroring(cm, blockPoolList, nil)
+		assert.False(t, errored)
+
+		updatedPool := &rookCephv1.CephBlockPool{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "pool-1", Namespace: testNamespace}, updatedPool)
+		assert.NoError(t, err)
+		assert.False(t, updatedPool.Spec.Mirroring.Enabled)
+	})
+
+	t.Run("skips internal-use-only pool", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		pool := newCephBlockPool("internal-pool", map[string]string{
+			util.ForInternalUseOnlyLabelKey: "true",
+		})
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, pool).Build()
+		r := newReconciler(fc, scheme)
+
+		blockPoolList := &rookCephv1.CephBlockPoolList{Items: []rookCephv1.CephBlockPool{*pool}}
+		remoteInfo := map[string]*pb.BlockPoolInfo{
+			"internal-pool": {BlockPoolName: "internal-pool", MirroringToken: "token", BlockPoolID: "id"},
+		}
+
+		errored := r.reconcileBlockPoolMirroring(cm, blockPoolList, remoteInfo)
+		assert.False(t, errored)
+
+		updatedPool := &rookCephv1.CephBlockPool{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "internal-pool", Namespace: testNamespace}, updatedPool)
+		assert.NoError(t, err)
+		assert.False(t, updatedPool.Spec.Mirroring.Enabled)
+	})
+
+	t.Run("skips forbid-mirroring pool", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		pool := newCephBlockPool("forbid-pool", map[string]string{
+			util.ForbidMirroringLabel: "true",
+		})
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, pool).Build()
+		r := newReconciler(fc, scheme)
+
+		blockPoolList := &rookCephv1.CephBlockPoolList{Items: []rookCephv1.CephBlockPool{*pool}}
+		remoteInfo := map[string]*pb.BlockPoolInfo{
+			"forbid-pool": {BlockPoolName: "forbid-pool", MirroringToken: "token", BlockPoolID: "id"},
+		}
+
+		errored := r.reconcileBlockPoolMirroring(cm, blockPoolList, remoteInfo)
+		assert.False(t, errored)
+
+		updatedPool := &rookCephv1.CephBlockPool{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "forbid-pool", Namespace: testNamespace}, updatedPool)
+		assert.NoError(t, err)
+		assert.False(t, updatedPool.Spec.Mirroring.Enabled)
+	})
+
+	t.Run("skips erasure-coded pool", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		pool := newCephBlockPool("ec-pool", nil)
+		pool.Spec.ErasureCoded = rookCephv1.ErasureCodedSpec{CodingChunks: 1, DataChunks: 2}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, pool).Build()
+		r := newReconciler(fc, scheme)
+
+		blockPoolList := &rookCephv1.CephBlockPoolList{Items: []rookCephv1.CephBlockPool{*pool}}
+		remoteInfo := map[string]*pb.BlockPoolInfo{
+			"ec-pool": {BlockPoolName: "ec-pool", MirroringToken: "token", BlockPoolID: "id"},
+		}
+
+		errored := r.reconcileBlockPoolMirroring(cm, blockPoolList, remoteInfo)
+		assert.False(t, errored)
+
+		updatedPool := &rookCephv1.CephBlockPool{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "ec-pool", Namespace: testNamespace}, updatedPool)
+		assert.NoError(t, err)
+		assert.False(t, updatedPool.Spec.Mirroring.Enabled)
+	})
+
+	t.Run("errors when mirroring token is empty", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		pool := newCephBlockPool("pool-1", nil)
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, pool).Build()
+		r := newReconciler(fc, scheme)
+
+		blockPoolList := &rookCephv1.CephBlockPoolList{Items: []rookCephv1.CephBlockPool{*pool}}
+		remoteInfo := map[string]*pb.BlockPoolInfo{
+			"pool-1": {BlockPoolName: "pool-1", MirroringToken: "", BlockPoolID: "bp-id-1"},
+		}
+
+		errored := r.reconcileBlockPoolMirroring(cm, blockPoolList, remoteInfo)
+		assert.True(t, errored)
+
+		updatedPool := &rookCephv1.CephBlockPool{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "pool-1", Namespace: testNamespace}, updatedPool)
+		assert.NoError(t, err)
+		assert.True(t, updatedPool.Spec.Mirroring.Enabled, "mirroring should still be enabled even without token")
+	})
+
+	t.Run("disables mirroring when pool is not in remote map", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		pool := newCephBlockPool("pool-1", nil)
+		pool.Spec.Mirroring = rookCephv1.MirroringSpec{Enabled: true, Mode: "init-only"}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, pool).Build()
+		r := newReconciler(fc, scheme)
+
+		blockPoolList := &rookCephv1.CephBlockPoolList{Items: []rookCephv1.CephBlockPool{*pool}}
+		remoteInfo := map[string]*pb.BlockPoolInfo{
+			"other-pool": {BlockPoolName: "other-pool", MirroringToken: "token", BlockPoolID: "id"},
+		}
+
+		errored := r.reconcileBlockPoolMirroring(cm, blockPoolList, remoteInfo)
+		assert.False(t, errored)
+
+		updatedPool := &rookCephv1.CephBlockPool{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "pool-1", Namespace: testNamespace}, updatedPool)
+		assert.NoError(t, err)
+		assert.False(t, updatedPool.Spec.Mirroring.Enabled)
+	})
+
+	t.Run("handles multiple pools with mixed eligibility", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		pool1 := newCephBlockPool("pool-1", nil)
+		pool2 := newCephBlockPool("pool-2", nil)
+		internalPool := newCephBlockPool("internal-pool", map[string]string{
+			util.ForInternalUseOnlyLabelKey: "true",
+		})
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, pool1, pool2, internalPool).Build()
+		r := newReconciler(fc, scheme)
+
+		blockPoolList := &rookCephv1.CephBlockPoolList{
+			Items: []rookCephv1.CephBlockPool{*pool1, *pool2, *internalPool},
+		}
+		remoteInfo := map[string]*pb.BlockPoolInfo{
+			"pool-1":        {BlockPoolName: "pool-1", MirroringToken: "token-1", BlockPoolID: "id-1"},
+			"pool-2":        {BlockPoolName: "pool-2", MirroringToken: "token-2", BlockPoolID: "id-2"},
+			"internal-pool": {BlockPoolName: "internal-pool", MirroringToken: "token-3", BlockPoolID: "id-3"},
+		}
+
+		errored := r.reconcileBlockPoolMirroring(cm, blockPoolList, remoteInfo)
+		assert.False(t, errored)
+
+		for _, tc := range []struct {
+			name           string
+			expectMirror   bool
+			expectSecretOk bool
+		}{
+			{"pool-1", true, true},
+			{"pool-2", true, true},
+			{"internal-pool", false, false},
+		} {
+			updatedPool := &rookCephv1.CephBlockPool{}
+			err := fc.Get(ctx, types.NamespacedName{Name: tc.name, Namespace: testNamespace}, updatedPool)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectMirror, updatedPool.Spec.Mirroring.Enabled, "pool %s", tc.name)
+
+			if tc.expectSecretOk {
+				secret := &corev1.Secret{}
+				err = fc.Get(ctx, types.NamespacedName{Name: GetMirroringSecretName(tc.name), Namespace: testNamespace}, secret)
+				assert.NoError(t, err, "mirroring secret for pool %s", tc.name)
+			}
+		}
+	})
+}
+
+func TestReconcileRadosNamespaceMirroring(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("enables mirroring on rados namespace", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		cm.Data = map[string]string{"local-client-id": "remote-client-id"}
+
+		consumer := &ocsv1alpha1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "consumer-1", Namespace: testNamespace, UID: types.UID("consumer-uid"),
+			},
+			Status: ocsv1alpha1.StorageConsumerStatus{
+				Client: &ocsv1alpha1.ClientStatus{ID: "local-client-id"},
+			},
+		}
+		rns := &rookCephv1.CephBlockPoolRadosNamespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "rns-1", Namespace: testNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{Kind: "StorageConsumer", Name: "consumer-1", UID: consumer.UID},
+				},
+			},
+			Spec: rookCephv1.CephBlockPoolRadosNamespaceSpec{BlockPoolName: "pool-1"},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, rns).Build()
+		r := newReconciler(fc, scheme)
+
+		errored := r.reconcileRadosNamespaceMirroring(
+			cm,
+			map[string]*ocsv1alpha1.StorageConsumer{"consumer-1": consumer},
+			map[string]*pb.ClientInfo{"remote-client-id": {ClientID: "remote-client-id", RadosNamespace: "remote-rns"}},
+			map[string]*pb.BlockPoolInfo{"pool-1": {BlockPoolName: "pool-1", MirroringToken: "token", BlockPoolID: "id"}},
+		)
+		assert.False(t, errored)
+
+		updatedRNS := &rookCephv1.CephBlockPoolRadosNamespace{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "rns-1", Namespace: testNamespace}, updatedRNS)
+		assert.NoError(t, err)
+		assert.NotNil(t, updatedRNS.Spec.Mirroring)
+		assert.Equal(t, ptr.To("remote-rns"), updatedRNS.Spec.Mirroring.RemoteNamespace)
+		assert.Equal(t, rookCephv1.RadosNamespaceMirroringMode("image"), updatedRNS.Spec.Mirroring.Mode)
+	})
+
+	t.Run("disables mirroring when remote info is nil", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		rns := &rookCephv1.CephBlockPoolRadosNamespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "rns-1", Namespace: testNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{Kind: "StorageConsumer", Name: "consumer-1", UID: "consumer-uid"},
+				},
+			},
+			Spec: rookCephv1.CephBlockPoolRadosNamespaceSpec{
+				BlockPoolName: "pool-1",
+				Mirroring:     &rookCephv1.RadosNamespaceMirroring{RemoteNamespace: ptr.To("remote-rns"), Mode: "image"},
+			},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, rns).Build()
+		r := newReconciler(fc, scheme)
+
+		errored := r.reconcileRadosNamespaceMirroring(cm, map[string]*ocsv1alpha1.StorageConsumer{}, nil, nil)
+		assert.False(t, errored)
+
+		updatedRNS := &rookCephv1.CephBlockPoolRadosNamespace{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "rns-1", Namespace: testNamespace}, updatedRNS)
+		assert.NoError(t, err)
+		assert.Nil(t, updatedRNS.Spec.Mirroring)
+	})
+
+	t.Run("skips rados namespace without StorageConsumer owner", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		rns := &rookCephv1.CephBlockPoolRadosNamespace{
+			ObjectMeta: metav1.ObjectMeta{Name: "rns-no-owner", Namespace: testNamespace},
+			Spec:       rookCephv1.CephBlockPoolRadosNamespaceSpec{BlockPoolName: "pool-1"},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, rns).Build()
+		r := newReconciler(fc, scheme)
+
+		errored := r.reconcileRadosNamespaceMirroring(
+			cm,
+			map[string]*ocsv1alpha1.StorageConsumer{},
+			map[string]*pb.ClientInfo{"remote-client-id": {ClientID: "remote-client-id", RadosNamespace: "remote-rns"}},
+			map[string]*pb.BlockPoolInfo{"pool-1": {BlockPoolName: "pool-1"}},
+		)
+		assert.False(t, errored)
+
+		updatedRNS := &rookCephv1.CephBlockPoolRadosNamespace{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "rns-no-owner", Namespace: testNamespace}, updatedRNS)
+		assert.NoError(t, err)
+		assert.Nil(t, updatedRNS.Spec.Mirroring)
+	})
+
+	t.Run("disables mirroring when block pool is not in remote map", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		cm.Data = map[string]string{"local-client-id": "remote-client-id"}
+
+		consumer := &ocsv1alpha1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "consumer-1", Namespace: testNamespace, UID: types.UID("consumer-uid"),
+			},
+			Status: ocsv1alpha1.StorageConsumerStatus{
+				Client: &ocsv1alpha1.ClientStatus{ID: "local-client-id"},
+			},
+		}
+		rns := &rookCephv1.CephBlockPoolRadosNamespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "rns-1", Namespace: testNamespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{Kind: "StorageConsumer", Name: "consumer-1", UID: consumer.UID},
+				},
+			},
+			Spec: rookCephv1.CephBlockPoolRadosNamespaceSpec{
+				BlockPoolName: "pool-not-in-remote",
+				Mirroring:     &rookCephv1.RadosNamespaceMirroring{RemoteNamespace: ptr.To("old-rns"), Mode: "image"},
+			},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, rns).Build()
+		r := newReconciler(fc, scheme)
+
+		errored := r.reconcileRadosNamespaceMirroring(
+			cm,
+			map[string]*ocsv1alpha1.StorageConsumer{"consumer-1": consumer},
+			map[string]*pb.ClientInfo{"remote-client-id": {ClientID: "remote-client-id", RadosNamespace: "remote-rns"}},
+			map[string]*pb.BlockPoolInfo{"pool-1": {BlockPoolName: "pool-1"}},
+		)
+		assert.False(t, errored)
+
+		updatedRNS := &rookCephv1.CephBlockPoolRadosNamespace{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "rns-1", Namespace: testNamespace}, updatedRNS)
+		assert.NoError(t, err)
+		assert.Nil(t, updatedRNS.Spec.Mirroring)
+	})
+}
+
+func TestReconcileStorageConsumer(t *testing.T) {
+	ctx := context.TODO()
+
+	t.Run("adds mirroring info annotation", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		cm.Data = map[string]string{"local-client-id": "remote-client-id"}
+		consumer := &ocsv1alpha1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{Name: "consumer-1", Namespace: testNamespace},
+			Status:     ocsv1alpha1.StorageConsumerStatus{Client: &ocsv1alpha1.ClientStatus{ID: "local-client-id"}},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, consumer).Build()
+		r := newReconciler(fc, scheme)
+
+		consumerList := &ocsv1alpha1.StorageConsumerList{Items: []ocsv1alpha1.StorageConsumer{*consumer}}
+		remoteInfo := map[string]*pb.ClientInfo{
+			"remote-client-id": {ClientID: "remote-client-id", RadosNamespace: "remote-rns", RbdStorageID: "storage-id"},
+		}
+
+		errored := r.reconcileStorageConsumer(consumerList, cm, remoteInfo)
+		assert.False(t, errored)
+
+		updatedConsumer := &ocsv1alpha1.StorageConsumer{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "consumer-1", Namespace: testNamespace}, updatedConsumer)
+		assert.NoError(t, err)
+
+		annotationValue := updatedConsumer.GetAnnotations()[util.StorageConsumerMirroringInfoAnnotation]
+		assert.NotEmpty(t, annotationValue)
+
+		var clientInfo pb.ClientInfo
+		err = json.Unmarshal([]byte(annotationValue), &clientInfo)
+		assert.NoError(t, err)
+		assert.Equal(t, "remote-client-id", clientInfo.ClientID)
+		assert.Equal(t, "remote-rns", clientInfo.RadosNamespace)
+	})
+
+	t.Run("removes mirroring info annotation when remote info is nil", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		consumer := &ocsv1alpha1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "consumer-1", Namespace: testNamespace,
+				Annotations: map[string]string{util.StorageConsumerMirroringInfoAnnotation: `{"clientID":"old"}`},
+			},
+			Status: ocsv1alpha1.StorageConsumerStatus{Client: &ocsv1alpha1.ClientStatus{ID: "local-client-id"}},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, consumer).Build()
+		r := newReconciler(fc, scheme)
+
+		consumerList := &ocsv1alpha1.StorageConsumerList{Items: []ocsv1alpha1.StorageConsumer{*consumer}}
+		errored := r.reconcileStorageConsumer(consumerList, cm, nil)
+		assert.False(t, errored)
+
+		updatedConsumer := &ocsv1alpha1.StorageConsumer{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "consumer-1", Namespace: testNamespace}, updatedConsumer)
+		assert.NoError(t, err)
+		_, exists := updatedConsumer.GetAnnotations()[util.StorageConsumerMirroringInfoAnnotation]
+		assert.False(t, exists)
+	})
+
+	t.Run("no update when annotation already has correct value", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		cm.Data = map[string]string{"local-client-id": "remote-client-id"}
+
+		clientInfo := &pb.ClientInfo{ClientID: "remote-client-id", RadosNamespace: "remote-rns"}
+		marshaledInfo, _ := json.Marshal(clientInfo)
+
+		consumer := &ocsv1alpha1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "consumer-1", Namespace: testNamespace,
+				Annotations: map[string]string{util.StorageConsumerMirroringInfoAnnotation: string(marshaledInfo)},
+			},
+			Status: ocsv1alpha1.StorageConsumerStatus{Client: &ocsv1alpha1.ClientStatus{ID: "local-client-id"}},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, consumer).Build()
+		r := newReconciler(fc, scheme)
+
+		consumerList := &ocsv1alpha1.StorageConsumerList{Items: []ocsv1alpha1.StorageConsumer{*consumer}}
+		errored := r.reconcileStorageConsumer(consumerList, cm, map[string]*pb.ClientInfo{"remote-client-id": clientInfo})
+		assert.False(t, errored)
+
+		updatedConsumer := &ocsv1alpha1.StorageConsumer{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "consumer-1", Namespace: testNamespace}, updatedConsumer)
+		assert.NoError(t, err)
+		assert.Equal(t, string(marshaledInfo), updatedConsumer.GetAnnotations()[util.StorageConsumerMirroringInfoAnnotation])
+	})
+
+	t.Run("skips consumer with no client status", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		consumer := &ocsv1alpha1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{Name: "consumer-no-client", Namespace: testNamespace},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, consumer).Build()
+		r := newReconciler(fc, scheme)
+
+		consumerList := &ocsv1alpha1.StorageConsumerList{Items: []ocsv1alpha1.StorageConsumer{*consumer}}
+		errored := r.reconcileStorageConsumer(consumerList, cm, map[string]*pb.ClientInfo{"some-id": {ClientID: "some-id"}})
+		assert.False(t, errored)
+
+		updatedConsumer := &ocsv1alpha1.StorageConsumer{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "consumer-no-client", Namespace: testNamespace}, updatedConsumer)
+		assert.NoError(t, err)
+		_, exists := updatedConsumer.GetAnnotations()[util.StorageConsumerMirroringInfoAnnotation]
+		assert.False(t, exists)
+	})
+
+	t.Run("skips consumer with unmapped client ID", func(t *testing.T) {
+		scheme := newScheme(t)
+		cm := newConfigMap("test-cm")
+		cm.Data = map[string]string{"other-client": "remote-id"}
+		consumer := &ocsv1alpha1.StorageConsumer{
+			ObjectMeta: metav1.ObjectMeta{Name: "consumer-1", Namespace: testNamespace},
+			Status:     ocsv1alpha1.StorageConsumerStatus{Client: &ocsv1alpha1.ClientStatus{ID: "unmapped-client-id"}},
+		}
+
+		fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cm, consumer).Build()
+		r := newReconciler(fc, scheme)
+
+		consumerList := &ocsv1alpha1.StorageConsumerList{Items: []ocsv1alpha1.StorageConsumer{*consumer}}
+		errored := r.reconcileStorageConsumer(consumerList, cm, map[string]*pb.ClientInfo{"remote-id": {ClientID: "remote-id"}})
+		assert.False(t, errored)
+
+		updatedConsumer := &ocsv1alpha1.StorageConsumer{}
+		err := fc.Get(ctx, types.NamespacedName{Name: "consumer-1", Namespace: testNamespace}, updatedConsumer)
+		assert.NoError(t, err)
+		_, exists := updatedConsumer.GetAnnotations()[util.StorageConsumerMirroringInfoAnnotation]
+		assert.False(t, exists)
+	})
 }

--- a/services/provider/server/server.go
+++ b/services/provider/server/server.go
@@ -1301,7 +1301,6 @@ func (s *OCSProviderServer) GetBlockPoolsInfo(ctx context.Context, req *pb.Block
 					"Bootstrap Secret",
 					secret.Name,
 				)
-				continue
 			} else if err != nil {
 				logger.Error(
 					err,
@@ -1311,7 +1310,13 @@ func (s *OCSProviderServer) GetBlockPoolsInfo(ctx context.Context, req *pb.Block
 					"Bootstrap Secret",
 					secret.Name,
 				)
-				continue
+				response.Errors = append(response.Errors,
+					&pb.BlockPoolInfoError{
+						BlockPoolName: cephBlockPool.Name,
+						Code:          pb.ErrorCode_Internal,
+						Message:       "failed loading block pool information",
+					},
+				)
 			}
 			mirroringToken = string(secret.Data["token"])
 		}

--- a/services/provider/server/server_test.go
+++ b/services/provider/server/server_test.go
@@ -1620,6 +1620,197 @@ func TestGetRGWCredentialsResourceVersion(t *testing.T) {
 	})
 }
 
+func TestGetBlockPoolsInfo(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty request returns empty response", func(t *testing.T) {
+		srv := newTestProviderServer(t)
+		resp, err := srv.GetBlockPoolsInfo(ctx, &pb.BlockPoolsInfoRequest{
+			BlockPoolNames: []string{},
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		assert.Empty(t, resp.BlockPoolsInfo)
+		assert.Empty(t, resp.Errors)
+	})
+
+	t.Run("block pool not found is skipped", func(t *testing.T) {
+		srv := newTestProviderServer(t)
+		resp, err := srv.GetBlockPoolsInfo(ctx, &pb.BlockPoolsInfoRequest{
+			BlockPoolNames: []string{"non-existent-pool"},
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, resp.BlockPoolsInfo)
+		assert.Empty(t, resp.Errors)
+	})
+
+	t.Run("pool without mirroring returns empty token", func(t *testing.T) {
+		pool := &rookCephv1.CephBlockPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pool-no-mirror",
+				Namespace: testNamespace,
+			},
+			Status: &rookCephv1.CephBlockPoolStatus{
+				PoolID: 42,
+			},
+		}
+		srv := newTestProviderServer(t, pool)
+		resp, err := srv.GetBlockPoolsInfo(ctx, &pb.BlockPoolsInfoRequest{
+			BlockPoolNames: []string{"pool-no-mirror"},
+		})
+		assert.NoError(t, err)
+		assert.Len(t, resp.BlockPoolsInfo, 1)
+		assert.Equal(t, "pool-no-mirror", resp.BlockPoolsInfo[0].BlockPoolName)
+		assert.Equal(t, "42", resp.BlockPoolsInfo[0].BlockPoolID)
+		assert.Empty(t, resp.BlockPoolsInfo[0].MirroringToken)
+		assert.Empty(t, resp.Errors)
+	})
+
+	t.Run("pool with mirroring enabled and token secret", func(t *testing.T) {
+		pool := &rookCephv1.CephBlockPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pool-mirrored",
+				Namespace: testNamespace,
+			},
+			Spec: rookCephv1.NamedBlockPoolSpec{
+				PoolSpec: rookCephv1.PoolSpec{
+					Mirroring: rookCephv1.MirroringSpec{Enabled: true},
+				},
+			},
+			Status: &rookCephv1.CephBlockPoolStatus{
+				PoolID: 7,
+				Info: map[string]string{
+					mirroringTokenKey: "bootstrap-secret",
+				},
+			},
+		}
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bootstrap-secret",
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{
+				"token": []byte("my-mirroring-token"),
+			},
+		}
+		srv := newTestProviderServer(t, pool, secret)
+		resp, err := srv.GetBlockPoolsInfo(ctx, &pb.BlockPoolsInfoRequest{
+			BlockPoolNames: []string{"pool-mirrored"},
+		})
+		assert.NoError(t, err)
+		assert.Len(t, resp.BlockPoolsInfo, 1)
+		assert.Equal(t, "pool-mirrored", resp.BlockPoolsInfo[0].BlockPoolName)
+		assert.Equal(t, "7", resp.BlockPoolsInfo[0].BlockPoolID)
+		assert.Equal(t, "my-mirroring-token", resp.BlockPoolsInfo[0].MirroringToken)
+		assert.Empty(t, resp.Errors)
+	})
+
+	t.Run("mirroring enabled but bootstrap secret not found", func(t *testing.T) {
+		pool := &rookCephv1.CephBlockPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pool-missing-secret",
+				Namespace: testNamespace,
+			},
+			Spec: rookCephv1.NamedBlockPoolSpec{
+				PoolSpec: rookCephv1.PoolSpec{
+					Mirroring: rookCephv1.MirroringSpec{Enabled: true},
+				},
+			},
+			Status: &rookCephv1.CephBlockPoolStatus{
+				PoolID: 3,
+				Info: map[string]string{
+					mirroringTokenKey: "missing-secret",
+				},
+			},
+		}
+		srv := newTestProviderServer(t, pool)
+		resp, err := srv.GetBlockPoolsInfo(ctx, &pb.BlockPoolsInfoRequest{
+			BlockPoolNames: []string{"pool-missing-secret"},
+		})
+		assert.NoError(t, err)
+		assert.Len(t, resp.BlockPoolsInfo, 1)
+		assert.Equal(t, "pool-missing-secret", resp.BlockPoolsInfo[0].BlockPoolName)
+		assert.Empty(t, resp.BlockPoolsInfo[0].MirroringToken, "token should be empty when secret not found")
+		assert.Empty(t, resp.Errors, "missing secret should not produce an error entry")
+	})
+
+	t.Run("mirroring enabled but no token key in status info", func(t *testing.T) {
+		pool := &rookCephv1.CephBlockPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pool-no-info",
+				Namespace: testNamespace,
+			},
+			Spec: rookCephv1.NamedBlockPoolSpec{
+				PoolSpec: rookCephv1.PoolSpec{
+					Mirroring: rookCephv1.MirroringSpec{Enabled: true},
+				},
+			},
+			Status: &rookCephv1.CephBlockPoolStatus{
+				PoolID: 5,
+			},
+		}
+		srv := newTestProviderServer(t, pool)
+		resp, err := srv.GetBlockPoolsInfo(ctx, &pb.BlockPoolsInfoRequest{
+			BlockPoolNames: []string{"pool-no-info"},
+		})
+		assert.NoError(t, err)
+		assert.Len(t, resp.BlockPoolsInfo, 1)
+		assert.Empty(t, resp.BlockPoolsInfo[0].MirroringToken)
+	})
+
+	t.Run("multiple pools mixed", func(t *testing.T) {
+		poolA := &rookCephv1.CephBlockPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pool-a",
+				Namespace: testNamespace,
+			},
+			Spec: rookCephv1.NamedBlockPoolSpec{
+				PoolSpec: rookCephv1.PoolSpec{
+					Mirroring: rookCephv1.MirroringSpec{Enabled: true},
+				},
+			},
+			Status: &rookCephv1.CephBlockPoolStatus{
+				PoolID: 1,
+				Info: map[string]string{
+					mirroringTokenKey: "secret-a",
+				},
+			},
+		}
+		secretA := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret-a",
+				Namespace: testNamespace,
+			},
+			Data: map[string][]byte{"token": []byte("token-a")},
+		}
+		poolB := &rookCephv1.CephBlockPool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pool-b",
+				Namespace: testNamespace,
+			},
+			Status: &rookCephv1.CephBlockPoolStatus{PoolID: 2},
+		}
+
+		srv := newTestProviderServer(t, poolA, secretA, poolB)
+		resp, err := srv.GetBlockPoolsInfo(ctx, &pb.BlockPoolsInfoRequest{
+			BlockPoolNames: []string{"pool-a", "non-existent", "pool-b"},
+		})
+		assert.NoError(t, err)
+		assert.Len(t, resp.BlockPoolsInfo, 2, "non-existent pool should be skipped")
+		assert.Empty(t, resp.Errors)
+
+		infoByName := map[string]*pb.BlockPoolInfo{}
+		for _, info := range resp.BlockPoolsInfo {
+			infoByName[info.BlockPoolName] = info
+		}
+
+		assert.Equal(t, "token-a", infoByName["pool-a"].MirroringToken)
+		assert.Equal(t, "1", infoByName["pool-a"].BlockPoolID)
+		assert.Empty(t, infoByName["pool-b"].MirroringToken)
+		assert.Equal(t, "2", infoByName["pool-b"].BlockPoolID)
+	})
+}
+
 func TestIsRGWAccountEnabled(t *testing.T) {
 	sc, consumer, _, _, _, _ := newRGWTestObjects()
 


### PR DESCRIPTION
1. add a check in mirroring controller to not enable mirroring for rns if blockpool mirroring is not enabled.
2. if bootstrap secret is not found we should log and error and continue sending other blockpool info.
3. if there was any other error with fetching the secret we should add it to the errors


Fixes: [DFBUGS-8224](https://redhat.atlassian.net/browse/DFBUGS-8224)

RCA of bug:
```
t1
1. mirroring controller calls GetBlockPoolInfo, it returns blockPool list without mirroringToken
2. mirroring controller enables mirroring for the cephblockpool
3. mirroring controller enabled mirroring for rns

t2
1. mirroring controller calls GetBlockPoolInfo, this time if the secret info is set on blockpool cr but the secret is not found so there is no information returned for the blockpool
2. mirroring controller disables mirroring on the cephblockpool since there is no information returned for blockpool
3. mirroring controller doesn't disable mirroring on the radosnamespace

t3
1. mirroring controller reconciles again and this time provider server on other side returns a secret, 
2. mirroring controller enables mirroring on cephblockpool with mode set

This disable and enable of mirroring causes a problem in rook
```

How does it fix the bug?
```
t1
1. mirroring controller calls GetBlockPoolInfo, it returns blockPool list without mirroringToken
2. mirroring controller enables mirroring for the cephblockpool
3. mirroring controller enabled mirroring for rns

t2
1. mirroring controller calls GetBlockPoolInfo, if the secret is not found then we still send blockpool info
2. mirroring controller doesn't disable mirroring on the cephblockpool as there is info returned for blockpool
3. mirroring controller doesn't disable mirroring on the radosnamespace

t3
1. mirroring controller reconciles again and this time provider server on other side returns a secret, 
2. mirroring controller enables mirroring on cephblockpool with mode set
```

Unit Tests Generated by AI