### PR TITLE
DFBUGS-9028: [release-4.22] Add cephfilesystems to metrics exporter RBAC Role

### DIFF
--- a/internal/controller/storagecluster/exporter.go
+++ b/internal/controller/storagecluster/exporter.go
@@ -846,7 +846,7 @@ func createMetricsExporterRoles(ctx context.Context, r *StorageClusterReconciler
 			},
 			{
 				APIGroups: []string{"ceph.rook.io"},
-				Resources: []string{"cephobjectstores", "cephclusters", "cephblockpools", "cephrbdmirrors", "cephblockpoolradosnamespaces", "cephfilesystemsubvolumegroups"},
+				Resources: []string{"cephobjectstores", "cephclusters", "cephblockpools", "cephrbdmirrors", "cephblockpoolradosnamespaces", "cephfilesystemsubvolumegroups", "cephfilesystems"},
 				Verbs:     []string{"get", "list", "watch"},
 			},
 			{


### PR DESCRIPTION
The CephFilesystem informer added in PR #3910 requires permission to list/get/watch cephfilesystems resources. The metrics/deploy/rbac.yaml was updated but the dynamic Role creation in exporter.go was not.

This caused the ocs-metrics-exporter ServiceAccount to lack permission to list CephFilesystem CRs, resulting in checkMDSKeyRotation() silently returning 0 on RBAC errors. The MDS key rotation mismatch alert would never get fired even when MDS daemons had stale keys.