### PR TITLE
security: add networkpolicy manifests for ocs-operator

### DIFF
--- a/config/networkpolicy/networkpolicy.yaml
+++ b/config/networkpolicy/networkpolicy.yaml
@@ -1,0 +1,53 @@
+/home/oviner/DEV_REPOS/ocs-op/ocs-operator/config/networkpolicy/ocs-operator/networkpolicy.yamlapiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ocs-operator
+  namespace: openshift-storage
+spec:
+  podSelector:
+    matchLabels:
+      name: ocs-operator
+  policyTypes:
+  - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ocs-metrics-exporter
+  namespace: openshift-storage
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: ocs-metrics-exporter
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-monitoring
+    ports:
+    - protocol: TCP
+      port: 8443
+    - protocol: TCP
+      port: 9443
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ocs-provider-server
+  namespace: openshift-storage
+spec:
+  podSelector:
+    matchLabels:
+      app: ocsProviderApiServer
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-storage
+    ports:
+    - protocol: TCP
+      port: 50051

--- a/deploy/ocs-operator/manifests/networkpolicy-role-binding.yaml
+++ b/deploy/ocs-operator/manifests/networkpolicy-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ocs-operator-networkpolicy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ocs-operator-networkpolicy
+subjects:
+- kind: ServiceAccount
+  name: ocs-operator
+  namespace: openshift-storage

--- a/deploy/ocs-operator/manifests/networkpolicy-role.yaml
+++ b/deploy/ocs-operator/manifests/networkpolicy-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ocs-operator-networkpolicy
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - update
+  - delete

--- a/rbac/networkpolicy-role-binding.yaml
+++ b/rbac/networkpolicy-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ocs-operator-networkpolicy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ocs-operator-networkpolicy
+subjects:
+- kind: ServiceAccount
+  name: ocs-operator
+  namespace: openshift-storage

--- a/rbac/networkpolicy-role.yaml
+++ b/rbac/networkpolicy-role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ocs-operator-networkpolicy
+rules:
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - create
+  - update
+  - delete


### PR DESCRIPTION
Add NetworkPolicy CRs to restrict ingress traffic for ocs-operator, ocs-metrics-exporter, and ocs-provider-server. Include Role and RoleBinding for networkpolicy management.